### PR TITLE
feat(g-promote-dev): port from project-local into Pipekit (v1.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,69 @@
 
 All notable Pipekit releases. Versioning follows semver-ish — minor bumps for new capability, patch for fixes/docs only.
 
-Pin to a specific version: `./scripts/sync-method.sh v1.8.0.6`.
+Pin to a specific version: `./scripts/sync-method.sh v1.8.1`.
+
+---
+
+## v1.8.1 — 2026-04-30
+
+### What's New
+
+**`/g-promote-dev` ported from project-local copies into Pipekit.** First skill in the `/g-*` port (v1.8.1–v1.8.5). Eliminates divergence between rs-vault's and piper's project-local copies; bug fixes propagate via `/pipekit-update`.
+
+#### `skills/g-promote-dev/skill.md` (NEW)
+
+Parameterized via `method.config.md`. Reads:
+
+- § Linear → Issue prefix (e.g. `RS`, `PROJ`)
+- § Linear → Workflow State IDs → In Progress
+- § Git Architecture → Integration branch (`dev`)
+- § Pre-Deploy Gate
+- § Stack → Hosting (`vercel` | `none`), DB push command (e.g. `supabase db push`), Migration dir, Shared DB across environments
+
+Skips capabilities gracefully when stack values are missing (no Vercel? No DB? Skill still works for the PR-only path).
+
+The migration push step (was hardcoded for rs-vault's shared Supabase) is now config-driven:
+- If `DB_PUSH_CMD` empty → skip migration step entirely
+- If `SHARED_DB=yes` → warn about forward-mutation, default-no on push prompt
+- If `SHARED_DB=no` → default-yes on push prompt (separate dev/prod DBs make this safe)
+
+#### `method.config.template.md` — § Stack section (NEW)
+
+New keys for skill parameterization:
+
+| Key | Used by |
+|---|---|
+| Hosting (`vercel` \| `none`) | `/g-test-vercel`, `/g-deploy` |
+| DB push command | `/g-promote-dev` |
+| Migration dir | `/g-promote-dev` |
+| Production smoke URL | `/g-deploy` |
+| Shared DB across environments (`yes` \| `no`) | `/g-promote-dev` |
+
+### Migration
+
+For rs-vault and other consumers with project-local `/g-promote-dev`:
+
+```bash
+./scripts/sync-method.sh v1.8.1
+```
+
+Pipekit's parameterized `g-promote-dev` will replace the project-local copy. Before running, verify your `method.config.md` has:
+- § Linear → Issue prefix ✓
+- § Linear → State IDs → In Progress ✓
+- § Pre-Deploy Gate ✓
+- § Stack section populated (NEW — copy from `method.config.template.md`)
+
+For rs-vault specifically: Stack section should set `Hosting=vercel`, `DB push command=supabase db push`, `Migration dir=supabase/migrations/`, `Shared DB across environments=yes` to preserve current behavior.
+
+If you need to keep the project-local version (e.g. piper hasn't migrated yet), place it at `.claude/overrides/skills/g-promote-dev/skill.md` — sync-method.sh will preserve the override.
+
+### Open items deferred to v1.8.2 – v1.8.5
+
+- v1.8.2: `/g-promote-main` port
+- v1.8.3: `/g-test-vercel` port
+- v1.8.4: `/g-deploy` port
+- v1.8.5: `/g-promote-beta` port (three-tier flows; piper-relevant)
 
 ---
 

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -136,3 +136,15 @@ pnpm turbo run check-types
 pnpm turbo run lint
 pnpm turbo run test
 ```
+
+## Stack (v1.8.1+)
+
+Stack-specific values consumed by `/g-promote-dev`, `/g-promote-main`, `/g-test-vercel`, `/g-deploy`. Leave blank to disable that capability — skills detect missing values and skip gracefully.
+
+| Key | Value | Used by |
+|-----|-------|---------|
+| **Hosting** | `vercel` \| `none` | `/g-test-vercel`, `/g-deploy` (skip Vercel-specific steps if `none`) |
+| **DB push command** | e.g. `supabase db push` | `/g-promote-dev` step 2.5 (skip migration push if blank) |
+| **Migration dir** | e.g. `supabase/migrations/` | `/g-promote-dev` (detect new migrations on the branch) |
+| **Production smoke URL** | e.g. `https://example.com` | `/g-deploy` (post-merge production smoke) |
+| **Shared DB across environments** | `yes` \| `no` | `/g-promote-dev` (warns about forward-mutation if `yes`) |

--- a/skills/g-promote-dev/skill.md
+++ b/skills/g-promote-dev/skill.md
@@ -1,0 +1,235 @@
+---
+name: g-promote-dev
+description: Promote current feature branch to dev by creating a PR. Reads method.config.md for Linear state IDs, pre-deploy gate, and stack-specific values. Verifies pre-deploy gate, optionally pushes migrations, extracts Linear issue references, transitions issues to In Progress.
+---
+
+# Git Promote Dev
+
+Creates a PR from the current feature/fix branch to the integration branch (typically `dev`). Two-tier flow: `feature/*` → PR to dev → (later) PR to main. Three-tier flow: same first hop; subsequent hops use `/g-promote-beta` and `/g-promote-main`.
+
+**Portable since v1.8.1.** Reads project-specific values from `method.config.md` — does not hardcode Linear prefixes, state IDs, gate commands, or stack assumptions.
+
+## Triggers
+
+- `/g-promote-dev`
+- "promote to dev", "open PR to dev"
+
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth status`)
+- Linear MCP available (`mcp__linear-server__*`)
+- Current branch follows the pattern `feature/*`, `fix/*`, or `hotfix/*`
+- Working tree clean (all changes committed)
+- `method.config.md` present and parseable
+
+## Steps
+
+### 1. Read project config
+
+Parse `method.config.md` once at the start. Extract:
+
+| Variable | Source section | Default if missing |
+|---|---|---|
+| `ISSUE_PREFIX` | § Linear → Issue prefix | error — required |
+| `IN_PROGRESS_ID` | § Linear → Workflow State IDs → In Progress | error — required |
+| `INTEGRATION` | § Git Architecture (`dev` for both two-tier and three-tier) | `dev` |
+| `GATE_CMD` | § Pre-Deploy Gate (joined with `&&`) | error — required |
+| `HOSTING` | § Stack → Hosting | `none` |
+| `DB_PUSH_CMD` | § Stack → DB push command | _(empty — skip migration push)_ |
+| `MIGRATION_DIR` | § Stack → Migration dir | _(empty — skip migration detection)_ |
+| `SHARED_DB` | § Stack → Shared DB across environments | `no` |
+
+If `method.config.md` is missing or unparseable, surface a clear error and stop.
+
+### 2. Sanity checks
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+STATUS=$(git status --porcelain)
+```
+
+Guard:
+- If `$CURRENT_BRANCH` is `main`, `dev`, or `beta`: STOP. _"Can't promote from `$CURRENT_BRANCH` — switch to a feature/fix branch first."_
+- If `$STATUS` is non-empty: STOP. _"Uncommitted changes: {list}. Commit or stash before promoting."_
+- If `$CURRENT_BRANCH` doesn't start with `feature/`, `fix/`, or `hotfix/`: WARN, ask user to confirm.
+
+### 3. Pre-deploy gate
+
+Run the gate command read from config:
+
+```bash
+$GATE_CMD
+```
+
+If any check fails, STOP and surface the output. Do not create a PR with a broken gate. The gate is project-defined; trust the config.
+
+### 4. Apply migrations to shared DB (if configured)
+
+Skip this step entirely if `DB_PUSH_CMD` or `MIGRATION_DIR` is empty.
+
+If both are set, detect new migrations on this branch:
+
+```bash
+NEW_MIGRATIONS=$(git diff --name-only --diff-filter=A "$INTEGRATION..HEAD" -- "$MIGRATION_DIR" 2>/dev/null)
+```
+
+If migrations exist, branch on `SHARED_DB`:
+
+**`SHARED_DB=yes`** (single DB across environments — common in pre-production projects):
+
+```bash
+echo "New migrations on this branch (not yet on $INTEGRATION):"
+echo "$NEW_MIGRATIONS" | sed 's/^/  /'
+echo ""
+echo "WARNING: this project shares one DB across environments. Pushing here"
+echo "forward-mutates the DB used by $INTEGRATION/main. If this PR is closed"
+echo "without merging, you will need to manually roll back these migrations."
+echo ""
+read -r -p "Push to shared DB now? [y/N] " confirm
+if [[ "$confirm" == "y" || "$confirm" == "Y" ]]; then
+  $DB_PUSH_CMD || {
+    echo "$DB_PUSH_CMD failed. STOP. Fix the migration and retry."
+    exit 1
+  }
+  echo "✓ Migrations applied."
+else
+  echo "Skipped. Migrations will be applied at /g-promote-main time. Preview"
+  echo "URL UAT will not be able to exercise migration-bearing code paths."
+fi
+```
+
+**`SHARED_DB=no`** (separate dev/prod DBs):
+
+```bash
+echo "New migrations on this branch (not yet on $INTEGRATION):"
+echo "$NEW_MIGRATIONS" | sed 's/^/  /'
+echo ""
+read -r -p "Push to dev DB now? [Y/n] " confirm
+if [[ "$confirm" != "n" && "$confirm" != "N" ]]; then
+  $DB_PUSH_CMD || {
+    echo "$DB_PUSH_CMD failed. STOP."
+    exit 1
+  }
+  echo "✓ Migrations applied to dev DB."
+fi
+```
+
+If the user declines, continue to step 5 — PR will still be created.
+
+### 5. Push branch
+
+```bash
+git push -u origin "$CURRENT_BRANCH"
+```
+
+If upstream already exists and is ahead, drop the `-u`. If push is rejected (non-fast-forward), surface the rebase command and stop: `git pull --rebase origin $CURRENT_BRANCH`.
+
+### 6. Extract Linear issue references
+
+Parse for `${ISSUE_PREFIX}-XXX` identifiers from:
+
+- Branch name (e.g. `feature/RS-21-edit-delete`)
+- Commit messages on this branch not yet on `$INTEGRATION`:
+  ```bash
+  git log --pretty=%s "$INTEGRATION..HEAD"
+  ```
+
+Collect a unique set. If none found, ask: _"No `${ISSUE_PREFIX}-XXX` references found. Link this PR to a Linear issue? (issue ID or skip)"_
+
+### 7. Create the PR
+
+```bash
+gh pr create \
+  --base "$INTEGRATION" \
+  --head "$CURRENT_BRANCH" \
+  --title "<title — derive from first commit subject>" \
+  --body "$(cat <<EOF
+## Summary
+<bullets — derive from commit messages on this branch>
+
+## Linear issues
+<refs from step 6>
+
+## Test plan
+- [ ] Pre-deploy gate passes ($GATE_CMD)
+- [ ] Manually verified in preview environment
+- [ ] <add issue-specific tests>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the PR URL from the output.
+
+### 8. Transition Linear issues
+
+For each referenced issue, move to `In Progress` (state ID `$IN_PROGRESS_ID`) if not already past it. Only advance forward — do not downgrade:
+
+```
+Specced | Approved → In Progress
+Needs Spec | On Deck → In Progress (warn: no spec found)
+Building | UAT | Done → leave as-is
+```
+
+Use `mcp__linear-server__save_issue` with `state: "In Progress"` (or the ID directly). Attach the PR as a link:
+
+```
+mcp__linear-server__save_issue({
+  id: "<ISSUE_PREFIX>-NNN",
+  state: "In Progress",
+  links: [{ url: "<pr-url>", title: "PR: <title>" }]
+})
+```
+
+### 9. Report
+
+Output:
+
+```
+✓ PR created: <pr-url>
+✓ Preview environment: (check PR comment if hosting=$HOSTING auto-posts a URL)
+✓ Linear issues moved to In Progress: <list>
+
+Next: review the PR, wait for preview build, then merge to $INTEGRATION.
+On merge to $INTEGRATION: no further Linear transition (issues stay In Progress until $PROD).
+```
+
+(`$PROD` resolves to `main` for two-tier; for three-tier, `merge to beta` moves to UAT and `merge to main` moves to Done.)
+
+## Tier reminder
+
+After merge to `$INTEGRATION`, issues STAY `In Progress`. They only move forward when promoted further:
+- **Two-tier**: merge to `main` → `Done` (use `/g-promote-main`)
+- **Three-tier**: merge to `beta` → `UAT` (use `/g-promote-beta`); merge to `main` → `Done` (use `/g-promote-main`)
+
+## Failure modes
+
+| Symptom | Fix |
+|---------|-----|
+| `gh auth status` fails | Run `gh auth login` |
+| Push rejected (non-fast-forward) | Rebase: `git pull --rebase origin $CURRENT_BRANCH` |
+| Linear MCP not connected | Skip Linear transitions; user must move issues manually |
+| Pre-deploy gate fails | Fix the issue. The gate is a hard requirement. |
+| `method.config.md` missing | Run `/startup` to bootstrap project config, or copy from `method.config.template.md` |
+| `$DB_PUSH_CMD` fails on a clean migration | The migration itself is broken. Fix the SQL; do not bypass. |
+
+## See also
+
+- `sop/Git_and_Deployment.md` — full release flow and merge strategy by hop
+- `method.config.md` — project-specific values
+- `/g-test-vercel` — push branch + smoke-test preview URL (use mid-feature)
+- `/g-promote-main` — next promotion step (two-tier)
+- `/g-promote-beta` — next promotion step (three-tier)
+- `/g-deploy` — post-merge production verification
+
+## Migration from project-local copies (rs-vault, piper)
+
+If this skill is being installed via `/pipekit-update` to replace a project-local `.claude/skills/g-promote-dev/skill.md`, verify these `method.config.md` values are populated before running:
+
+- § Linear → Issue prefix
+- § Linear → Workflow State IDs → In Progress
+- § Pre-Deploy Gate
+- § Stack → Hosting, DB push command, Migration dir, Shared DB across environments
+
+If you need to keep the old project-local version, place it at `.claude/overrides/skills/g-promote-dev/skill.md` — `sync-method.sh` will preserve the override.


### PR DESCRIPTION
First /g-* skill port. Parameterized via method.config.md (Linear prefix + state IDs, pre-deploy gate, Stack section). Skips capabilities gracefully when stack values missing. Migration to rs-vault/piper documented in CHANGELOG.