### PR TITLE
fix(repo-config): per-branch merge enforcement via Rulesets (v1.8.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,37 @@
 
 All notable Pipekit releases. Versioning follows semver-ish — minor bumps for new capability, patch for fixes/docs only.
 
-Pin to a specific version: `./scripts/sync-method.sh v1.8.0.5`.
+Pin to a specific version: `./scripts/sync-method.sh v1.8.0.6`.
+
+---
+
+## v1.8.0.6 — 2026-04-30 (patch)
+
+### What changed
+
+**Per-branch merge enforcement via GitHub Rulesets.** Earlier patches (v1.7.0–v1.8.0.5) disallowed merge-commits at the repo level to prevent the phantom-conflict trap on `main`. That's machine-safe but blunt — also bans merge bubbles on `dev`, which some users prefer for feature-branch readability in GitKraken / git-log.
+
+v1.8.0.6 switches to per-branch enforcement:
+
+- **Repo level**: all three merge methods enabled (rebase + squash + merge-commit).
+- **`pipekit-main-squash-only` ruleset**: enforces squash-only on `main`. UI dropdown will only show "Squash and merge" for PRs targeting main.
+- **Net effect**: feature → dev gets the user's choice (rebase or merge-commit). dev → main is squash, machine-enforced. Mistakes on the dangerous hop are impossible.
+
+`scripts/pipekit-configure-repo.sh` extended to handle both — repo-flag PATCH plus ruleset create-or-update via `POST/PUT /repos/<org>/<repo>/rulesets`. Idempotent. The ruleset name is `pipekit-main-squash-only` so re-runs find and update the existing rule rather than creating duplicates.
+
+### Touched
+
+- `scripts/pipekit-configure-repo.sh` — full rewrite. 2 steps: repo-level flags + ruleset.
+- `RUNBOOK.md` § One-time setup — updated table; recommends rulesets-based config.
+- `sop/Git_and_Deployment.md` § Merge Strategy by Hop — explains the per-branch model + why the change.
+
+### Migration
+
+`./scripts/sync-method.sh v1.8.0.6` then `bash scripts/pipekit-configure-repo.sh <org>/<repo>`. The script will:
+1. Re-enable `allow_merge_commit` at the repo level (was disabled by v1.7.0–v1.8.0.5).
+2. Create the `pipekit-main-squash-only` ruleset.
+
+If you want to keep the v1.8.0.5 behavior (merge-commits disallowed globally), just don't run the configure script.
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -23,7 +23,8 @@ The definitive step-by-step for shipping one Linear issue through the pipeline. 
 10. [Open the PR — `/launch --close`](#10-open-the-pr--launch---close)
 11. [Rebase-merge the PR](#11-rebase-merge-the-pr-github-ui-or-gh-pr-merge---rebase)
 12. [Smoke against dev preview (optional)](#12-smoke-against-dev-preview-optional) — `/g-test-vercel`
-13. [Worktree cleanup](#13-worktree-cleanup) — `exit` worktree, `cd ~/Projects/<repo>`, `/branch finish RS-XX-slug`
+13. [Worktree cleanup](#13-worktree-cleanup) 
+     `exit` worktree  →   `cd ~/Projects/<repo>`  → `/branch finish RS-XX-slug`
 
 **Then periodically (separate flow):**
 
@@ -51,34 +52,34 @@ Confirm these once per consuming project. They make the loop friction-free.
 | Setting | Where | Why |
 |---|---|---|
 | Branch protection on `dev` and `main` | GitHub repo Settings → Branches | Forces all changes through PRs |
-| **Rebase-merge enabled, merge-commits disallowed** | Settings → General → Pull Requests | feature → dev keeps atomic commits readable; eliminates merge-commit topology that causes phantom conflicts |
-| **Squash-merge enabled** | Same | dev → main collapses to one release commit; per-issue commits stay on dev |
+| **All merge methods enabled at repo level** (rebase + squash + merge-commit) | Settings → General → Pull Requests | Gives flexibility on feature → dev |
+| **`pipekit-main-squash-only` ruleset** | Settings → Rules → Rulesets | Enforces squash-only on `main` (machine-enforced; can't accidentally merge-commit to main) |
 | **Auto-delete head branches on merge** | Settings → General → Pull Requests | Remote cleanup is automatic; claude-squad handles local |
-| Pipekit synced to **v1.8.0+** | `./scripts/sync-method.sh v1.8.0` | One-PR-per-issue flow (no cherry-pick); short branch names |
+| Pipekit synced to **v1.8.0.6+** | `./scripts/sync-method.sh v1.8.0.6` | Per-branch ruleset enforcement |
 
-**Recommended merge strategy by hop:**
-- feature → dev: **rebase** (preserves atomic commits, readable in GitKraken/git-log)
-- dev → main: **squash** (single commit per release; kills merge-commit topology)
-- merge-commits: **never** (creates phantom conflicts on subsequent promotes)
+**Effective merge policy by hop (v1.8.0.6+):**
+- **feature → dev**: rebase OR merge-commit — your choice in the GitHub UI. Both are safe (merge-commits on dev get absorbed when dev → main squashes).
+- **dev → main**: squash-only (ruleset enforces; UI dropdown will only show "Squash and merge"). Single commit per release. No phantom-conflict trap.
 
-Verify in 30 seconds:
+**One-shot configure** (idempotent):
+
+```bash
+bash scripts/pipekit-configure-repo.sh <org>/<repo>
+```
+
+This sets repo-level merge flags AND creates/updates the main-squash-only ruleset. Safe to re-run.
+
+Verify:
 
 ```bash
 gh repo view <org>/<repo> --json deleteBranchOnMerge,squashMergeAllowed,rebaseMergeAllowed,mergeCommitAllowed \
-  --jq '{deleteBranches:.deleteBranchOnMerge, squashOk:.squashMergeAllowed, rebaseOk:.rebaseMergeAllowed, mergeBlocked:(.mergeCommitAllowed|not)}'
-# Expect: {deleteBranches: true, squashOk: true, rebaseOk: true, mergeBlocked: true}
+  --jq '{deleteBranches:.deleteBranchOnMerge, squash:.squashMergeAllowed, rebase:.rebaseMergeAllowed, merge:.mergeCommitAllowed}'
+# Expect: all four true (per-branch enforcement is in the ruleset, not repo flags)
 
-grep -m1 'v1\.' method/method.md   # expect v1.8.0 or later
-```
+gh api repos/<org>/<repo>/rulesets --jq '.[] | select(.name=="pipekit-main-squash-only") | {name, enforcement}'
+# Expect: {name: "pipekit-main-squash-only", enforcement: "active"}
 
-**One-shot configure** (idempotent — safe to re-run):
-
-```bash
-gh api repos/<org>/<repo> --method PATCH \
-  -f delete_branch_on_merge=true \
-  -f allow_merge_commit=false \
-  -f allow_squash_merge=true \
-  -f allow_rebase_merge=true
+grep -m1 'v1\.' method/method.md   # expect v1.8.0.6 or later
 ```
 
 ---

--- a/scripts/pipekit-configure-repo.sh
+++ b/scripts/pipekit-configure-repo.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 # pipekit-configure-repo.sh
 #
-# Idempotent one-shot to configure a GitHub repo with the merge-strategy
-# combination Pipekit recommends (v1.8.0+):
-#   - rebase merges allowed (for feature → dev)
-#   - squash merges allowed (for dev → main)
-#   - merge commits disallowed (kills phantom-conflict topology)
-#   - auto-delete head branches on merge (remote cleanup)
+# Configure a GitHub repo with Pipekit's recommended merge strategy
+# (v1.8.0.6+):
+#
+#   - Repo level: rebase, squash, AND merge-commits all allowed
+#       → gives you flexibility on feature → dev (rebase or merge-commit, your choice)
+#   - main branch: squash-only enforced via GitHub Ruleset
+#       → prevents accidental merge-commits to main (the phantom-conflict trap)
+#   - delete_branch_on_merge: true (auto-delete remote branches)
+#
+# Why Rulesets instead of just disallowing merge_commit globally?
+# Earlier (v1.7.0–v1.8.0.5) we disallowed merge_commit at the repo level. That
+# prevented the phantom-conflict trap on main, but also banned merge bubbles
+# on dev — which some users prefer for feature-branch readability in
+# GitKraken / git-log. Rulesets let us be precise: main = squash-only,
+# dev/everything-else = your choice.
 #
 # Usage:
 #   bash scripts/pipekit-configure-repo.sh <org>/<repo>
@@ -26,7 +35,16 @@ if [ -z "$REPO" ]; then
   fi
 fi
 
+RULESET_NAME="pipekit-main-squash-only"
+
 echo "Repo: $REPO"
+echo
+
+# ---------------------------------------------------------------------------
+# Step 1: repo-level merge settings — allow rebase, squash, AND merge-commits
+# ---------------------------------------------------------------------------
+
+echo "Step 1 — Repo-level merge settings"
 echo
 
 echo "Before:"
@@ -38,10 +56,10 @@ gh api "repos/$REPO" --jq '{
 }'
 echo
 
-echo "Applying Pipekit-recommended settings..."
+echo "Applying: merge=on, squash=on, rebase=on, auto-delete=on..."
 gh api "repos/$REPO" --method PATCH \
   -f delete_branch_on_merge=true \
-  -f allow_merge_commit=false \
+  -f allow_merge_commit=true \
   -f allow_squash_merge=true \
   -f allow_rebase_merge=true \
   --jq '{
@@ -52,7 +70,61 @@ gh api "repos/$REPO" --method PATCH \
   }'
 
 echo
-echo "Done. Next time you 'Merge pull request' in the UI:"
-echo "  feature → dev      → Rebase and merge"
-echo "  dev → main         → Squash and merge"
-echo "  Anything to merge-commit is disabled (intentional)."
+
+# ---------------------------------------------------------------------------
+# Step 2: main-branch ruleset — squash-only on PRs targeting main
+# ---------------------------------------------------------------------------
+
+echo "Step 2 — Main-branch ruleset ($RULESET_NAME)"
+echo
+
+# Check for existing ruleset by name
+EXISTING_ID=$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || echo "")
+
+RULESET_BODY=$(cat <<JSON
+{
+  "name": "$RULESET_NAME",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    }
+  ]
+}
+JSON
+)
+
+if [ -n "$EXISTING_ID" ]; then
+  echo "Updating existing ruleset (id=$EXISTING_ID)..."
+  echo "$RULESET_BODY" | gh api "repos/$REPO/rulesets/$EXISTING_ID" \
+    --method PUT \
+    --input - \
+    --jq '{name, enforcement, allowed_merge_methods: (.rules[] | select(.type == "pull_request") | .parameters.allowed_merge_methods)}'
+else
+  echo "Creating new ruleset..."
+  echo "$RULESET_BODY" | gh api "repos/$REPO/rulesets" \
+    --method POST \
+    --input - \
+    --jq '{name, enforcement, allowed_merge_methods: (.rules[] | select(.type == "pull_request") | .parameters.allowed_merge_methods)}'
+fi
+
+echo
+echo "Done. Effective merge policy:"
+echo "  feature → dev      → Rebase OR Merge commit (your choice in the GitHub UI)"
+echo "  dev → main         → Squash (enforced by ruleset; UI dropdown will show only Squash)"
+echo "  Auto-delete remote branches on merge → enabled."

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -69,28 +69,35 @@ dev  (active development)
 | `beta` (three-tier only) | Protected. Requires PR + CI passing. No direct merges. |
 | `dev` | Default branch for PRs. CI runs on all PRs targeting dev. |
 
-### Merge Strategy by Hop (v1.8.0+)
+### Merge Strategy by Hop (v1.8.0.6+)
 
-Match the merge strategy to the hop. The combination below preserves history readability *and* eliminates the merge-commit topology problem (which produced phantom conflicts on subsequent dev → main promotes — observed and resolved during the v1.7.0/v1.8.0 work).
+Different hops want different strategies. The phantom-conflict trap (observed during v1.7.0 / v1.8.0 work) only happens when the **dev → main** hop uses a merge commit. Other hops can use whatever fits the project's history-readability preferences.
 
-| Hop | Strategy | Rationale |
-|---|---|---|
-| `feature/*` → `dev` | **Rebase** | Preserves atomic commits as a linear sequence on dev. Readable in GitKraken/git-log; useful for `git blame`, `git bisect` per task. |
-| `dev` → `beta` (three-tier only) | **Rebase** | Same rationale as feature → dev — atomic commit history rolls forward. |
-| `dev` → `main` (two-tier) or `beta` → `main` (three-tier) | **Squash** | One commit per release on main. Clean release history; no merge bubbles to back-merge. |
-| Any hop | **Never merge-commit** | Merge bubbles cause phantom conflicts on the next promote PR. Disable in repo settings. |
+| Hop | Recommended | Also OK | Rationale |
+|---|---|---|---|
+| `feature/*` → `dev` | **Rebase** | Merge-commit | Rebase = linear atomic commits; merge-commit = bubble preserving feature scope. Either works on dev (no phantom-conflict risk; bubbles get absorbed when dev → main squashes). |
+| `dev` → `beta` (three-tier) | Rebase or merge-commit | — | Same as feature → dev. |
+| **`dev` → `main`** (two-tier) or `beta` → `main` (three-tier) | **Squash (enforced)** | — | One release commit per promotion. Merge-commits here cause phantom conflicts on subsequent promotes. **Enforced by ruleset, not user discipline.** |
+
+#### Enforcement model (v1.8.0.6+): Rulesets, not repo flags
+
+Earlier (v1.7.0–v1.8.0.5) Pipekit recommended disallowing merge-commits at the repo level (`allow_merge_commit=false`). That's machine-safe but blunt — it bans merge bubbles on dev too, which some users prefer for feature-branch readability.
+
+v1.8.0.6 switches to **per-branch enforcement via GitHub Rulesets**:
+
+- Repo level: all three merge methods enabled (rebase, squash, merge-commit).
+- A `pipekit-main-squash-only` ruleset enforces squash-only on `main` specifically.
+- Other branches (dev, beta, feature/*) inherit the repo-level flexibility.
+
+Result: GitHub UI's "Merge pull request" dropdown shows all options on feature → dev PRs but only "Squash and merge" on PRs targeting main. Mistakes impossible.
 
 **One-shot configure** (idempotent — safe to re-run on any consuming repo):
 
 ```bash
-gh api repos/<org>/<repo> --method PATCH \
-  -f delete_branch_on_merge=true \
-  -f allow_merge_commit=false \
-  -f allow_squash_merge=true \
-  -f allow_rebase_merge=true
+bash scripts/pipekit-configure-repo.sh <org>/<repo>
 ```
 
-When you click "Merge pull request" in the GitHub UI, the dropdown will let you pick. Match it to the hop using the table above.
+This sets repo-level merge flags AND creates/updates the ruleset. The script lives in pipekit and gets synced into consuming projects via `sync-method.sh`.
 
 ---
 


### PR DESCRIPTION
Switches from repo-level merge-commit ban to per-branch ruleset enforcement. main = squash-only (machine-enforced). feature → dev = your choice (rebase or merge-commit). pipekit-configure-repo.sh handles both repo flags and ruleset create-or-update; idempotent. Tested on withpiper/pipekit.