### PR TITLE
feat(v1.8.0): one-PR-per-issue flow + short branch names + merge strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,76 @@
 
 All notable Pipekit releases. Versioning follows semver-ish — minor bumps for new capability, patch for fixes/docs only.
 
-Pin to a specific version: `./scripts/sync-method.sh v1.7.0`.
+Pin to a specific version: `./scripts/sync-method.sh v1.8.0`.
+
+---
+
+## v1.8.0 — 2026-04-30
+
+### What's New
+
+**One-PR-per-issue release.** Three coupled fixes that close the cherry-pick friction observed during RS-22 work and tighten the per-issue loop. Closes #15, #16, #17.
+
+#### `/end-session` re-orders before `/launch --close` (closes #15)
+
+The biggest day-to-day friction in v1.6.0/v1.7.0: /end-session ran *after* /launch --close, so the session log + NEXT.md update landed on a feature branch *after* PR merge — orphaned unless cherry-picked. The runbook documented a workaround that cost one extra PR (5-min gate-check tax) per issue.
+
+v1.8.0 reverses the order: **/end-session runs first, /launch --close second.** Both inside the worktree, on the feature branch. The session log + NEXT.md update commit to the feature branch *before* the PR opens; /launch --close then bundles everything into the single PR. **One PR per issue. No cherry-pick.**
+
+Two coupled changes inside /end-session:
+
+1. **Integration-branch refusal.** /end-session refuses to run if the current branch is `dev` or `main`. Pre-flight A added; clear error message points to RUNBOOK.md § The loop step 10. Prevents accidental direct-to-integration writes.
+2. **NEXT.md base refresh.** Inside the feature worktree, NEXT.md is a snapshot from when `/branch` ran. If a parallel session has shipped to dev since, the snapshot is stale. Pre-flight B fetches `origin/<integration>` and `git checkout`s NEXT.md to the current dev tip *before* recomputing. Race window shrinks from "hours of work in worktree" to "minutes between /end-session and PR merge."
+
+#### Short branch names from `/branch --linear` (closes #16)
+
+`/branch --linear RS-21` used to produce `feature/ethan/rs-21-record-edit-delete-with-change-tracking` (40+ chars, awkward in TUIs and PR titles, derived from Linear's verbose `gitBranchName`).
+
+v1.8.0 derives a short slug from the Linear title: **`feature/RS-21-edit-delete`** (issue ID + 2-3 meaningful words). Algorithm is deterministic — same Linear title always yields the same slug. Stopwords (`with`, `and`, `the`, `for`, `of`, `to`, `in`, `on`, `a`, `an`, `change`, `tracking`, `record`) are stripped before picking the first 2-3 words.
+
+The printed spawn hint also updates: `cd .worktrees/<branch> && claude --dangerously-skip-permissions` — saves a manual flag every time.
+
+#### Recommended merge strategy: rebase feature→dev, squash dev→main (closes #17)
+
+Squash-merging *everything* (v1.7.0's recommendation) flattens atomic per-task commits on dev — unreadable in GitKraken/git-log, useless for `git blame` per task, breaks `git bisect`. Squash-merging dev → main is correct (kills phantom-conflict topology), but feature → dev should preserve atomic commits.
+
+v1.8.0 documents the right combination:
+
+| Hop | Strategy |
+|---|---|
+| feature/* → dev | **Rebase** (preserves atomic commits as a linear sequence) |
+| dev → main | **Squash** (one release commit; kills merge-commit topology) |
+| Anything → merge-commit | **Disabled** (creates phantom conflicts on subsequent promotes) |
+
+New `scripts/pipekit-configure-repo.sh` flips all four GitHub repo settings idempotently in one shot:
+
+```bash
+bash scripts/pipekit-configure-repo.sh <org>/<repo>
+```
+
+Updated: `RUNBOOK.md` § One-time setup, `sop/Git_and_Deployment.md` § Merge Strategy by Hop. The actual flip is per-consumer (Pipekit doesn't enforce repo settings — it recommends).
+
+### Migration
+
+For consuming projects on v1.7.0:
+
+1. `./scripts/sync-method.sh v1.8.0` — pulls updated `/branch`, `/end-session`, `/launch` skills, `Git_and_Deployment.md`, `RUNBOOK.md`, and the new `scripts/pipekit-configure-repo.sh` helper.
+2. **Configure your repo's merge strategy:**
+   ```bash
+   bash scripts/pipekit-configure-repo.sh <org>/<repo>
+   ```
+3. **New per-issue loop** — see `RUNBOOK.md` § The loop. The order is now: `/end-session` → `/launch --close` → rebase-merge PR → `/branch finish`. The cherry-pick workaround documented in v1.7.0 is removed.
+4. No config / template / state-ID changes. Old per-issue flow (`/launch --close` first, /end-session after, cherry-pick log) still works if invoked in that order — but strongly prefer the new order.
+
+### Open items deferred to v1.8.1
+
+- **Port `/g-promote-dev`, `/g-promote-main`, `/g-test-vercel`, `/g-deploy`, `/g-promote-beta`** from rs-vault/piper into Pipekit with parameterization via `method.config.md`. Currently these are project-local copies, diverged between consumers. Folding them into Pipekit closes the per-issue + promotion loop end-to-end.
+
+### Open items deferred to v1.9.0
+
+- `/pipekit-resume` — state-file consumer for cross-session resumption (carried forward).
+- Diagnostic gate output (no more bare `REMEDIATION_REQUIRED`).
+- Orchestrator-side permission-denial detection (carried since v1.4.0).
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -13,18 +13,34 @@ Confirm these once per consuming project. They make the loop friction-free.
 | Setting | Where | Why |
 |---|---|---|
 | Branch protection on `dev` and `main` | GitHub repo Settings → Branches | Forces all changes through PRs |
-| **Squash-merge only** (disallow merge commits) | Settings → General → Pull Requests | Eliminates merge-commit topology that causes phantom conflicts on subsequent promotes |
-| **Auto-delete head branches on merge** | Settings → General → Pull Requests | Remote cleanup is automatic; CWT/claude-squad handles local |
-| Pipekit synced to **v1.7.0+** | `./scripts/sync-method.sh v1.7.0` | Out-of-repo state directory; defer mechanism actually works |
+| **Rebase-merge enabled, merge-commits disallowed** | Settings → General → Pull Requests | feature → dev keeps atomic commits readable; eliminates merge-commit topology that causes phantom conflicts |
+| **Squash-merge enabled** | Same | dev → main collapses to one release commit; per-issue commits stay on dev |
+| **Auto-delete head branches on merge** | Settings → General → Pull Requests | Remote cleanup is automatic; claude-squad handles local |
+| Pipekit synced to **v1.8.0+** | `./scripts/sync-method.sh v1.8.0` | One-PR-per-issue flow (no cherry-pick); short branch names |
+
+**Recommended merge strategy by hop:**
+- feature → dev: **rebase** (preserves atomic commits, readable in GitKraken/git-log)
+- dev → main: **squash** (single commit per release; kills merge-commit topology)
+- merge-commits: **never** (creates phantom conflicts on subsequent promotes)
 
 Verify in 30 seconds:
 
 ```bash
-gh repo view <org>/<repo> --json deleteBranchOnMerge,squashMergeAllowed,mergeCommitAllowed \
-  --jq '{deleteBranches:.deleteBranchOnMerge, squashOk:.squashMergeAllowed, mergeBlocked:(.mergeCommitAllowed|not)}'
-# Expect: {deleteBranches: true, squashOk: true, mergeBlocked: true}
+gh repo view <org>/<repo> --json deleteBranchOnMerge,squashMergeAllowed,rebaseMergeAllowed,mergeCommitAllowed \
+  --jq '{deleteBranches:.deleteBranchOnMerge, squashOk:.squashMergeAllowed, rebaseOk:.rebaseMergeAllowed, mergeBlocked:(.mergeCommitAllowed|not)}'
+# Expect: {deleteBranches: true, squashOk: true, rebaseOk: true, mergeBlocked: true}
 
-grep -m1 'v1\.' method/method.md   # expect v1.7.0 or later
+grep -m1 'v1\.' method/method.md   # expect v1.8.0 or later
+```
+
+**One-shot configure** (idempotent — safe to re-run):
+
+```bash
+gh api repos/<org>/<repo> --method PATCH \
+  -f delete_branch_on_merge=true \
+  -f allow_merge_commit=false \
+  -f allow_squash_merge=true \
+  -f allow_rebase_merge=true
 ```
 
 ---
@@ -68,13 +84,13 @@ Verifies file paths, line refs, dependencies still real. Read-only. **Skip if yo
 /branch --linear RS-XX
 ```
 
-What happens:
+What happens (v1.8.0+):
 - Pre-checks Linear status (warns if already shipped/canceled).
-- Creates `feature/<linear-slug>` (or `fix/`, `hotfix/`) branch off `dev`.
+- Creates `feature/<PREFIX>-<NN>-<2-3-word-slug>` off `dev` — short, deterministic. E.g. `feature/RS-21-edit-delete`, not the verbose Linear gitBranchName.
 - Spawns worktree at `.worktrees/<branch-name>`.
 - Symlinks `.env` and `node_modules` into the worktree.
 - Transitions Linear: Approved → In Progress.
-- Prints: `cd .worktrees/<branch-name> && claude` to enter.
+- Prints: `cd .worktrees/<branch-name> && claude --dangerously-skip-permissions` to enter.
 
 If you'd rather use a TUI for worktree management, claude-squad (`brew install claude-squad`) wraps the same primitives across multiple agents. CWT (archived 2026-04-29) — don't ingest.
 
@@ -118,7 +134,7 @@ vbw:vbw-qa returns Pass / Fail / Partial.
 
 | Verdict | What to do |
 |---|---|
-| **Pass** | Approve → `--auto` runs `/launch --close`, transitions Linear to UAT, ends |
+| **Pass** | Approve → continues to UAT (step 7) |
 | **Partial** | Read the verdict carefully. Often the right answer is **plan-amendment** (declare the deviation in SUMMARY.md) rather than re-running QA. Hand-driven amendment is one round; full re-execute is multiple agents. |
 | **Fail** | Pause hard. `/vbw:vibe --verify` for inline UAT loop, or escalate. **Do not re-run --auto on Fail** — the gate has spoken. |
 
@@ -130,39 +146,47 @@ Either:
 
 Both are valid. Use `/vbw:vibe --verify` when you want the agent-mediated checklist; smoke directly when you trust the AC.
 
-### 8. Close the session
+### 8. Close the session — `/end-session` FIRST (v1.8.0+)
 
 ```bash
 /end-session
 ```
 
-What it does (v1.7.0+):
-- Reads the deferred NEXT.md queue from `~/.cache/pipekit/<repo>/pending-next-md.json` and applies it (or recomputes if stale).
+What it does (v1.8.0+):
+- Refuses to run if you're on `dev` or `main` (guard against accidental direct-to-integration writes).
+- **Refreshes NEXT.md to `origin/<integration>` tip** — picks up any parallel-session updates so the recompute starts from a current base.
+- Reads the deferred NEXT.md queue from `~/.cache/pipekit/<repo>/pending-next-md.json` and applies/discards as appropriate.
 - Writes session log to `Logs/Sessions/YYYY-MM-DD_HHMM.md`.
-- Recomputes NEXT.md (next Approved issue / `/strategy-sync` / `/phase-plan`).
-- Commits log + NEXT.md + pushes to the **feature branch**.
+- Recomputes NEXT.md (next Approved issue / `/strategy-sync` / `/phase-plan`) on top of the refreshed base.
+- Commits log + NEXT.md to the **current feature branch**.
 
-⚠️ **Known friction (open):** /end-session writes log + NEXT.md to the feature branch. After PR merge, those commits are post-merge orphans on a deleted branch. **Workaround until v1.8.0:**
+The commit lands on the feature branch *before* the PR opens. Step 9 (`/launch --close`) then bundles everything into the single PR. **No cherry-pick; one PR per issue.**
+
+### 9. Open the PR — `/launch --close`
 
 ```bash
-# In the parent worktree, before CWT-deleting the feature worktree:
-cd ~/Projects/<repo>
-git checkout dev && git pull --ff-only
-git checkout -b chore/preserve-rs-XX-session-artifacts
-git cherry-pick <feature-branch-tip>     # picks the /end-session commit only
-git push -u origin chore/preserve-rs-XX-session-artifacts
-gh pr create --base dev --title "chore(log): preserve RS-XX session artifacts"
-# Squash-merge that PR.
+/launch RS-XX --close
 ```
 
-### 9. Promote feature → dev (if not done by --close)
+Opens feature → dev PR with code + session log + NEXT.md update. Linear → UAT. The PR has everything in one place.
 
-`/launch --close` opens the PR. Squash-merge it. Auto-delete handles the remote.
+### 10. Rebase-merge the PR (GitHub UI or `gh pr merge --rebase`)
 
-### 10. Worktree cleanup
+Atomic commits flow onto dev linearly. Auto-delete handles the remote branch.
+
+### 11. Smoke against dev preview (optional)
 
 ```bash
-/branch finish        # local: removes worktree + branch
+/g-test-vercel RS-XX           # project-side skill — pushes branch + smoke-tests preview URL
+```
+
+(Mostly relevant if you didn't run it during step 7. Otherwise skip.)
+
+### 12. Worktree cleanup
+
+```bash
+exit                           # leave the worktree session
+/branch finish                 # in parent: removes local worktree + branch
 ```
 
 Or claude-squad TUI: select the session → `d`. Same outcome.
@@ -266,9 +290,15 @@ If you see `state-file writes are best-effort during scod stages — skipping si
          │
          ├─ UAT (/vbw:vibe --verify or local smoke)
          │
-         └─ /end-session
-            └─ cherry-pick session log to dev (workaround)
-            └─ /branch finish (or claude-squad delete)
+         ├─ /end-session              ← v1.8.0+: BEFORE --close
+         │    (refuses on dev/main; refreshes NEXT.md from origin/dev tip;
+         │     commits log + NEXT.md to feature branch)
+         │
+         ├─ /launch RS-XX --close     ← opens single PR with everything
+         │
+         ├─ Rebase-merge PR
+         │
+         └─ /branch finish (or claude-squad delete)
 
 …then later, batch-promote dev → main:
    gh pr create --base main --head dev …

--- a/scripts/pipekit-configure-repo.sh
+++ b/scripts/pipekit-configure-repo.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# pipekit-configure-repo.sh
+#
+# Idempotent one-shot to configure a GitHub repo with the merge-strategy
+# combination Pipekit recommends (v1.8.0+):
+#   - rebase merges allowed (for feature → dev)
+#   - squash merges allowed (for dev → main)
+#   - merge commits disallowed (kills phantom-conflict topology)
+#   - auto-delete head branches on merge (remote cleanup)
+#
+# Usage:
+#   bash scripts/pipekit-configure-repo.sh <org>/<repo>
+#   bash scripts/pipekit-configure-repo.sh                  # auto-detect from `gh repo view`
+#
+# Output: shows before-and-after state. Safe to re-run.
+
+set -euo pipefail
+
+REPO="${1:-}"
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$REPO" ]; then
+    echo "ERROR: pass <org>/<repo> as the first argument or run from inside a gh-linked repo." >&2
+    exit 1
+  fi
+fi
+
+echo "Repo: $REPO"
+echo
+
+echo "Before:"
+gh api "repos/$REPO" --jq '{
+  delete_branch_on_merge,
+  allow_merge_commit,
+  allow_squash_merge,
+  allow_rebase_merge
+}'
+echo
+
+echo "Applying Pipekit-recommended settings..."
+gh api "repos/$REPO" --method PATCH \
+  -f delete_branch_on_merge=true \
+  -f allow_merge_commit=false \
+  -f allow_squash_merge=true \
+  -f allow_rebase_merge=true \
+  --jq '{
+    delete_branch_on_merge,
+    allow_merge_commit,
+    allow_squash_merge,
+    allow_rebase_merge
+  }'
+
+echo
+echo "Done. Next time you 'Merge pull request' in the UI:"
+echo "  feature → dev      → Rebase and merge"
+echo "  dev → main         → Squash and merge"
+echo "  Anything to merge-commit is disabled (intentional)."

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -190,6 +190,8 @@ sync_file "$TEMP/scripts/pipekit-state-dir.sh" "$PROJECT_ROOT/scripts/pipekit-st
 [ -f "$PROJECT_ROOT/scripts/pipekit-state-dir.sh" ] && chmod +x "$PROJECT_ROOT/scripts/pipekit-state-dir.sh"
 sync_file "$TEMP/scripts/verify-next-md-defer.sh" "$PROJECT_ROOT/scripts/verify-next-md-defer.sh" "scripts/verify-next-md-defer.sh"
 [ -f "$PROJECT_ROOT/scripts/verify-next-md-defer.sh" ] && chmod +x "$PROJECT_ROOT/scripts/verify-next-md-defer.sh"
+sync_file "$TEMP/scripts/pipekit-configure-repo.sh" "$PROJECT_ROOT/scripts/pipekit-configure-repo.sh" "scripts/pipekit-configure-repo.sh"
+[ -f "$PROJECT_ROOT/scripts/pipekit-configure-repo.sh" ] && chmod +x "$PROJECT_ROOT/scripts/pipekit-configure-repo.sh"
 
 # --- Sync canonical .claude/rules/ files ---
 # Contract: Pipekit owns three canonical rule files prefixed `pipekit-`

--- a/skills/branch/skill.md
+++ b/skills/branch/skill.md
@@ -49,6 +49,29 @@ Example parsing:
 - `/branch --fix login-redirect` -> `fix/login-redirect` from `dev`
 - `/branch --hotfix auth-crash` -> `hotfix/auth-crash` from `main`
 
+#### Slug derivation when `--linear` is passed (v1.8.0+)
+
+When the user passes only `--linear PROJ-XX` (no explicit name argument), derive the slug from the Linear issue title — but **short** (issue ID + 2-3 meaningful words), not the verbose `gitBranchName` field Linear returns.
+
+Algorithm:
+1. Fetch Linear title (already fetched in Step 3 — reuse it).
+2. Lowercase the title.
+3. Strip stopwords: `with`, `and`, `the`, `for`, `of`, `to`, `in`, `on`, `a`, `an`, `change`, `tracking`, `record` (the last three are common Linear filler — extend the list as patterns surface).
+4. Strip punctuation; split on whitespace.
+5. Take first 2–3 remaining words.
+6. Kebab-case them; prefix with the Linear ID.
+
+Result format: `<PREFIX>-<NN>-<word1>-<word2>[-<word3>]`
+
+Examples (real Linear titles):
+- `RS-21 — Record edit + delete with change tracking` → `RS-21-edit-delete`
+- `RS-19 — Sales results grid (AG Grid Community)` → `RS-19-sales-results`
+- `RS-22 — Server-side audit logging` → `RS-22-audit-logging`
+
+If the user passes both `--linear PROJ-XX` and an explicit name, the explicit name wins (use the user's name as the slug; still prefix with the Linear ID for traceability: `<PREFIX>-<NN>-<user-name>`).
+
+This is **deterministic** — same Linear title always yields the same slug.
+
 ### 2. Ensure Base Branch Is Current
 
 ```bash
@@ -145,7 +168,7 @@ Worktree: {worktree prefix from method.config.md}{kebab-name}
 Base: dev (or main for hotfix)
 
 To start working:
-  cd {worktree prefix from method.config.md}{kebab-name} && claude
+  cd {worktree prefix from method.config.md}{kebab-name} && claude --dangerously-skip-permissions
 
 When done:
   /branch finish

--- a/skills/end-session/skill.md
+++ b/skills/end-session/skill.md
@@ -28,6 +28,52 @@ This skill is invoked when the user says:
 
 ## Execution Steps
 
+### Pre-flight A — Integration-branch refusal (v1.8.0+)
+
+Before doing anything else, check what branch we're on. If `git branch --show-current` returns the integration branch (`dev`) or production branch (`main`), **refuse with a clear error**:
+
+```bash
+CURRENT=$(git branch --show-current)
+case "$CURRENT" in
+  dev|main|master)
+    echo "ERROR: /end-session is meant to run on a feature branch inside a worktree." >&2
+    echo "  Current branch: $CURRENT" >&2
+    echo "  This guard exists because writing the session log directly to" >&2
+    echo "  $CURRENT would either fail (branch protection) or pollute" >&2
+    echo "  integration history. Run /end-session from inside the feature" >&2
+    echo "  worktree, BEFORE /launch --close opens the PR." >&2
+    echo "" >&2
+    echo "  See RUNBOOK.md § The loop, step 10." >&2
+    exit 1
+    ;;
+esac
+```
+
+Rationale: starting v1.8.0 (#15), /end-session is part of the feature-branch flow. It runs *before* /launch --close so the session log + NEXT.md update ship in the same PR as the code. Running it on dev/main is either blocked by branch protection or — worse — succeeds and creates a divergent direct write.
+
+If you genuinely need to write a session log without a feature branch (e.g., session of pure planning, no ship), commit your work first, branch off dev, then run /end-session in the new branch.
+
+---
+
+### Pre-flight B — Refresh NEXT.md from integration tip (v1.8.0+)
+
+Inside the feature worktree, NEXT.md is a snapshot from when `/branch` was run. If a parallel session has shipped to `dev` since, that snapshot is stale. Before recomputing NEXT.md (Step 7b.1), pull dev's current version:
+
+```bash
+INTEGRATION="$INTEGRATION"  # resolved by Step 0a below
+git fetch origin "$INTEGRATION" --quiet
+if git cat-file -e "origin/$INTEGRATION:NEXT.md" 2>/dev/null; then
+  git checkout "origin/$INTEGRATION" -- NEXT.md
+  echo "✓ NEXT.md refreshed to origin/$INTEGRATION (parallel-session-safe base)"
+fi
+```
+
+This loads only NEXT.md — no branch switch, no other state change. The recompute logic in Step 7b.1 is from-Linear-truth, so the base just affects "Last updated" and optional sections (parallelizable / blocked). Race window shrinks from "hours of work in worktree" to "minutes between /end-session and PR merge."
+
+**Ordering note:** `$INTEGRATION` is resolved in the next sub-step (the existing Session Shutdown Preflight reads `method.config.md` § Git Architecture). In practice: read config → resolve `$INTEGRATION` → refresh NEXT.md → continue with the rest of the preflight.
+
+---
+
 ### Step 0 — Session Shutdown Preflight
 
 This step is **transparent and confirmatory**: it scans the workspace for everything that typically needs cleanup after a ship (feature branch, agent worktrees, stale locks, orphan branches), presents a plan, and waits for approval before executing anything destructive. No silent cleanup.

--- a/skills/launch/skill.md
+++ b/skills/launch/skill.md
@@ -341,6 +341,10 @@ Do **not** auto-advance to `--close`. The user must explicitly invoke it. This i
 
 Invoked when the user returns with verify confirmed (either via `/vbw:vibe --verify` passed, or via project-precedent self-verification on non-VBW-native layouts).
 
+**v1.8.0+ ordering:** the canonical pattern is `/end-session` → `/launch --close`, both inside the worktree on the feature branch. /end-session writes the session log + NEXT.md to the feature branch first; /launch --close then opens the PR with code + log + NEXT.md bundled. One PR per issue. See `RUNBOOK.md` § The loop, steps 10–11.
+
+If `/launch --close` is invoked **without** a preceding `/end-session`, proceed normally — the close path is independent. The session log will then need to land via the v1.7.0 cherry-pick workaround (or simply run `/end-session` later from a fresh chore branch off dev). Strongly prefer the new ordering.
+
 [Heavy: before transitioning, verify all close-gate artifacts are present:
 - QA report exists and is passing
 - Security review report exists at the path defined in `method.config.md`

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -69,6 +69,29 @@ dev  (active development)
 | `beta` (three-tier only) | Protected. Requires PR + CI passing. No direct merges. |
 | `dev` | Default branch for PRs. CI runs on all PRs targeting dev. |
 
+### Merge Strategy by Hop (v1.8.0+)
+
+Match the merge strategy to the hop. The combination below preserves history readability *and* eliminates the merge-commit topology problem (which produced phantom conflicts on subsequent dev → main promotes — observed and resolved during the v1.7.0/v1.8.0 work).
+
+| Hop | Strategy | Rationale |
+|---|---|---|
+| `feature/*` → `dev` | **Rebase** | Preserves atomic commits as a linear sequence on dev. Readable in GitKraken/git-log; useful for `git blame`, `git bisect` per task. |
+| `dev` → `beta` (three-tier only) | **Rebase** | Same rationale as feature → dev — atomic commit history rolls forward. |
+| `dev` → `main` (two-tier) or `beta` → `main` (three-tier) | **Squash** | One commit per release on main. Clean release history; no merge bubbles to back-merge. |
+| Any hop | **Never merge-commit** | Merge bubbles cause phantom conflicts on the next promote PR. Disable in repo settings. |
+
+**One-shot configure** (idempotent — safe to re-run on any consuming repo):
+
+```bash
+gh api repos/<org>/<repo> --method PATCH \
+  -f delete_branch_on_merge=true \
+  -f allow_merge_commit=false \
+  -f allow_squash_merge=true \
+  -f allow_rebase_merge=true
+```
+
+When you click "Merge pull request" in the GitHub UI, the dropdown will let you pick. Match it to the hop using the table above.
+
 ---
 
 ## Release Flow


### PR DESCRIPTION
## Summary

Closes #15, #16, #17. Three coupled fixes that close the cherry-pick friction observed during RS-22 work and tighten the per-issue loop.

- **#15 — /end-session re-orders before /launch --close.** Both run in the worktree on the feature branch. /end-session writes log + NEXT.md to the feature branch, /launch --close opens the single PR. One PR per issue. No cherry-pick. Plus integration-branch refusal guard and NEXT.md base refresh from origin/dev (closes parallel-session race).
- **#16 — Short branch names from /branch --linear.** \`feature/RS-21-edit-delete\` instead of the verbose Linear default. Deterministic slug. Spawn hint includes \`--dangerously-skip-permissions\`.
- **#17 — Recommended merge strategy by hop.** Rebase feature→dev, squash dev→main, no merge-commits. New \`scripts/pipekit-configure-repo.sh\` flips all four GitHub repo settings idempotently.

Deferred to v1.8.1: port \`/g-promote-{dev,main,beta}\`, \`/g-test-vercel\`, \`/g-deploy\` from rs-vault/piper.

## Test plan

- [x] /end-session pre-flight A refuses on dev/main with clear error
- [x] /end-session pre-flight B fetches origin/<integration> and checks out NEXT.md before recompute
- [x] /branch slug derivation produces \`RS-21-edit-delete\` from RS-21's title
- [x] scripts/pipekit-configure-repo.sh runs idempotently on withpiper/pipekit
- [ ] **Live test on RS-21 in rs-vault** — sync to v1.8.0 and run the full new loop
- [ ] CHANGELOG migration steps verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)