### PR TITLE
fix(branch): clarify /branch finish run-from-parent contract (v1.8.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 All notable Pipekit releases. Versioning follows semver-ish — minor bumps for new capability, patch for fixes/docs only.
 
-Pin to a specific version: `./scripts/sync-method.sh v1.8.0.4`.
+Pin to a specific version: `./scripts/sync-method.sh v1.8.0.5`.
+
+---
+
+## v1.8.0.5 — 2026-04-30 (patch)
+
+### What changed
+
+**`/branch finish` clarified — accepts explicit slug arg, auto-detects merged worktrees.** Live RS-59 observation: RUNBOOK step 13 said "exit + /branch finish" but didn't make clear that /branch finish runs from the parent repo (not from inside the worktree being removed), and the skill itself didn't define how it would identify the right worktree if multiple existed.
+
+This patch:
+
+- **`skills/branch/skill.md`** — Finish subcommand now documents the run-from-parent contract explicitly and adds a 3-tier resolution algorithm: (1) explicit slug arg matches a worktree path; (2) running from inside a worktree errors with a clear "exit and re-run from parent" message; (3) no-arg in parent auto-detects merged-on-origin worktrees, confirms the unambiguous one, or asks user to pick from multiple.
+- **`RUNBOOK.md`** — step 13 split into Part A (exit) + Part B (cd to parent, run /branch finish). Notes that squash-merge breaks `git branch -d`'s ancestry check; `-D` is the correct response.
+
+### Migration
+
+`./scripts/sync-method.sh v1.8.0.5`. Pure documentation + skill-prose change; no behavior change unless you were relying on `/branch finish` running from inside the worktree (which fails today regardless).
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -241,12 +241,41 @@ Atomic commits flow onto dev linearly. Auto-delete handles the remote branch.
 
 ### 13. Worktree cleanup
 
+This step has two parts because `git worktree remove` can't delete the directory you're sitting in.
+
+**Part A — exit the worktree session:**
+
 ```bash
-exit                           # leave the worktree session
-/branch finish                 # in parent: removes local worktree + branch
+exit       # leaves claude, drops to your shell at .worktrees/RS-XX-…
 ```
 
-Or claude-squad TUI: select the session → `d`. Same outcome.
+**Part B — go to the parent repo and finish:**
+
+```bash
+cd ~/Projects/<repo>           # parent repo, NOT the worktree
+claude                         # start (or attach to) your parent claude session
+```
+
+Then in the parent claude:
+
+```bash
+/branch finish RS-XX-edit-delete    # explicit slug = unambiguous
+```
+
+Or without the arg:
+
+```bash
+/branch finish                       # auto-detects merged worktrees; confirms with you
+```
+
+Auto-detect logic: `/branch finish` lists worktrees whose branch is merged on `origin`. If exactly one matches, it confirms. If multiple match, it asks you to pick.
+
+What it does:
+- Removes the worktree directory under `.worktrees/`.
+- Deletes the local branch (`-D` if needed — squash-merge breaks `-d`'s "fully merged" check, that's normal).
+- Remote branch is already gone (auto-delete-on-merge handled it when the PR was squash-merged).
+
+**Or** if you use claude-squad: TUI → select the session → `d`. Same outcome.
 
 ---
 

--- a/skills/branch/skill.md
+++ b/skills/branch/skill.md
@@ -176,27 +176,68 @@ When done:
 
 ## Finish Subcommand
 
-`/branch finish` cleans up the current worktree and branch.
+`/branch finish` cleans up a worktree and its branch.
+
+### Where to run it (v1.8.0.5+)
+
+**Run from the parent repo** (`~/Projects/<repo>`), not from inside the worktree being removed. `git worktree remove` fails if you're inside the directory it's deleting.
+
+Typical sequence after the feature PR is rebase-merged:
+
+```bash
+# Inside the worktree:
+exit                          # leave claude (drops to shell)
+
+# Back at the parent shell:
+cd ~/Projects/<repo>          # if not already there
+claude                        # or attach to your existing parent session
+
+# In parent claude:
+/branch finish RS-XX-edit-delete    # explicit arg = unambiguous
+# or:
+/branch finish                       # no arg = auto-detect merged worktrees
+```
 
 ### Steps
 
-1. Detect current worktree context
-2. Check branch status:
-   - Uncommitted changes -> warn and ask to commit or stash
-   - Unpushed commits -> warn and ask to push
-   - Open PR -> show PR status
-   - Merged -> safe to clean up
-3. Offer cleanup options:
-   - Delete worktree + local branch + remote branch (if merged)
-   - Keep branch but remove worktree
-   - Cancel
-4. Execute cleanup:
-   ```bash
-   # From main repo (not the worktree being deleted)
-   git worktree remove "$WORKTREE_PATH"
-   git branch -d {branch-name}  # only if merged
-   git push origin --delete {branch-name}  # only if merged and remote exists
-   ```
+#### 1. Resolve which worktree to finish
+
+In priority order:
+
+1. **Explicit slug arg** (`/branch finish RS-XX-edit-delete`) — match against `git worktree list` paths. If found, use it. If not, error: "no worktree matches `RS-XX-edit-delete`."
+2. **Currently inside a worktree (not the parent repo)** — use the current worktree, but **error and instruct the user to `exit` and re-run from the parent**:
+   > "Detected /branch finish run from inside the worktree at <path>. Re-run from the parent repo at <repo-root> — `git worktree remove` can't delete the directory you're sitting in."
+3. **No arg, in the parent repo** — list `git worktree list` worktrees that are NOT the parent. For each, check:
+   - Is the branch merged to dev/main on `origin`? (`git branch -r --merged origin/dev | grep <branch>`)
+   - If exactly one worktree's branch is merged → that's the candidate. Confirm with user before removing.
+   - If multiple worktrees are merged → list them, ask user to pick.
+   - If none merged → list active worktrees, ask "which one to finish?"
+
+#### 2. Check branch status (after target worktree resolved)
+
+- Uncommitted changes in the target worktree → warn and ask to commit or stash (cannot stash from outside the worktree; user must cd in, stash, cd back).
+- Unpushed commits → warn and ask to push.
+- Open PR → show PR status; default action is "wait for PR to merge first."
+- Merged → safe to clean up.
+
+#### 3. Offer cleanup options
+
+- **Delete worktree + local branch** (default if merged). Auto-delete on remote already handled if `delete_branch_on_merge=true` is set on the repo (v1.7.0+ recommendation).
+- Keep branch but remove worktree.
+- Cancel.
+
+#### 4. Execute cleanup
+
+```bash
+# Run from the parent repo (this is where /branch finish executes):
+git worktree remove "$WORKTREE_PATH"
+git branch -d "$BRANCH_NAME"          # only if merged
+# Note: with delete_branch_on_merge=true, the remote branch is already gone.
+# Only run the next line if for some reason it isn't:
+# git push origin --delete "$BRANCH_NAME"
+```
+
+If `git branch -d` fails ("not fully merged" — happens after squash-merge because squash creates a new commit on dev that doesn't match the feature branch's commits in ancestry), use `git branch -D` (force-delete). Squash-merge is the correct case for `-D`; the content is on dev, the commit objects are not.
 
 ## List Subcommand
 


### PR DESCRIPTION
Live RS-59: RUNBOOK step 13 ambiguous; skill lacked disambiguation logic. Patch: explicit run-from-parent contract + 3-tier resolution + -D note for squash-merge.