### PR TITLE
fix(state): move Pipekit ephemeral state out of repo (#13)

### DIFF
--- a/VBW_COMMANDS.md
+++ b/VBW_COMMANDS.md
@@ -62,7 +62,7 @@ VBW v1.35.0 added configurable lifecycle hooks via `.vbw-planning/config.json` u
 
 | Hook | When it fires | Pipekit usage |
 |------|---------------|----------------|
-| `post_archive` | After `/vbw:vibe --archive` completes | `scripts/pipekit-post-archive.sh` writes `.pipekit/pending-strategy-sync` marker (surfaced by `/start-session`) |
+| `post_archive` | After `/vbw:vibe --archive` completes | `scripts/pipekit-post-archive.sh` writes a `pending-strategy-sync` marker to Pipekit's out-of-repo state dir (resolved by `scripts/pipekit-state-dir.sh`); surfaced by `/start-session` |
 
 See `method.md` § Event Hook: Post-Archive → Strategy Sync for registration details.
 

--- a/method.md
+++ b/method.md
@@ -332,8 +332,8 @@ Pipekit wraps VBW — it does not replace VBW's planning layer. The two systems 
    **Pipekit's VBW-steering surface (Tier 1 / Option 3 architecture, 2026-04-25):**
    1. **One direct agent spawn** — `plan-reviewer` in `/review-plan`. Not a VBW agent; Pipekit-shipped.
    2. **Read-only state observation** — `.vbw-planning/{ROADMAP,STATE,PHASES,linear-map}.md` reads from `/sync-linear`, `/phase-plan`, `/00-roadmap-review`, `/01-light-spec`, `/10-strategy-sync`, `/end-session`.
-   3. **One lifecycle hook** — `scripts/pipekit-post-archive.sh` fires on `/vbw:vibe --archive`, writes `.pipekit/pending-strategy-sync` marker.
-   4. **Pipekit-side ephemeral state** (v1.6.0+) — `.pipekit/` directory holds Pipekit-only state never read by VBW: `pending-strategy-sync` marker (above), `pending-next-md.json` queue (NEXT.md writes deferred under VBW active-plan scope, per `sop/Skills_SOP.md` § Deferral mechanism), and `pipeline-state/<issue-id>.json` records (per-skill transition state, consumed by `/launch --auto`). The directory is gitignored. Writes from inside VBW active-plan scope are best-effort; the consumer's gitignore + the Option B allowlist (upstream VBW coordination) supersede the queue mechanism when present.
+   3. **One lifecycle hook** — `scripts/pipekit-post-archive.sh` fires on `/vbw:vibe --archive`, writes a `pending-strategy-sync` marker into Pipekit's machine-local state directory.
+   4. **Pipekit-side ephemeral state** (v1.6.0+, relocated v1.7.0) — Pipekit's machine-local state lives **outside the repo** at `${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>/`, resolved by `scripts/pipekit-state-dir.sh`. It holds: `pending-strategy-sync` marker, `pending-next-md.json` queue (deferred NEXT.md writes), and `pipeline-state/<issue-id>.json` records (per-skill transition state, consumed by `/launch --auto`). v1.6.0 placed these inside the repo at `.pipekit/`, but VBW's file-guard hook silently blocked the writes during active-plan scope (#13) — the relocation makes them invisible to VBW's hook, so writes succeed unconditionally.
 
    No direct VBW-agent spawns. No execution-flow wrapping. VBW upgrades touch zero Pipekit code.
 6. **When drift is suspected, stop and reconcile.** Symptoms: Linear status doesn't match VBW execution state; a PLAN.md references a Linear issue that doesn't exist; a Linear issue has no corresponding plan. Resolve the mismatch before continuing — drift compounds.
@@ -351,7 +351,7 @@ If drift becomes a recurring pattern in practice, add a `/drift-check` skill for
 
 ### Event Hook: Post-Archive → Strategy Sync
 
-VBW v1.35.0 added a post-archive lifecycle hook (PR #481) that fires after `/vbw:vibe --archive` completes. Pipekit ships `scripts/pipekit-post-archive.sh` to wire this into the strategy-sync loop — when a milestone is archived, the hook writes a `.pipekit/pending-strategy-sync` marker that `/start-session` surfaces on the next session, nudging the user to run `/strategy-sync`.
+VBW v1.35.0 added a post-archive lifecycle hook (PR #481) that fires after `/vbw:vibe --archive` completes. Pipekit ships `scripts/pipekit-post-archive.sh` to wire this into the strategy-sync loop — when a milestone is archived, the hook writes a `pending-strategy-sync` marker into Pipekit's machine-local state directory (out-of-repo, v1.7.0+) that `/start-session` surfaces on the next session, nudging the user to run `/strategy-sync`.
 
 This is the first concrete instance of the event-based wrapping discussed in Rule 5 above. It replaces the previous convention ("remember to run /strategy-sync after shipping") with a hook that fires deterministically without Pipekit re-implementing VBW's archive flow.
 

--- a/scripts/pipekit-post-archive.sh
+++ b/scripts/pipekit-post-archive.sh
@@ -28,7 +28,18 @@ if [ -z "$MILESTONE_SLUG" ] || [ -z "$ARCHIVE_PATH" ]; then
 fi
 
 PROJECT_ROOT="${VBW_CONFIG_ROOT:-$(pwd -P 2>/dev/null || pwd)}"
-MARKER_DIR="$PROJECT_ROOT/.pipekit"
+
+# v1.7.0+: marker lives outside the repo (XDG cache) so VBW's file-guard
+# never blocks the write. See scripts/pipekit-state-dir.sh and #13.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -x "$SCRIPT_DIR/pipekit-state-dir.sh" ]; then
+  MARKER_DIR=$(cd "$PROJECT_ROOT" && bash "$SCRIPT_DIR/pipekit-state-dir.sh")
+else
+  # Fallback: inline the resolution logic so the hook doesn't hard-fail
+  # on consumers mid-upgrade.
+  REPO_BASE=$(cd "$PROJECT_ROOT" && git rev-parse --show-toplevel 2>/dev/null | xargs basename 2>/dev/null || echo "_default")
+  MARKER_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/$REPO_BASE"
+fi
 MARKER_FILE="$MARKER_DIR/pending-strategy-sync"
 
 mkdir -p "$MARKER_DIR" 2>/dev/null || {

--- a/scripts/pipekit-state-dir.sh
+++ b/scripts/pipekit-state-dir.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# pipekit-state-dir.sh
+#
+# Resolve Pipekit's per-repo machine-local state directory. Pipekit's ephemeral
+# state (NEXT.md defer queue, pipeline-state records, strategy-sync marker) used
+# to live in `<repo>/.pipekit/` but that path is inside the repo and gets
+# blocked by VBW's file-guard hook when running inside an active-plan scope
+# (issue #13). The fix: relocate to an XDG-style cache dir outside the repo,
+# which the file-guard never inspects.
+#
+# Path scheme:
+#   ${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>/
+#
+# Usage:
+#   STATE_DIR=$(bash scripts/pipekit-state-dir.sh)
+#   mkdir -p "$STATE_DIR/pipeline-state"
+#   echo "$payload" > "$STATE_DIR/pending-next-md.json"
+#
+# Output: absolute path. Always succeeds; falls back to `_default` basename
+# when not inside a git repo (e.g. the helper is invoked from an arbitrary cwd).
+#
+# Side effects: none. Does not create the directory — caller decides.
+
+set -u
+
+CACHE_BASE="${XDG_CACHE_HOME:-$HOME/.cache}/pipekit"
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -n "$REPO_ROOT" ]; then
+  REPO_BASE=$(basename "$REPO_ROOT")
+else
+  REPO_BASE="_default"
+fi
+
+echo "$CACHE_BASE/$REPO_BASE"

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -182,6 +182,10 @@ sync_file "$TEMP/scripts/pipekit-post-archive.sh" "$PROJECT_ROOT/scripts/pipekit
 [ -f "$PROJECT_ROOT/scripts/pipekit-post-archive.sh" ] && chmod +x "$PROJECT_ROOT/scripts/pipekit-post-archive.sh"
 sync_file "$TEMP/scripts/pipekit-next-step-nudge.sh" "$PROJECT_ROOT/scripts/pipekit-next-step-nudge.sh" "scripts/pipekit-next-step-nudge.sh"
 [ -f "$PROJECT_ROOT/scripts/pipekit-next-step-nudge.sh" ] && chmod +x "$PROJECT_ROOT/scripts/pipekit-next-step-nudge.sh"
+sync_file "$TEMP/scripts/pipekit-state-dir.sh" "$PROJECT_ROOT/scripts/pipekit-state-dir.sh" "scripts/pipekit-state-dir.sh"
+[ -f "$PROJECT_ROOT/scripts/pipekit-state-dir.sh" ] && chmod +x "$PROJECT_ROOT/scripts/pipekit-state-dir.sh"
+sync_file "$TEMP/scripts/verify-next-md-defer.sh" "$PROJECT_ROOT/scripts/verify-next-md-defer.sh" "scripts/verify-next-md-defer.sh"
+[ -f "$PROJECT_ROOT/scripts/verify-next-md-defer.sh" ] && chmod +x "$PROJECT_ROOT/scripts/verify-next-md-defer.sh"
 
 # --- Sync canonical .claude/rules/ files ---
 # Contract: Pipekit owns three canonical rule files prefixed `pipekit-`

--- a/scripts/verify-next-md-defer.sh
+++ b/scripts/verify-next-md-defer.sh
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
 # verify-next-md-defer.sh
 #
-# Reproducible end-to-end check for the v1.6.0 NEXT.md defer + apply
-# round-trip introduced by #12. Exercises the deferral detection logic
-# from skills/review-plan/skill.md (Step 7) and the apply logic from
-# skills/end-session/skill.md (Step 7b.0).
+# Reproducible end-to-end check for the NEXT.md defer + apply round-trip
+# (v1.6.0 #12, relocated v1.7.0 #13). Exercises the deferral detection
+# logic from skills/review-plan/skill.md (Step 7) and the apply logic
+# from skills/end-session/skill.md (Step 7b.0).
+#
+# v1.7.0 update: queue file lives at $STATE_DIR/pending-next-md.json
+# where $STATE_DIR is resolved by scripts/pipekit-state-dir.sh and points
+# OUTSIDE the repo (under $XDG_CACHE_HOME). This dodges VBW's file-guard
+# hook which silently blocked the in-repo .pipekit/ path in v1.6.0.
 #
 # Usage:
 #   bash scripts/verify-next-md-defer.sh
 #
 # Behavior:
-#   1. Builds an ephemeral fake project tree under a temp dir.
-#   2. Creates a fake VBW PLAN.md with a files_modified field that
+#   1. Builds an ephemeral fake project tree under a temp dir, plus an
+#      isolated XDG_CACHE_HOME so we don't pollute the real cache.
+#   2. Symlinks pipekit-state-dir.sh into the fake repo so the helper
+#      resolves correctly inside the temp tree.
+#   3. Creates a fake VBW PLAN.md with a files_modified field that
 #      does NOT include NEXT.md (the conflict that #12 fixes).
-#   3. Runs the deferral check inline; expects DEFER_NEXT_MD=1.
-#   4. Writes a queue file at .pipekit/pending-next-md.json.
-#   5. Runs the apply step (/end-session Step 7b.0); expects NEXT.md
+#   4. Runs the deferral check inline; expects DEFER_NEXT_MD=1.
+#   5. Resolves $STATE_DIR via the helper and writes the queue file there.
+#   6. Confirms the queue file is OUTSIDE the repo (the v1.7.0 fix).
+#   7. Runs the apply step (/end-session Step 7b.0); expects NEXT.md
 #      to receive the queued content and the queue file to be deleted.
 #
 # Exit status: 0 on success, non-zero on failure with a diagnostic line.
@@ -25,11 +34,22 @@
 
 set -euo pipefail
 
+REAL_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pipekit-state-dir.sh"
+if [ ! -x "$REAL_HELPER" ]; then
+  echo "FAIL: helper not found at $REAL_HELPER" >&2
+  exit 1
+fi
+
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+TMP_CACHE=$(mktemp -d)
+trap 'rm -rf "$TMP" "$TMP_CACHE"' EXIT
+
+export XDG_CACHE_HOME="$TMP_CACHE"
 
 cd "$TMP"
-mkdir -p .vbw-planning/phases/test-phase .pipekit/pipeline-state
+git init -q
+mkdir -p .vbw-planning/phases/test-phase scripts
+ln -s "$REAL_HELPER" scripts/pipekit-state-dir.sh
 
 cat > .vbw-planning/phases/test-phase/01-01-PLAN.md <<'PLAN'
 # Test Phase Plan
@@ -59,8 +79,21 @@ if [ "$DEFER_NEXT_MD" != "1" ]; then
   exit 1
 fi
 
+# --- Resolve out-of-repo state dir (v1.7.0 fix) ---
+STATE_DIR=$(bash scripts/pipekit-state-dir.sh)
+mkdir -p "$STATE_DIR"
+
+# Confirm the fix: STATE_DIR must be outside the repo.
+case "$STATE_DIR" in
+  "$TMP"/*)
+    echo "FAIL: STATE_DIR ($STATE_DIR) resolved inside the repo — v1.7.0 fix not applied" >&2
+    exit 1
+    ;;
+esac
+
 # --- Queue write (review-plan would do this) ---
-cat > .pipekit/pending-next-md.json <<JSON
+QUEUE="$STATE_DIR/pending-next-md.json"
+cat > "$QUEUE" <<JSON
 {
   "queued_at": "2026-04-29T14:32:00-04:00",
   "writer": "/review-plan",
@@ -69,13 +102,12 @@ cat > .pipekit/pending-next-md.json <<JSON
 }
 JSON
 
-if [ ! -f .pipekit/pending-next-md.json ]; then
-  echo "FAIL: queue file not written" >&2
+if [ ! -f "$QUEUE" ]; then
+  echo "FAIL: queue file not written at $QUEUE" >&2
   exit 1
 fi
 
 # --- Apply (end-session Step 7b.0) ---
-QUEUE=".pipekit/pending-next-md.json"
 python3 -c "import json,sys; open('NEXT.md','w').write(json.load(open('$QUEUE'))['content'])"
 rm -f "$QUEUE"
 
@@ -84,7 +116,7 @@ if [ ! -f NEXT.md ]; then
   exit 1
 fi
 
-if [ -f .pipekit/pending-next-md.json ]; then
+if [ -f "$QUEUE" ]; then
   echo "FAIL: queue file not cleaned up" >&2
   exit 1
 fi
@@ -94,4 +126,5 @@ if ! grep -q "/vbw:vibe --execute test-phase" NEXT.md; then
   exit 1
 fi
 
-echo "OK: defer detection, queue write, and apply round-trip all passed."
+echo "OK: defer detection, out-of-repo queue write, and apply round-trip all passed."
+echo "    STATE_DIR resolved to: $STATE_DIR"

--- a/skills/06-linear-todo-runner/skill.md
+++ b/skills/06-linear-todo-runner/skill.md
@@ -185,13 +185,13 @@ When any background agent completes:
 1. Move issue to "UAT" via `mcp__linear-server__save_issue` with `stateId: {UAT state ID from method.config.md}`
 2. Post a Linear comment with: branch name, commit summary, pre-deploy gate results
 3. Log the branch for PR creation
-4. **Write pipeline state file (v1.6.0+):** `.pipekit/pipeline-state/<issue-id>.json` per `sop/Skills_SOP.md` § Pipeline state file with `stage: "linear-todo-runner"`, `verdict: "Pass"`, `next_command: "/g-test-vercel"` (or whatever the project's post-UAT pointer is), `cwd`, `timestamp`. Hook-blocked writes are best-effort — skip silently.
+4. **Write pipeline state file (v1.6.0+, relocated v1.7.0):** resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and write `$STATE_DIR/pipeline-state/<issue-id>.json` per `sop/Skills_SOP.md` § Pipeline state file with `stage: "linear-todo-runner"`, `verdict: "Pass"`, `next_command: "/g-test-vercel"` (or whatever the project's post-UAT pointer is), `cwd`, `timestamp`. Path is out-of-repo so no hook block; write should always succeed.
 
 **On failure (agent reports errors or AC not met):**
 1. Move issue back to "Approved" via `mcp__linear-server__save_issue` with `stateId: {Approved state ID from method.config.md}`
 2. Post a Linear comment with the failure reason and any partial progress
 3. Log as failed
-4. **Write pipeline state file (v1.6.0+):** `.pipekit/pipeline-state/<issue-id>.json` with `stage: "linear-todo-runner"`, `verdict: "Fail"`, `next_command: "/01-light-spec-revise <issue-id>"` (or `/light-spec-revise` depending on diagnosis), `cwd`, `timestamp`.
+4. **Write pipeline state file (v1.6.0+, relocated v1.7.0):** `$STATE_DIR/pipeline-state/<issue-id>.json` (with `STATE_DIR` resolved as above) with `stage: "linear-todo-runner"`, `verdict: "Fail"`, `next_command: "/01-light-spec-revise <issue-id>"` (or `/light-spec-revise` depending on diagnosis), `cwd`, `timestamp`.
 
 **Then refill:**
 1. Re-evaluate the queue — check if any previously-blocked issues are now unblocked (their blockers may have just completed)

--- a/skills/10-strategy-sync/skill.md
+++ b/skills/10-strategy-sync/skill.md
@@ -143,10 +143,11 @@ After updating primary docs, check consistency across all docs in the manifest:
 
 ### Phase 7b — Clear Post-Archive Marker
 
-If `.pipekit/pending-strategy-sync` exists, it was written by `scripts/pipekit-post-archive.sh` to signal that a milestone archive left strategy docs potentially stale. After Phase 6 applies approved updates, remove the marker:
+If `$STATE_DIR/pending-strategy-sync` exists (resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`), it was written by `scripts/pipekit-post-archive.sh` to signal that a milestone archive left strategy docs potentially stale. (v1.7.0+: location moved out-of-repo to evade VBW's file-guard.) After Phase 6 applies approved updates, remove the marker:
 
 ```bash
-rm -f .pipekit/pending-strategy-sync
+STATE_DIR=$(bash scripts/pipekit-state-dir.sh)
+rm -f "$STATE_DIR/pending-strategy-sync"
 ```
 
 If no approved updates were applied (user skipped all diffs), leave the marker in place so the nudge persists into the next session.

--- a/skills/end-session/skill.md
+++ b/skills/end-session/skill.md
@@ -330,10 +330,11 @@ Create file: `Logs/Sessions/YYYY-MM-DD_HHMM.md` with personal reflections and te
 
 #### Step 7b.0 — Apply any queued NEXT.md write (v1.6.0+)
 
-Pipekit skills that ran inside VBW's active-plan scope (typically `/review-plan` and `/launch --close` mid-session) defer their `NEXT.md` writes to `.pipekit/pending-next-md.json` per `sop/Skills_SOP.md` § Deferral mechanism. `/end-session` runs outside any active-plan scope (sessions end after the build is done), so this is the canonical apply point.
+Pipekit skills that ran inside VBW's active-plan scope (typically `/review-plan` and `/launch --close` mid-session) defer their `NEXT.md` writes to `$STATE_DIR/pending-next-md.json` (out-of-repo, v1.7.0+) per `sop/Skills_SOP.md` § Deferral mechanism. `/end-session` runs outside any active-plan scope (sessions end after the build is done), so this is the canonical apply point.
 
 ```bash
-QUEUE=".pipekit/pending-next-md.json"
+STATE_DIR=$(bash scripts/pipekit-state-dir.sh)
+QUEUE="$STATE_DIR/pending-next-md.json"
 if [ -f "$QUEUE" ]; then
   WRITER=$(jq -r '.writer' "$QUEUE")
   QUEUED_AT=$(jq -r '.queued_at' "$QUEUE")
@@ -346,7 +347,7 @@ If the queue file exists:
 1. Read the queued content. Compare its `next_command` against what the session has actually shipped (commits, Linear status changes, branch state).
 2. **If the queued recommendation is still relevant** (queued `/vbw:vibe --execute X` and the session did not execute X) — apply atomically: write the queued `content` field to `NEXT.md` at the project root. Skip Step 7b.1 — the queued write is the truth.
 3. **If the session has shipped past the queued point** (queued `/vbw:vibe --execute X` but the session ran execute, verify, and `--close`) — the queue is stale. Discard without writing. Step 7b.1 recomputes from current state.
-4. **In either case, delete the queue file** after handling: `rm -f .pipekit/pending-next-md.json`. The queue is ephemeral; no persistent cruft.
+4. **In either case, delete the queue file** after handling: `rm -f "$QUEUE"`. The queue is ephemeral; no persistent cruft.
 
 If no queue file exists, proceed to Step 7b.1 unchanged.
 
@@ -358,7 +359,7 @@ Source for the next action, in priority order:
 
 1. **Current phase has more Approved issues?** — recommend `/launch {next Approved issue}`. Pick the one whose dependency graph (via Linear `blocked_by` relations) unblocks the most downstream work. Briefly name what it unblocks in the "Why this one" field.
 2. **Current phase fully shipped but has unshipped `Specced` issues?** — recommend moving the top-priority one to Approved (human review gate).
-3. **Current phase fully shipped and specced?** — recommend `/strategy-sync` if there's a pending-strategy-sync marker at `.pipekit/pending-strategy-sync`, otherwise recommend `/phase-plan` to select the next phase.
+3. **Current phase fully shipped and specced?** — recommend `/strategy-sync` if there's a pending-strategy-sync marker at `$STATE_DIR/pending-strategy-sync` (resolved via `scripts/pipekit-state-dir.sh`), otherwise recommend `/phase-plan` to select the next phase.
 4. **No phase active?** — recommend `/phase-plan`.
 
 Write `NEXT.md` at the project root using the exact schema (`# Next Step` / `**Last updated:**` / `## Recommended next command` / `## Why this one` / optional parallelizable and blocked sections). Include this session's `YYYY-MM-DD_HHMM` as the timestamp and `/end-session` as the writer.

--- a/skills/launch/skill.md
+++ b/skills/launch/skill.md
@@ -345,7 +345,7 @@ Invoked when the user returns with verify confirmed (either via `/vbw:vibe --ver
 - QA report exists and is passing
 - Security review report exists at the path defined in `method.config.md`
 - `/strategy-sync` last-run timestamp is after this issue's last build commit
-- No `.pipekit/pending-strategy-sync` marker exists
+- No `$STATE_DIR/pending-strategy-sync` marker exists (resolve `STATE_DIR` via `bash scripts/pipekit-state-dir.sh`)
 
 If any check fails, refuse to close with a list of missing artifacts and stop. Do not transition Linear status.]
 
@@ -501,7 +501,7 @@ After Steps 1–6 complete unchanged (gate validation, tier confirm, dependency 
 
 ### Pipeline state file at each transition
 
-`/launch --auto` is the primary consumer of the pipeline state file (`.pipekit/pipeline-state/<issue-id>.json`, schema in `sop/Skills_SOP.md` § Pipeline state file). After each spawn returns, the orchestrator updates the state file with `stage`, `verdict`, `next_command`, `cwd`, and timestamp. This supports:
+`/launch --auto` is the primary consumer of the pipeline state file (`$STATE_DIR/pipeline-state/<issue-id>.json`, where `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`; schema in `sop/Skills_SOP.md` § Pipeline state file). After each spawn returns, the orchestrator updates the state file with `stage`, `verdict`, `next_command`, `cwd`, and timestamp. This supports:
 
 - **Auto-chain progress tracking** — the orchestrator knows where it is even after a long Dev run.
 - **Resumption-after-crash** — if the orchestrator is interrupted, the next `/launch --auto PROJ-XXX` can read the state file and prompt: `"Last transition: {stage} at {timestamp}. Resume from {next stage}?"` (resumption skill `/pipekit-resume` deferred to v1.7.0; the state file is written now so the data exists when the consumer ships).
@@ -624,7 +624,7 @@ Tier 1 / Option 3 has two `/launch` invocations per issue: open and `--close`. E
 **Close-time NEXT.md logic** (priority order):
 
 1. Next Specced issue in current phase → `/launch {next issue}`
-2. If `.pipekit/pending-strategy-sync` marker exists → `/strategy-sync`
+2. If `$STATE_DIR/pending-strategy-sync` marker exists (resolved via `bash scripts/pipekit-state-dir.sh`) → `/strategy-sync`
 3. If phase complete and synced → `/phase-plan`
 4. Otherwise → `/g-test-vercel` for the just-shipped issue
 
@@ -632,9 +632,9 @@ Inline `➜ Next:` and `NEXT.md` contents must match. See SOP schema in `sop/Ski
 
 **Note:** Pipekit no longer writes NEXT.md between phases (between `--plan`, `--execute`, `--verify`). Those are VBW's pause points; if the user wants context recovery there, they consult `.vbw-planning/STATE.md` directly. Pipekit's NEXT.md tracks the **issue lifecycle**, not the build lifecycle.
 
-**VBW active-plan scope deferral (v1.6.0+):** before writing `NEXT.md` (open *or* `--close` path), run the active-plan scope detection from `sop/Skills_SOP.md` § Deferral mechanism. If `DEFER_NEXT_MD=1`, write the intended content to `.pipekit/pending-next-md.json` instead of NEXT.md directly. The most common case for `/launch --close` to hit deferral is when the user invokes `--close` while still inside the same chat that ran `/vbw:vibe --plan` (the active plan is still the most recent VBW write). Inline `➜ Next:` is still emitted to the terminal; only the file write defers. `/end-session` applies the queue.
+**VBW active-plan scope deferral (v1.6.0+, relocated v1.7.0):** before writing `NEXT.md` (open *or* `--close` path), run the active-plan scope detection from `sop/Skills_SOP.md` § Deferral mechanism. If `DEFER_NEXT_MD=1`, resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and write the intended content to `$STATE_DIR/pending-next-md.json` instead of NEXT.md directly. The most common case for `/launch --close` to hit deferral is when the user invokes `--close` while still inside the same chat that ran `/vbw:vibe --plan` (the active plan is still the most recent VBW write). Inline `➜ Next:` is still emitted to the terminal; only the file write defers. `/end-session` applies the queue.
 
-**Pipeline state file (v1.6.0+):** at the end of both open and `--close` paths, write `.pipekit/pipeline-state/<issue-id>.json` per the SOP schema. For open, `stage: "launch"` and `verdict: null` (gate-pass is not a verdict in the review sense); for close, `stage: "launch-close"` and `verdict: null`. Hook-blocked writes are best-effort — skip silently.
+**Pipeline state file (v1.6.0+, relocated v1.7.0):** at the end of both open and `--close` paths, write `$STATE_DIR/pipeline-state/<issue-id>.json` per the SOP schema. For open, `stage: "launch"` and `verdict: null` (gate-pass is not a verdict in the review sense); for close, `stage: "launch-close"` and `verdict: null`. The path is out-of-repo so no hook block; write should always succeed.
 
 ---
 

--- a/skills/pipekit-help/skill.md
+++ b/skills/pipekit-help/skill.md
@@ -26,7 +26,7 @@ Read each of these without writing. Stop reading as soon as a rule in `state-rul
 |--------|---------|
 | `git rev-parse --abbrev-ref HEAD` | Current branch / worktree |
 | `git log -5 --oneline` | Recent commits (look for Linear prefixes like `PROJ-XXX`) |
-| `.pipekit/pending-strategy-sync` (presence) | Post-archive hook marker — strategy sync owed |
+| `$STATE_DIR/pending-strategy-sync` (presence; `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`) | Post-archive hook marker — strategy sync owed |
 | `.vbw-planning/PHASES.md` (presence) | Stage 0 complete? |
 | `.vbw-planning/phases/<latest>/PLAN.md` (presence + age) | Plan exists for current phase? |
 | `.vbw-planning/phases/<latest>/REVIEW.md` (presence) | Plan-reviewed? |
@@ -74,7 +74,7 @@ Resolve the *latest* phase by mtime of `.vbw-planning/phases/*/PLAN.md`. Don't i
 
 ```
 ➜ Next: /strategy-sync
-  Why: .pipekit/pending-strategy-sync marker present (last archive triggered it)
+  Why: pending-strategy-sync marker present (last archive triggered it)
 ```
 
 ```

--- a/skills/pipekit-help/state-rules.md
+++ b/skills/pipekit-help/state-rules.md
@@ -38,7 +38,7 @@ The foundation contract (see `method.md` § Foundation Contract) is the set of a
 
 ## 2. Pending strategy sync
 
-**Match:** `.pipekit/pending-strategy-sync` file exists.
+**Match:** `$STATE_DIR/pending-strategy-sync` file exists (`STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`).
 
 **Recommend:** `/strategy-sync`
 **Why:** Post-archive hook flagged a milestone close; strategy docs are out of date with shipped reality.

--- a/skills/review-plan/skill.md
+++ b/skills/review-plan/skill.md
@@ -177,7 +177,7 @@ if [ -n "$ACTIVE_PLAN" ] && ! grep -q "NEXT\.md" "$ACTIVE_PLAN"; then
 fi
 ```
 
-If `DEFER_NEXT_MD=1`: create `.pipekit/` if absent, write the queue file at `.pipekit/pending-next-md.json` with the schema in the SOP. Mention briefly in your output: `"NEXT.md write deferred (VBW scope) — will apply on /end-session."`
+If `DEFER_NEXT_MD=1`: resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR"`, write the queue file at `$STATE_DIR/pending-next-md.json` with the schema in the SOP. Mention briefly in your output: `"NEXT.md write deferred (VBW scope) — will apply on /end-session."`
 
 If `DEFER_NEXT_MD=0`: write `NEXT.md` directly at the project root.
 
@@ -185,7 +185,7 @@ Inline `➜ Next:` and the eventual NEXT.md contents (whether written directly o
 
 #### Pipeline state file (v1.6.0+)
 
-After the verdict is delivered, write `.pipekit/pipeline-state/<issue-id>.json` per the SOP schema (`stage: "review-plan"`, verdict, next_command, cwd, timestamp). Issue ID resolution mirrors Step 2's spec resolution; if no Linear ID, use the phase slug. If the write fails on a hook block (consumer not yet on Option B allowlist), skip silently — `/launch --auto` reconstructs from VBW state.
+After the verdict is delivered, resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR/pipeline-state"`, and write `$STATE_DIR/pipeline-state/<issue-id>.json` per the SOP schema (`stage: "review-plan"`, verdict, next_command, cwd, timestamp). Issue ID resolution mirrors Step 2's spec resolution; if no Linear ID, use the phase slug. The path is out-of-repo (v1.7.0+) so no hook block; write should always succeed.
 
 ---
 

--- a/skills/start-session/skill.md
+++ b/skills/start-session/skill.md
@@ -45,7 +45,7 @@ If `NEXT.md` doesn't exist (fresh project or before the first pipeline step comp
 
 ### 2b. Check Pending Strategy Sync Marker
 
-Check if `.pipekit/pending-strategy-sync` exists. It is written by `scripts/pipekit-post-archive.sh` after VBW archives a milestone. When present, surface it before session planning:
+Resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and check if `$STATE_DIR/pending-strategy-sync` exists. It is written by `scripts/pipekit-post-archive.sh` after VBW archives a milestone. (v1.7.0+: location moved out-of-repo to evade VBW's file-guard.) When present, surface it before session planning:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -135,11 +135,36 @@ Always include both date and time in the `Last updated` line. A bare date hides 
 
 **`/start-session` reads and displays it** automatically at session start, so users don't need to navigate to the file.
 
-#### Deferral mechanism for VBW active-plan scope (v1.6.0+)
+#### Pipekit machine-local state directory (v1.7.0+)
+
+Pipekit's ephemeral, per-machine state (NEXT.md defer queue, pipeline-state records, strategy-sync marker) lives **outside** the repo at:
+
+```
+${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>/
+├── pending-next-md.json           # NEXT.md defer queue (see below)
+├── pending-strategy-sync          # post-archive marker (see /strategy-sync)
+└── pipeline-state/
+    └── <issue-id>.json            # per-skill transition state
+```
+
+**Why out-of-repo (#13):** v1.6.0 placed these files at `<repo>/.pipekit/`, which sits inside the repo and gets blocked by VBW's file-guard hook the same way `NEXT.md` does. The defer mechanism only worked for non-VBW-scoped writers — exactly the case it was *not* meant to fix. v1.7.0 moves the directory outside the repo entirely. VBW's file-guard never inspects paths outside the project, so writes succeed unconditionally.
+
+**Resolving the path:** every skill that reads/writes Pipekit state uses the helper:
+
+```bash
+STATE_DIR=$(bash scripts/pipekit-state-dir.sh)
+mkdir -p "$STATE_DIR"
+```
+
+`scripts/pipekit-state-dir.sh` resolves `${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>` (basename derived from `git rev-parse --show-toplevel`). All file paths below are *relative to* `$STATE_DIR`.
+
+**Migration from v1.6.0:** consuming projects with a populated `<repo>/.pipekit/` should one-shot move it: `mkdir -p "$(bash scripts/pipekit-state-dir.sh)" && mv .pipekit/* "$(bash scripts/pipekit-state-dir.sh)/" && rmdir .pipekit`. The files are ephemeral so a clean wipe is also fine — the queue and state files self-recreate on next write.
+
+#### NEXT.md deferral mechanism for VBW active-plan scope (v1.6.0+, relocated v1.7.0)
 
 A Pipekit skill that wants to write `NEXT.md` while the user is inside a VBW active-plan scope will be blocked by VBW's file-guard hook (NEXT.md is Pipekit-owned but not in the active plan's `files_modified` field). Per `method.md` § VBW / Pipekit Ownership Model, NEXT.md is unambiguously Pipekit's — but VBW's hook can't tell that, so the write fails and the audit trail is lost.
 
-**The fix (Pipekit-side, ships in v1.6.0):** any Pipekit skill that updates `NEXT.md` from a context that may run under VBW's active-plan scope (`/review-plan`, `/launch --close`, others) must run a deferral check before writing.
+**The fix:** any Pipekit skill that updates `NEXT.md` from a context that may run under VBW's active-plan scope (`/review-plan`, `/launch --close`, others) must run a deferral check before writing.
 
 ```bash
 # Detect active VBW plan scope. Look for files_modified field in any
@@ -162,7 +187,7 @@ if [ -n "$ACTIVE_PLAN" ] && ! grep -q "NEXT\.md" "$ACTIVE_PLAN"; then
 fi
 ```
 
-**If `DEFER_NEXT_MD=1`**, queue the intended NEXT.md content to `.pipekit/pending-next-md.json` instead of writing the file. Schema:
+**If `DEFER_NEXT_MD=1`**, queue the intended NEXT.md content to `$STATE_DIR/pending-next-md.json` (resolved via `scripts/pipekit-state-dir.sh`) instead of writing the file. Schema:
 
 ```json
 {
@@ -173,17 +198,17 @@ fi
 }
 ```
 
-The `.pipekit/` directory must be gitignored (the queue is ephemeral and per-machine). `.pipekit/pending-next-md.json` holds the most recent deferred write; later deferrals overwrite earlier ones (NEXT.md tracks the *current* recommended next action — there is no value in queueing history).
+`pending-next-md.json` holds the most recent deferred write; later deferrals overwrite earlier ones (NEXT.md tracks the *current* recommended next action — there is no value in queueing history).
 
 **Inline `➜ Next:` is NOT deferred** — only the file write. The user still sees the next-command line in the terminal output of the current skill. The deferred file write is purely the persistence/audit layer.
 
-**Apply on session-end:** `/end-session` (and any non-VBW-scoped Pipekit skill that touches NEXT.md) checks for `.pipekit/pending-next-md.json` and applies the queued content atomically before its own NEXT.md logic runs. If `/end-session`'s own recompute supersedes the queued recommendation (the session shipped past the queued point), the queue is cleared without writing. The queue file is deleted post-apply — no persistent cruft.
+**Apply on session-end:** `/end-session` (and any non-VBW-scoped Pipekit skill that touches NEXT.md) checks for `$STATE_DIR/pending-next-md.json` and applies the queued content atomically before its own NEXT.md logic runs. If `/end-session`'s own recompute supersedes the queued recommendation (the session shipped past the queued point), the queue is cleared without writing. The queue file is deleted post-apply — no persistent cruft.
 
 **Graceful degradation:** if VBW lands an upstream `always_allow` allowlist for the file-guard hook (Option B in #12), this Pipekit-side queue mechanism becomes redundant but does not break — `NEXT.md` writes succeed inline, the deferral check finds no active scope (because the allowlist short-circuits the hook), and the queue file is never created. Both paths coexist safely.
 
-#### Pipeline state file (v1.6.0+)
+#### Pipeline state file (v1.6.0+, relocated v1.7.0)
 
-Each pipeline skill that completes a meaningful state transition writes a small JSON file to `.pipekit/pipeline-state/<issue-id>.json` capturing the transition:
+Each pipeline skill that completes a meaningful state transition writes a small JSON file to `$STATE_DIR/pipeline-state/<issue-id>.json` capturing the transition:
 
 ```json
 {
@@ -204,9 +229,9 @@ Fields:
 - `next_command` — the inline `➜ Next:` text (must match what was emitted to terminal and to NEXT.md)
 - `cwd` — absolute path of the project root at the time of write
 
-The state file is consumed by `/launch --auto` to track auto-chain progress and (deferred to v1.7.0) by `/pipekit-resume` to recover cross-session. Skills overwrite their own most-recent record — this is a state file, not an event log. `.pipekit/pipeline-state/` is gitignored along with the rest of `.pipekit/`.
+The state file is consumed by `/launch --auto` to track auto-chain progress and (deferred to a future minor) by `/pipekit-resume` to recover cross-session. Skills overwrite their own most-recent record — this is a state file, not an event log. The whole tree lives under `$STATE_DIR` (out-of-repo), so nothing needs gitignoring.
 
-State-file writes are subject to the same VBW active-plan scope deferral as NEXT.md (path is under `.pipekit/`, which mirrors the `always_allow` glob in #12 Option B). Where consumers have not yet adopted Option B, state-file writes during VBW-scoped stages are best-effort: skip silently on hook block rather than failing the skill. The orchestrator (`/launch --auto`) reconstructs missed transitions from VBW's own state where needed.
+Because the directory sits outside the repo, state-file writes are no longer subject to VBW's file-guard hook. Writes succeed unconditionally during VBW-scoped stages — no deferral, no silent drop. (Pre-v1.7.0 best-effort behavior is removed; if a write now fails, it's a real bug.)
 
 ---
 

--- a/templates/tier-heavy.md
+++ b/templates/tier-heavy.md
@@ -46,6 +46,6 @@ Heavy tier always routes through full VBW planning, regardless of complexity rat
 1. QA report present and passing
 2. Security review report present
 3. `/strategy-sync` last-run timestamp is after this issue's last build commit
-4. No `.pipekit/pending-strategy-sync` marker
+4. No `pending-strategy-sync` marker in Pipekit's state dir (`bash scripts/pipekit-state-dir.sh`)
 
 If any check fails, `--close` is refused with a list of missing artifacts. Linear status only transitions to UAT once all checks pass.


### PR DESCRIPTION
## Summary

- Closes #13 by relocating Pipekit's machine-local state (NEXT.md defer queue, pipeline-state records, strategy-sync marker) from \`<repo>/.pipekit/\` to \`\${XDG_CACHE_HOME:-~/.cache}/pipekit/<repo-basename>/\`.
- v1.6.0 #12 only fixed the in-the-clear NEXT.md write — the queue file written to dodge it lived at the same in-repo location and hit the same VBW file-guard hook. Net: silent audit-trail loss continued, one level deeper.
- Out-of-repo location is invisible to VBW's file-guard. Writes succeed unconditionally during VBW active-plan scope. No more best-effort, no more silent drops.

## Changes

- New \`scripts/pipekit-state-dir.sh\` — single source of truth for path resolution.
- SOP, skills, scripts, method.md, VBW_COMMANDS.md, tier-heavy.md updated to use the helper.
- \`scripts/verify-next-md-defer.sh\` dogfoods the new path and asserts STATE_DIR is outside the repo.
- \`scripts/pipekit-post-archive.sh\` includes inline fallback path resolution so the hook doesn't hard-fail mid-upgrade.

## Test plan

- [x] \`bash scripts/verify-next-md-defer.sh\` exits 0 (round-trip passes against new path)
- [x] \`bash scripts/pipekit-state-dir.sh\` resolves to \`~/.cache/pipekit/pipekit\` from this repo
- [ ] In rs-vault: \`/launch RS-22 --auto\` no longer reports \"hook-blocked / skipping silently\" for state-file writes
- [ ] \`/end-session\` reads queued NEXT.md from \`~/.cache/pipekit/<repo>/pending-next-md.json\` and applies atomically
- [ ] Migration command works on rs-vault's existing \`.pipekit/\` content

## Migration for consuming projects on v1.6.0

\`\`\`bash
mkdir -p "\$(bash scripts/pipekit-state-dir.sh)"
mv .pipekit/* "\$(bash scripts/pipekit-state-dir.sh)/" 2>/dev/null
rmdir .pipekit 2>/dev/null
\`\`\`

Files are ephemeral; a clean wipe is also fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)