### PR TITLE
fix(launch): default /launch recommendations to --auto (v1.8.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable Pipekit releases. Versioning follows semver-ish — minor bumps for new capability, patch for fixes/docs only.
 
-Pin to a specific version: `./scripts/sync-method.sh v1.8.0.1`.
+Pin to a specific version: `./scripts/sync-method.sh v1.8.0.2`.
+
+---
+
+## v1.8.0.2 — 2026-04-30 (patch)
+
+### What changed
+
+**Default `/launch` recommendations to `--auto`.** Live test on RS-21 surfaced that /start-session offered "say `/launch RS-21` (or `go` and I'll fire it)" — without `--auto`. The bare form skips the auto-chain orchestration that's the whole point of v1.6.0+. Default should match the canonical Standard-tier path.
+
+Three skill prose updates:
+
+- **`/start-session`** — new step 9 explicitly offers the next command in `--auto` form (Standard tier). Tier handling: Standard → `--auto`, Heavy → plain `/launch` (since `--auto` rejects Heavy), Quick → `/06-linear-todo-runner`.
+- **`/end-session`** — NEXT.md recompute writes `/launch RS-XX --auto` instead of bare `/launch RS-XX`. Same tier exceptions.
+- **`/launch --close`** — close-time NEXT.md logic emits `/launch {next issue} --auto`. Same tier exceptions.
+
+### Migration
+
+`./scripts/sync-method.sh v1.8.0.2`. No behavior change in the auto-chain itself; only what gets recommended in NEXT.md and what /start-session offers to fire.
 
 ---
 

--- a/skills/end-session/skill.md
+++ b/skills/end-session/skill.md
@@ -403,7 +403,7 @@ Previous `NEXT.md` likely points at the issue that just shipped. Recompute and o
 
 Source for the next action, in priority order:
 
-1. **Current phase has more Approved issues?** — recommend `/launch {next Approved issue}`. Pick the one whose dependency graph (via Linear `blocked_by` relations) unblocks the most downstream work. Briefly name what it unblocks in the "Why this one" field.
+1. **Current phase has more Approved issues?** — recommend `/launch {next Approved issue} --auto`. **Default to `--auto`** for Standard-tier issues (the canonical case). Pick the one whose dependency graph (via Linear `blocked_by` relations) unblocks the most downstream work. Briefly name what it unblocks in the "Why this one" field. *Exception:* if the issue is explicitly Heavy-tier in the spec (security review + mandatory /strategy-sync), drop `--auto` since `/launch --auto` rejects Heavy. For Quick-tier issues, recommend `/06-linear-todo-runner` instead.
 2. **Current phase fully shipped but has unshipped `Specced` issues?** — recommend moving the top-priority one to Approved (human review gate).
 3. **Current phase fully shipped and specced?** — recommend `/strategy-sync` if there's a pending-strategy-sync marker at `$STATE_DIR/pending-strategy-sync` (resolved via `scripts/pipekit-state-dir.sh`), otherwise recommend `/phase-plan` to select the next phase.
 4. **No phase active?** — recommend `/phase-plan`.

--- a/skills/launch/skill.md
+++ b/skills/launch/skill.md
@@ -627,7 +627,7 @@ Tier 1 / Option 3 has two `/launch` invocations per issue: open and `--close`. E
 
 **Close-time NEXT.md logic** (priority order):
 
-1. Next Specced issue in current phase → `/launch {next issue}`
+1. Next Approved/Specced issue in current phase → `/launch {next issue} --auto` (default to `--auto` for Standard-tier; drop the flag for Heavy-tier issues since `/launch --auto` rejects Heavy)
 2. If `$STATE_DIR/pending-strategy-sync` marker exists (resolved via `bash scripts/pipekit-state-dir.sh`) → `/strategy-sync`
 3. If phase complete and synced → `/phase-plan`
 4. Otherwise → `/g-test-vercel` for the just-shipped issue

--- a/skills/start-session/skill.md
+++ b/skills/start-session/skill.md
@@ -157,6 +157,24 @@ Prompt the user:
 
 Acknowledge their intentions and store for end-of-session reflection.
 
+### 9. Offer to fire the recommended next command (v1.8.0.2+)
+
+If NEXT.md surfaced a `/launch <ID>` recommendation AND the current branch is a feature branch matching that issue (i.e., user already ran `/branch --linear`), offer to fire the command. **Default the offered form to `--auto`** for Standard-tier issues — that's the canonical happy path:
+
+```
+Ready when you are. Say `go` and I'll run /launch RS-XX --auto
+(or run a specific variant: `/launch RS-XX` without --auto, or `/launch RS-XX --close` if you've already finished and just need to close).
+```
+
+**Tier handling:**
+- Standard tier (the common case) → offer `--auto`
+- Heavy tier (security review + mandatory `/strategy-sync`) → offer plain `/launch RS-XX` (without `--auto`); `/launch --auto` rejects Heavy
+- Quick tier → offer `/06-linear-todo-runner` (or `/launch` plain — runner handles the queue)
+
+If you don't know the tier from NEXT.md or the spec, default to `--auto` and let `/launch` reject and route appropriately if it's Heavy.
+
+If the current branch is NOT the feature branch for the recommended issue (e.g., user is still on dev), offer the issue but defer firing — point them to `/branch --linear RS-XX` first.
+
 ## Related
 
 - End Session skill (`/end-session`) - captures reflections at session end


### PR DESCRIPTION
## Summary

Live observation from RS-21: /start-session surfaced "say \`/launch RS-21\` (or \`go\` and I'll fire it)" — bare form, no --auto. v1.6.0+ established --auto as the canonical Standard-tier path; recommendations should match.

- /start-session: new step 9 explicitly offers --auto form (Standard tier)
- /end-session: NEXT.md recompute uses --auto
- /launch --close: close-time NEXT.md uses --auto

Tier exceptions documented (Heavy drops --auto, Quick goes to /linear-todo-runner).

## Test plan

- [x] /start-session prose now defaults to --auto in step 9
- [x] /end-session NEXT.md recompute documented to emit --auto
- [x] /launch --close documented to emit --auto in next-action
- [ ] **Live: continue RS-21 with v1.8.0.2 synced; /start-session should now offer "go" → /launch RS-21 --auto**

🤖 Generated with [Claude Code](https://claude.com/claude-code)