### PR TITLE
fix(launch): QA-Pass defaults to pause-for-end-session (v1.8.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 All notable Pipekit releases. Versioning follows semver-ish — minor bumps for new capability, patch for fixes/docs only.
 
-Pin to a specific version: `./scripts/sync-method.sh v1.8.0.3`.
+Pin to a specific version: `./scripts/sync-method.sh v1.8.0.4`.
+
+---
+
+## v1.8.0.4 — 2026-04-30 (patch)
+
+### What changed
+
+**QA-Pass default is now `pause-for-end-session`, not `close-now`.** Live RS-59 observation: /launch --auto's QA-Pass prompt still recommended `close` as the default action, which routes through the v1.7.0 cherry-pick path and defeats v1.8.0's "one PR per issue" model.
+
+The recommended flow on QA Pass is:
+
+1. `pause-for-end-session` (new default) — exit cleanly so the user can run `/end-session` (writes log + NEXT.md to the feature branch), then `/launch --close` (opens the single bundled PR). One PR. No cherry-pick.
+2. `close-now` (legacy, preserved) — old v1.7.0 behavior; closes immediately, requires cherry-pick of the session log later.
+
+Touched: `skills/launch/skill.md` auto-chain mode step 6 prose. Fail/Partial defaults unchanged (`pause-here`).
+
+### Migration
+
+`./scripts/sync-method.sh v1.8.0.4`. No breaking changes — `close-now` is still available for users who prefer the v1.7.0 flow.
 
 ---
 

--- a/skills/launch/skill.md
+++ b/skills/launch/skill.md
@@ -506,14 +506,18 @@ After Steps 1–6 complete unchanged (gate validation, tier confirm, dependency 
 
    {Fail / Partial: surface the failing AC items verbatim from the verification report}
 
-   Run /launch --close to transition Linear to UAT?
+   Per v1.8.0+ canonical ordering: run /end-session first (so the session log + NEXT.md ride in the same PR as the code), then /launch --close. How to proceed?
    ```
 
    Options:
-   - **Pass** → `close` (default), `pause-here`, `abort`
+   - **Pass** → `pause-for-end-session` (**default** — exit cleanly so user runs `/end-session` then `/launch --close`), `close-now` (legacy v1.7.0 path; will require cherry-pick of the session log later), `abort`
    - **Fail / Partial** → `pause-here` (default), `re-execute-with-scope`, `abort`
 
-   On `close`, continue to step 7. On `pause-here`, exit cleanly (Linear stays in Building; user runs `/launch --close` later). On `re-execute-with-scope`, prompt for fix scope and re-spawn `vbw:vbw-dev` (loop back to step 4 with the new scope; do NOT re-run plan-review). On `abort`, exit.
+   **Recommend `pause-for-end-session` for QA Pass.** The auto-chain stops here cleanly; the user runs `/end-session` (writes log + NEXT.md to the feature branch), then `/launch --close` (opens the single PR with everything bundled). One PR per issue, no cherry-pick.
+
+   `close-now` is preserved for users who want the old behavior — but warn them it triggers the cherry-pick workaround documented in RUNBOOK.md (cherry-pick the session log onto a chore branch off dev → second PR).
+
+   On `pause-for-end-session`, exit cleanly with NEXT.md pointing at `/end-session` (or, since /end-session is the next step regardless, just exit and let the user invoke it). Linear stays in Building. On `close-now`, continue to step 7 (legacy path). On `pause-here` (Fail/Partial), exit cleanly. On `re-execute-with-scope` (Fail/Partial), prompt for fix scope and re-spawn `vbw:vbw-dev` (loop back to step 4 with the new scope; do NOT re-run plan-review). On `abort`, exit.
 
 7. **Run `/launch PROJ-XXX --close` inline.** Use the existing Step 9 logic — same Linear transition, same close-summary comment. Does not spawn another subagent; runs in the orchestrator's own context (it is gate-and-status work, not build work).
 


### PR DESCRIPTION
RS-59 live: QA-Pass still recommended close-now (v1.7.0 cherry-pick path). Change default to pause-for-end-session (v1.8.0 canonical order). close-now preserved for users who want the old behavior.