### PR TITLE
docs(runbook): replace 417-line runbook with one-page flowchart

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,417 +1,188 @@
-# Pipekit Per-Issue Runbook
+# Pipekit Loop — Current State (v1.8.2)
 
-The definitive step-by-step for shipping one Linear issue through the pipeline. Read once; refer back when you forget the exact order.
+The whole per-issue loop on one page. Read top-to-bottom.
 
-**Canonical pipeline:** `method.md` § Stages 1-5. **This doc:** the practical, tool-by-tool walkthrough.
-
----
-
-## Quick Index — follow in order
-
-**Per-issue loop:**
-
-0. [Pick the issue (parent, lightweight)](#0-pick-the-issue-parent-lightweight) — NEXT.md / `/linear-status` / `/spec-preflight`
-1. [Branch + worktree](#1-branch--worktree) — `/branch --linear RS-XX`
-2. [Enter the worktree](#2-enter-the-worktree) — `cd … && claude --dangerously-skip-permissions`
-3. [`/start-session` (worktree)](#3-start-session-worktree-on-feature-branch--paired-with-end-session) — orient on the issue
-4. [Launch the auto-chain](#4-launch-the-auto-chain) — `/launch RS-XX --auto`
-5. [Decision: plan-review verdict](#5-decision-plan-review-verdict) — Pass / Revise / Block
-6. [Watch (don't intervene during) execution](#6-watch-dont-intervene-during-execution)
-7. [Decision: QA verdict](#7-decision-qa-verdict) — Pass / Partial / Fail
-8. [UAT](#8-uat) — `/vbw:vibe --verify` or local smoke
-9. [Close the session — `/end-session`](#9-close-the-session--end-session-paired-with-step-3s-start-session)
-10. [Open the PR — `/launch --close`](#10-open-the-pr--launch---close)
-11. [Rebase-merge the PR](#11-rebase-merge-the-pr-github-ui-or-gh-pr-merge---rebase)
-12. [Smoke against dev preview (optional)](#12-smoke-against-dev-preview-optional) — `/g-test-vercel`
-13. [Worktree cleanup](#13-worktree-cleanup) 
-     `exit` worktree  →   `cd ~/Projects/<repo>`  → `/branch finish RS-XX-slug`
-
-**Then periodically (separate flow):**
-
-- P1–P4. [Promote dev → main](#promote-dev--main) — `/g-promote-main` → squash → `/g-promote-main --post-merge` → `/strategy-sync`
-
-**If something goes wrong:**
-
-- [Phantom conflicts on dev → main PR](#phantom-conflicts-on-dev--main-pr)
-- [Stale git index lock](#stale-git-index-lock)
-- [Plan-reviewer Block on round 2 (stalemate)](#plan-reviewer-block-on-round-2-stalemate)
-- [State-file or NEXT.md write hook-blocked](#state-file-or-nextmd-write-hook-blocked)
-
-**Reference:**
-
-- [One-time setup (per repo)](#one-time-setup-per-repo) — squash/rebase/auto-delete config + `pipekit-configure-repo.sh`
-- [Decision tree at a glance](#decision-tree-at-a-glance)
-- [What's NOT in this runbook](#whats-not-in-this-runbook-separate-flows)
+**Today's test mode:** step 4 has two paths.
+- **RS-58** (Phase 2 closeout) → VBW path (`/launch --auto`)
+- **RS-30** (export threshold alert) → native path (`launch-native`)
+- After both, decide: which becomes the default in v2.0.0.
 
 ---
 
-## One-time setup (per repo)
-
-Confirm these once per consuming project. They make the loop friction-free.
-
-| Setting | Where | Why |
-|---|---|---|
-| Branch protection on `dev` and `main` | GitHub repo Settings → Branches | Forces all changes through PRs |
-| **All merge methods enabled at repo level** (rebase + squash + merge-commit) | Settings → General → Pull Requests | Gives flexibility on feature → dev |
-| **`pipekit-main-squash-only` ruleset** | Settings → Rules → Rulesets | Enforces squash-only on `main` (machine-enforced; can't accidentally merge-commit to main) |
-| **Auto-delete head branches on merge** | Settings → General → Pull Requests | Remote cleanup is automatic; claude-squad handles local |
-| Pipekit synced to **v1.8.0.6+** | `./scripts/sync-method.sh v1.8.0.6` | Per-branch ruleset enforcement |
-
-**Effective merge policy by hop (v1.8.0.6+):**
-- **feature → dev**: rebase OR merge-commit — your choice in the GitHub UI. Both are safe (merge-commits on dev get absorbed when dev → main squashes).
-- **dev → main**: squash-only (ruleset enforces; UI dropdown will only show "Squash and merge"). Single commit per release. No phantom-conflict trap.
-
-**One-shot configure** (idempotent):
-
-```bash
-bash scripts/pipekit-configure-repo.sh <org>/<repo>
-```
-
-This sets repo-level merge flags AND creates/updates the main-squash-only ruleset. Safe to re-run.
-
-Verify:
-
-```bash
-gh repo view <org>/<repo> --json deleteBranchOnMerge,squashMergeAllowed,rebaseMergeAllowed,mergeCommitAllowed \
-  --jq '{deleteBranches:.deleteBranchOnMerge, squash:.squashMergeAllowed, rebase:.rebaseMergeAllowed, merge:.mergeCommitAllowed}'
-# Expect: all four true (per-branch enforcement is in the ruleset, not repo flags)
-
-gh api repos/<org>/<repo>/rulesets --jq '.[] | select(.name=="pipekit-main-squash-only") | {name, enforcement}'
-# Expect: {name: "pipekit-main-squash-only", enforcement: "active"}
-
-grep -m1 'v1\.' method/method.md   # expect v1.8.0.6 or later
-```
-
----
-
-## The loop
-
-Same shape every time. ~12 steps from "I want to ship X" to "X is in production."
-
-**Pairing model (v1.8.0.1+):** /start-session and /end-session both run **inside the worktree, on the feature branch**. /start-session orients you on the issue; /end-session writes the log when the issue is done. Both refresh NEXT.md from `origin/<integration>` so you see current state regardless of how long the worktree has lived.
-
-### 0. Pick the issue (parent, lightweight)
-
-In the project root (parent on `dev`), pick the issue *without* opening a full session:
-
-```bash
-cat NEXT.md                         # what was queued at end of last session
-/linear-status                       # quick triage
-/phase-plan --status                 # phase-aware view (optional)
-```
-
-Confirm the issue is **Approved** (or higher — Specced isn't ready). For an Approved issue, optionally:
-
-```bash
-/spec-preflight RS-XX                # empirical pre-flight on the spec
-```
-
-Verifies file paths, line refs, dependencies still real. Read-only. **Skip if you trust the spec was reviewed recently.**
-
-(If you genuinely want a full /start-session at the project level — e.g. start of a workday, no specific issue yet in mind — run it now. Otherwise skip; step 4 below opens the real session inside the worktree.)
-
-### 1. Branch + worktree
-
-**Use `/branch`, not raw `git worktree`.** It handles Linear status transition, env symlinks, and worktree naming convention.
-
-```bash
-/branch --linear RS-XX
-```
-
-What happens (v1.8.0+):
-- Pre-checks Linear status (warns if already shipped/canceled).
-- Creates `feature/<PREFIX>-<NN>-<2-3-word-slug>` off `dev` — short, deterministic. E.g. `feature/RS-21-edit-delete`, not the verbose Linear gitBranchName.
-- Spawns worktree at `.worktrees/<branch-name>`.
-- Symlinks `.env` and `node_modules` into the worktree.
-- Transitions Linear: Approved → In Progress.
-- Prints: `cd .worktrees/<branch-name> && claude --dangerously-skip-permissions` to enter.
-
-If you'd rather use a TUI for worktree management, claude-squad (`brew install claude-squad`) wraps the same primitives across multiple agents. CWT (archived 2026-04-29) — don't ingest.
-
-### 2. Enter the worktree
-
-Run the command /branch printed:
-
-```bash
-cd .worktrees/RS-XX-edit-delete && claude --dangerously-skip-permissions
-```
-
-Now you're in the worktree session, on the feature branch. Steps 3–9 all run here.
-
-### 3. `/start-session` (worktree, on feature branch) — paired with /end-session
-
-```bash
-/start-session
-```
-
-What it does (v1.8.0.1+ inside a worktree):
-- Refreshes NEXT.md to `origin/<integration>` tip (parallel-session-safe view).
-- Surfaces NEXT.md, pending-strategy-sync marker, recent session log.
-- Pulls up the issue spec from Linear (you /branch'd with --linear, so we know which one).
-- Notes the start time for duration tracking.
-
-This is the *real* session opener. It pairs with /end-session at step 9 — same scope (this feature branch), same NEXT.md base.
-
-### 4. Launch the auto-chain
-
-```bash
-/launch RS-XX --auto
-```
-
-`--auto` is **Standard tier only**. Quick tier delegates to `/linear-todo-runner`. Heavy tier rejects (security review + `/strategy-sync` need human pacing).
-
-The orchestration spawns each stage as a fresh Task subagent, preserving fresh-chat discipline:
+## Flowchart
 
 ```
-vbw:vbw-lead → plan-reviewer → vbw:vbw-dev → vbw:vbw-qa
-```
-
-Pauses only at the two real decision points (steps 5 and 7 below).
-
-### 5. Decision: plan-review verdict
-
-`--auto` stops with the plan-reviewer's structured verdict. One of three:
-
-| Verdict | Default action (v1.8.0.3+) | Notes |
-|---|---|---|
-| **Pass** | `proceed` → Dev runs next | The clean path |
-| **Revise** | **`apply-fixes-and-re-review`** → Lead applies the blocking items, plan-reviewer re-runs as round 2 | Round-2 Pass → Dev. Round-2 Revise → loop to round 3 with stalemate detection. Round-2 Block → abort. Default is **NOT** "proceed" — that was a v1.6.0–v1.8.0.2 bug. |
-| **Block** | `abort` → edit spec or escalate | Don't push through |
-
-**Stalemate detection (round 3+):** if round 3's Revise verdict overlaps with round 2's blocking items, `--auto` pauses and surfaces: "Plan-reviewer is flagging the same items in round 3 that it flagged in round 2. The spec may need hand-editing rather than auto-revision." Default at this prompt is **pause**. The orchestrator does NOT auto-loop a 4th round.
-
-**Override option:** if you genuinely want to skip the round-2 re-review (rare; almost always wrong), `proceed-without-re-review` is available. The override is logged to the pipeline state file (`override: "skip-plan-review-round-2"`) for audit.
-
-### 6. Watch (don't intervene during) execution
-
-vbw:vbw-dev runs the plan with atomic commits. Don't review-as-you-go — let it finish. If you see permission denials surface (`EditPermissionDenied` / `HookFeedbackBlocked`), the agent should stop and surface; if it doesn't, kill the run and check the v1.4 permission-denial protocol.
-
-### 7. Decision: QA verdict
-
-vbw:vbw-qa returns Pass / Fail / Partial.
-
-| Verdict | What to do |
-|---|---|
-| **Pass** | Approve → continues to UAT (step 8) |
-| **Partial** | Read the verdict carefully. Often the right answer is **plan-amendment** (declare the deviation in SUMMARY.md) rather than re-running QA. Hand-driven amendment is one round; full re-execute is multiple agents. |
-| **Fail** | Pause hard. `/vbw:vibe --verify` for inline UAT loop, or escalate. **Do not re-run --auto on Fail** — the gate has spoken. |
-
-### 8. UAT
-
-Either:
-- `/vbw:vibe --verify` for the inline VBW UAT loop, or
-- Smoke locally + smoke against preview deploy
-
-Both are valid. Use `/vbw:vibe --verify` when you want the agent-mediated checklist; smoke directly when you trust the AC.
-
-### 9. Close the session — `/end-session` (paired with step 3's /start-session)
-
-```bash
-/end-session
-```
-
-What it does (v1.8.0+):
-- Refuses to run if you're on `dev` or `main` (guard against accidental direct-to-integration writes).
-- **Refreshes NEXT.md to `origin/<integration>` tip** — picks up any parallel-session updates so the recompute starts from a current base.
-- Reads the deferred NEXT.md queue from `~/.cache/pipekit/<repo>/pending-next-md.json` and applies/discards as appropriate.
-- Writes session log to `Logs/Sessions/YYYY-MM-DD_HHMM.md`.
-- Recomputes NEXT.md (next Approved issue / `/strategy-sync` / `/phase-plan`) on top of the refreshed base.
-- Commits log + NEXT.md to the **current feature branch**.
-
-The commit lands on the feature branch *before* the PR opens. Step 10 (`/launch --close`) then bundles everything into the single PR. **No cherry-pick; one PR per issue.**
-
-### 10. Open the PR — `/launch --close`
-
-```bash
-/launch RS-XX --close
-```
-
-Opens feature → dev PR with code + session log + NEXT.md update. Linear → UAT. The PR has everything in one place.
-
-### 11. Rebase-merge the PR (GitHub UI or `gh pr merge --rebase`)
-
-Atomic commits flow onto dev linearly. Auto-delete handles the remote branch.
-
-### 12. Smoke against dev preview (optional)
-
-```bash
-/g-test-vercel RS-XX           # project-side skill — pushes branch + smoke-tests preview URL
-```
-
-(Mostly relevant if you didn't run it during step 8. Otherwise skip.)
-
-### 13. Worktree cleanup
-
-This step has two parts because `git worktree remove` can't delete the directory you're sitting in.
-
-**Part A — exit the worktree session:**
-
-```bash
-exit       # leaves claude, drops to your shell at .worktrees/RS-XX-…
-```
-
-**Part B — go to the parent repo and finish:**
-
-```bash
-cd ~/Projects/<repo>           # parent repo, NOT the worktree
-claude                         # start (or attach to) your parent claude session
-```
-
-Then in the parent claude:
-
-```bash
-/branch finish RS-XX-edit-delete    # explicit slug = unambiguous
-```
-
-Or without the arg:
-
-```bash
-/branch finish                       # auto-detects merged worktrees; confirms with you
-```
-
-Auto-detect logic: `/branch finish` lists worktrees whose branch is merged on `origin`. If exactly one matches, it confirms. If multiple match, it asks you to pick.
-
-What it does:
-- Removes the worktree directory under `.worktrees/`.
-- Deletes the local branch (`-D` if needed — squash-merge breaks `-d`'s "fully merged" check, that's normal).
-- Remote branch is already gone (auto-delete-on-merge handled it when the PR was squash-merged).
-
-**Or** if you use claude-squad: TUI → select the session → `d`. Same outcome.
-
----
-
-## Promote dev → main
-
-Separate flow. Run when you have one or more shipped issues on dev ready for production.
-
-```bash
-cd ~/Projects/<repo>
-git checkout dev && git pull --ff-only
-
-# Pre-deploy gate (whatever the project's gate is)
-pnpm check-types && pnpm lint && pnpm test && <project gates>
-
-# Open the promote PR
-gh pr create --base main --head dev \
-  --title "Promote dev → main (YYYY-MM-DD) — RS-XX[, RS-YY]" \
-  --body "<commits + verification>"
-```
-
-Squash-merge the PR. Then:
-
-```bash
-/g-promote-main --post-merge
-```
-
-Runs:
-- `supabase db push` (or project DB sync)
-- Vercel/prod smoke
-- Linear transitions: shipped issues → Done
-
----
-
-## Recovery procedures
-
-### Phantom conflicts on dev → main PR
-
-Symptom: PR shows conflicts in files that should be identical, or files like `src/lib/...` show "add/add" against an old merge-base.
-
-Cause: pre-squash-flip merge-commit topology. Fixed permanently going forward, but legacy merge commits leave divergent ancestry.
-
-Fix:
-
-```bash
-git checkout main && git pull --ff-only
-git checkout -b promote-YYYY-MM-DD
-git merge origin/dev -X theirs --no-ff -m "Promote dev → main (YYYY-MM-DD)"
-# -X theirs takes dev's content (which is the truth — it has RS-XX merged in)
-pnpm <gate>          # confirm green
-git push -u origin promote-YYYY-MM-DD
-gh pr create --base main --head promote-YYYY-MM-DD --title "..."
-```
-
-Squash-merge that PR. The squash collapses to one commit on main; main and dev align cleanly going forward.
-
-### Stale git index lock
-
-`fatal: Unable to create '.git/index.lock': File exists.`
-
-```bash
-ps aux | grep -E '[g]it' | grep -v claude   # confirm no real git process
-rm <repo>/.git/index.lock                    # safe when nothing's running
-```
-
-### Plan-reviewer Block on round 2 (stalemate)
-
-Stop spinning. Edit the spec by hand, then `/launch RS-XX --auto` from scratch. Plan-reviewer can't reconcile a fundamentally broken spec — adding more rounds wastes agent budget.
-
-### State-file or NEXT.md write hook-blocked
-
-If you see `state-file writes are best-effort during scod stages — skipping silently`: you're on Pipekit < v1.7.0. Run `./scripts/sync-method.sh v1.7.0` and retry. v1.7.0 moved state out of repo so the hook can't block it.
-
----
-
-## Decision tree at a glance
-
-```
-parent (on dev):
-   pick issue (cat NEXT.md or /linear-status)
-   │
-   /branch --linear RS-XX        ← creates worktree + Linear In Progress
-   │
-   cd .worktrees/<slug> && claude --dangerously-skip-permissions
-   │
-worktree (on feature branch):
-   /start-session                 ← v1.8.0.1+: paired with /end-session
-   │   (refreshes NEXT.md from origin/dev tip; orients on issue)
-   │
-   /launch RS-XX --auto           ← Standard tier
-      │
-      ├─ Plan-review verdict?
-      │    Pass → continue
-      │    Revise → feedback loop, re-review
-      │    Block → abort, edit spec, restart
-      │
-      ├─ (Dev runs autonomously)
-      │
-      ├─ QA verdict?
-      │    Pass → continue to UAT
-      │    Partial → plan-amendment usually
-      │    Fail → stop, diagnose, no auto-rerun
-      │
-      ├─ UAT (/vbw:vibe --verify or local smoke)
-      │
-      ├─ /end-session             ← v1.8.0+: BEFORE --close
-      │    (refuses on dev/main; refreshes NEXT.md;
-      │     commits log + NEXT.md to feature branch)
-      │
-      ├─ /launch RS-XX --close    ← opens single PR with everything
-      │
-      ├─ Rebase-merge PR (atomic commits flow onto dev)
-      │
-      └─ exit (back to parent)
-
-parent:
-   /branch finish                 ← removes worktree + local branch
-
-…then later, batch-promote dev → main:
-   /g-promote-main → squash → /g-promote-main --post-merge
+┌─────────────────────────────────────────────────────────────────┐
+│  PARENT REPO       cwd: ~/Projects/<repo>     branch: dev       │
+└─────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [1] Pick issue                                           │
+  │     cat NEXT.md                                          │
+  │     /linear-status         (optional)                    │
+  │     /spec-preflight RS-XX  (optional, if spec is older)  │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [2] Branch + worktree                                    │
+  │     /branch --linear RS-XX                               │
+  │     • creates feature/RS-XX-<slug>                       │
+  │     • worktree at .worktrees/RS-XX-<slug>                │
+  │     • symlinks .env, node_modules                        │
+  │     • Linear:  Approved → In Progress                    │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+       cd .worktrees/RS-XX-<slug>
+       claude --dangerously-skip-permissions
+       │
+┌──────┴──────────────────────────────────────────────────────────┐
+│  WORKTREE       cwd: .worktrees/RS-XX-<slug>     branch: feature │
+└─────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [3] /start-session                                       │
+  │     • refresh NEXT.md from origin/dev                    │
+  │     • surface issue spec from Linear                     │
+  │     • note start time                                    │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [4] Launch                                               │
+  │                                                          │
+  │  ┌─── VBW path ──────────┐    ┌─── Native path ────────┐ │
+  │  │ /launch RS-XX --auto  │    │ launch-native RS-XX    │ │
+  │  │                       │    │                        │ │
+  │  │  vbw:lead             │    │  Task: planner         │ │
+  │  │   → plan              │    │   → plan               │ │
+  │  │                       │    │                        │ │
+  │  │  plan-reviewer        │    │  human verdict         │ │
+  │  │   ◇ Pass? Revise?     │    │   (one screen)         │ │
+  │  │     Block?            │    │                        │ │
+  │  │   Pass  → continue    │    │  Task: dev             │ │
+  │  │   Revise→ apply+rerun │    │   → atomic commits     │ │
+  │  │   Block → abort,      │    │                        │ │
+  │  │           edit spec   │    │  tests + smoke         │ │
+  │  │                       │    │                        │ │
+  │  │  vbw:dev              │    └────────────────────────┘ │
+  │  │   → atomic commits    │                               │
+  │  │                       │                               │
+  │  │  vbw:qa               │                               │
+  │  │   ◇ Pass? Partial?    │                               │
+  │  │     Fail?             │                               │
+  │  │   Pass    → continue  │                               │
+  │  │   Partial → amend     │                               │
+  │  │   Fail    → stop      │                               │
+  │  │                       │                               │
+  │  │  /vbw:vibe --verify   │                               │
+  │  │   (or local smoke)    │                               │
+  │  └───────────────────────┘                               │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [5] /end-session                                         │
+  │     • refuses on dev/main                                │
+  │     • refresh NEXT.md from origin/dev                    │
+  │     • write Logs/Sessions/<timestamp>.md                 │
+  │     • commit log + NEXT.md to feature branch             │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [6] /launch RS-XX --close                                │
+  │     • open feature → dev PR                              │
+  │       (code + log + NEXT.md in one PR)                   │
+  │     • Linear:  Building → UAT                            │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [7] Merge PR  (feature → dev)                            │
+  │     gh pr merge --merge     (or GitHub UI: "Create       │
+  │                              merge commit")              │
+  │     • merge-commit preserves per-feature history on dev  │
+  │     • absorbed cleanly when dev → main squashes          │
+  │     • auto-delete remote branch                          │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+       exit              (drops to shell at .worktrees/...)
+       cd ~/Projects/<repo>
+       claude            (parent session)
+       │
+┌──────┴──────────────────────────────────────────────────────────┐
+│  PARENT REPO       cwd: ~/Projects/<repo>     branch: dev       │
+└─────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [8] /branch finish RS-XX-<slug>                          │
+  │     • remove worktree                                    │
+  │     • delete local branch                                │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+       ◇ accumulated 1–3 dev merges?
+              │
+       No  ───┼───→  loop to [1]
+              │
+       Yes ───┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [9] PROMOTE dev → main   (separate, batched flow)        │
+  │     git checkout dev && git pull --ff-only               │
+  │     pnpm check-types && pnpm lint && pnpm test           │
+  │     gh pr create --base main --head dev                  │
+  │     squash-merge          (Ruleset enforces)             │
+  │     /g-promote-main --post-merge                         │
+  │       • supabase db push                                 │
+  │       • prod smoke                                       │
+  │       • Linear:  UAT → Done                              │
+  └──────────────────────────────────────────────────────────┘
 ```
 
 ---
 
-## What's NOT in this runbook (separate flows)
+## Step ↔ skill cheat sheet
 
-- `/concept`, `/define`, `/strategy-create` — Stage 0 (project bootstrap), see `STARTUP.md`.
-- `/roadmap-create`, `/phase-plan` — milestone- and phase-level planning.
-- `/light-spec`, `/light-spec-revise`, `/spec-preflight` — spec authoring (precedes /launch).
-- `/strategy-sync`, `/release-changelog` — post-ship doc maintenance.
-- `/linear-todo-runner` — Quick-tier batch flow (own runbook needed eventually).
-
-For those, refer to `method.md` and the relevant skill files.
+| # | Step | Skill / command | Where you run it |
+|---|---|---|---|
+| 1 | Pick issue | `cat NEXT.md` / `/linear-status` | parent, on dev |
+| 2 | Branch | `/branch --linear RS-XX` | parent, on dev |
+| 3 | Start session | `/start-session` | worktree, feature |
+| 4 | Launch (VBW) | `/launch RS-XX --auto` | worktree, feature |
+| 4 | Launch (native) | `launch-native RS-XX` | worktree, feature |
+| 5 | End session | `/end-session` | worktree, feature |
+| 6 | Open PR | `/launch RS-XX --close` | worktree, feature |
+| 7 | Merge (feature → dev) | `gh pr merge --merge` | anywhere |
+| 8 | Cleanup | `/branch finish RS-XX-<slug>` | parent, on dev |
+| 9 | Promote | `/g-promote-main --post-merge` | parent, on dev |
 
 ---
 
-## When this runbook drifts
+## Recovery (one rule)
 
-Skill behavior changes occasionally. If a step here disagrees with a skill's actual prose, **the skill is the truth**. Open a PR against this runbook to bring it back in line.
+**Rerun the skill.** Most current skills are idempotent. If a rerun doesn't fix it:
+
+- **Plan-reviewer Block round-2:** edit spec by hand, restart `/launch --auto`.
+- **QA Fail:** stop. `/vbw:vibe --verify` or escalate. Don't re-run `--auto`.
+- **NEXT.md write blocked:** sync to v1.7.0+ (out-of-repo state).
+- **Stale git index lock:** verify no real git process, then `rm <repo>/.git/index.lock`.
+- **Phantom dev → main conflicts:** legacy pre-squash topology. Use `git merge -X theirs` workaround (see deprecated RUNBOOK.md § Recovery if needed).
+
+For everything else: see `RUNBOOK.md` § Recovery (legacy reference).
+
+---
+
+## Test-mode annotations (2026-05-01)
+
+- RS-58 → step 4 VBW path (already running, don't disrupt).
+- RS-30 → step 4 native path (small, isolated, fast signal).
+- Compare on: plan quality, dev execution, QA catches, wall time, token cost.
+- Verdict feeds the v2.0.0 redesign (`/work` backend choice).

--- a/RUNBOOK_legacy.md
+++ b/RUNBOOK_legacy.md
@@ -1,0 +1,417 @@
+# Pipekit Per-Issue Runbook
+
+The definitive step-by-step for shipping one Linear issue through the pipeline. Read once; refer back when you forget the exact order.
+
+**Canonical pipeline:** `method.md` § Stages 1-5. **This doc:** the practical, tool-by-tool walkthrough.
+
+---
+
+## Quick Index — follow in order
+
+**Per-issue loop:**
+
+0. [Pick the issue (parent, lightweight)](#0-pick-the-issue-parent-lightweight) — NEXT.md / `/linear-status` / `/spec-preflight`
+1. [Branch + worktree](#1-branch--worktree) — `/branch --linear RS-XX`
+2. [Enter the worktree](#2-enter-the-worktree) — `cd … && claude --dangerously-skip-permissions`
+3. [`/start-session` (worktree)](#3-start-session-worktree-on-feature-branch--paired-with-end-session) — orient on the issue
+4. [Launch the auto-chain](#4-launch-the-auto-chain) — `/launch RS-XX --auto`
+5. [Decision: plan-review verdict](#5-decision-plan-review-verdict) — Pass / Revise / Block
+6. [Watch (don't intervene during) execution](#6-watch-dont-intervene-during-execution)
+7. [Decision: QA verdict](#7-decision-qa-verdict) — Pass / Partial / Fail
+8. [UAT](#8-uat) — `/vbw:vibe --verify` or local smoke
+9. [Close the session — `/end-session`](#9-close-the-session--end-session-paired-with-step-3s-start-session)
+10. [Open the PR — `/launch --close`](#10-open-the-pr--launch---close)
+11. [Rebase-merge the PR](#11-rebase-merge-the-pr-github-ui-or-gh-pr-merge---rebase)
+12. [Smoke against dev preview (optional)](#12-smoke-against-dev-preview-optional) — `/g-test-vercel`
+13. [Worktree cleanup](#13-worktree-cleanup) 
+     `exit` worktree  →   `cd ~/Projects/<repo>`  → `/branch finish RS-XX-slug`
+
+**Then periodically (separate flow):**
+
+- P1–P4. [Promote dev → main](#promote-dev--main) — `/g-promote-main` → squash → `/g-promote-main --post-merge` → `/strategy-sync`
+
+**If something goes wrong:**
+
+- [Phantom conflicts on dev → main PR](#phantom-conflicts-on-dev--main-pr)
+- [Stale git index lock](#stale-git-index-lock)
+- [Plan-reviewer Block on round 2 (stalemate)](#plan-reviewer-block-on-round-2-stalemate)
+- [State-file or NEXT.md write hook-blocked](#state-file-or-nextmd-write-hook-blocked)
+
+**Reference:**
+
+- [One-time setup (per repo)](#one-time-setup-per-repo) — squash/rebase/auto-delete config + `pipekit-configure-repo.sh`
+- [Decision tree at a glance](#decision-tree-at-a-glance)
+- [What's NOT in this runbook](#whats-not-in-this-runbook-separate-flows)
+
+---
+
+## One-time setup (per repo)
+
+Confirm these once per consuming project. They make the loop friction-free.
+
+| Setting | Where | Why |
+|---|---|---|
+| Branch protection on `dev` and `main` | GitHub repo Settings → Branches | Forces all changes through PRs |
+| **All merge methods enabled at repo level** (rebase + squash + merge-commit) | Settings → General → Pull Requests | Gives flexibility on feature → dev |
+| **`pipekit-main-squash-only` ruleset** | Settings → Rules → Rulesets | Enforces squash-only on `main` (machine-enforced; can't accidentally merge-commit to main) |
+| **Auto-delete head branches on merge** | Settings → General → Pull Requests | Remote cleanup is automatic; claude-squad handles local |
+| Pipekit synced to **v1.8.0.6+** | `./scripts/sync-method.sh v1.8.0.6` | Per-branch ruleset enforcement |
+
+**Effective merge policy by hop (v1.8.0.6+):**
+- **feature → dev**: rebase OR merge-commit — your choice in the GitHub UI. Both are safe (merge-commits on dev get absorbed when dev → main squashes).
+- **dev → main**: squash-only (ruleset enforces; UI dropdown will only show "Squash and merge"). Single commit per release. No phantom-conflict trap.
+
+**One-shot configure** (idempotent):
+
+```bash
+bash scripts/pipekit-configure-repo.sh <org>/<repo>
+```
+
+This sets repo-level merge flags AND creates/updates the main-squash-only ruleset. Safe to re-run.
+
+Verify:
+
+```bash
+gh repo view <org>/<repo> --json deleteBranchOnMerge,squashMergeAllowed,rebaseMergeAllowed,mergeCommitAllowed \
+  --jq '{deleteBranches:.deleteBranchOnMerge, squash:.squashMergeAllowed, rebase:.rebaseMergeAllowed, merge:.mergeCommitAllowed}'
+# Expect: all four true (per-branch enforcement is in the ruleset, not repo flags)
+
+gh api repos/<org>/<repo>/rulesets --jq '.[] | select(.name=="pipekit-main-squash-only") | {name, enforcement}'
+# Expect: {name: "pipekit-main-squash-only", enforcement: "active"}
+
+grep -m1 'v1\.' method/method.md   # expect v1.8.0.6 or later
+```
+
+---
+
+## The loop
+
+Same shape every time. ~12 steps from "I want to ship X" to "X is in production."
+
+**Pairing model (v1.8.0.1+):** /start-session and /end-session both run **inside the worktree, on the feature branch**. /start-session orients you on the issue; /end-session writes the log when the issue is done. Both refresh NEXT.md from `origin/<integration>` so you see current state regardless of how long the worktree has lived.
+
+### 0. Pick the issue (parent, lightweight)
+
+In the project root (parent on `dev`), pick the issue *without* opening a full session:
+
+```bash
+cat NEXT.md                         # what was queued at end of last session
+/linear-status                       # quick triage
+/phase-plan --status                 # phase-aware view (optional)
+```
+
+Confirm the issue is **Approved** (or higher — Specced isn't ready). For an Approved issue, optionally:
+
+```bash
+/spec-preflight RS-XX                # empirical pre-flight on the spec
+```
+
+Verifies file paths, line refs, dependencies still real. Read-only. **Skip if you trust the spec was reviewed recently.**
+
+(If you genuinely want a full /start-session at the project level — e.g. start of a workday, no specific issue yet in mind — run it now. Otherwise skip; step 4 below opens the real session inside the worktree.)
+
+### 1. Branch + worktree
+
+**Use `/branch`, not raw `git worktree`.** It handles Linear status transition, env symlinks, and worktree naming convention.
+
+```bash
+/branch --linear RS-XX
+```
+
+What happens (v1.8.0+):
+- Pre-checks Linear status (warns if already shipped/canceled).
+- Creates `feature/<PREFIX>-<NN>-<2-3-word-slug>` off `dev` — short, deterministic. E.g. `feature/RS-21-edit-delete`, not the verbose Linear gitBranchName.
+- Spawns worktree at `.worktrees/<branch-name>`.
+- Symlinks `.env` and `node_modules` into the worktree.
+- Transitions Linear: Approved → In Progress.
+- Prints: `cd .worktrees/<branch-name> && claude --dangerously-skip-permissions` to enter.
+
+If you'd rather use a TUI for worktree management, claude-squad (`brew install claude-squad`) wraps the same primitives across multiple agents. CWT (archived 2026-04-29) — don't ingest.
+
+### 2. Enter the worktree
+
+Run the command /branch printed:
+
+```bash
+cd .worktrees/RS-XX-edit-delete && claude --dangerously-skip-permissions
+```
+
+Now you're in the worktree session, on the feature branch. Steps 3–9 all run here.
+
+### 3. `/start-session` (worktree, on feature branch) — paired with /end-session
+
+```bash
+/start-session
+```
+
+What it does (v1.8.0.1+ inside a worktree):
+- Refreshes NEXT.md to `origin/<integration>` tip (parallel-session-safe view).
+- Surfaces NEXT.md, pending-strategy-sync marker, recent session log.
+- Pulls up the issue spec from Linear (you /branch'd with --linear, so we know which one).
+- Notes the start time for duration tracking.
+
+This is the *real* session opener. It pairs with /end-session at step 9 — same scope (this feature branch), same NEXT.md base.
+
+### 4. Launch the auto-chain
+
+```bash
+/launch RS-XX --auto
+```
+
+`--auto` is **Standard tier only**. Quick tier delegates to `/linear-todo-runner`. Heavy tier rejects (security review + `/strategy-sync` need human pacing).
+
+The orchestration spawns each stage as a fresh Task subagent, preserving fresh-chat discipline:
+
+```
+vbw:vbw-lead → plan-reviewer → vbw:vbw-dev → vbw:vbw-qa
+```
+
+Pauses only at the two real decision points (steps 5 and 7 below).
+
+### 5. Decision: plan-review verdict
+
+`--auto` stops with the plan-reviewer's structured verdict. One of three:
+
+| Verdict | Default action (v1.8.0.3+) | Notes |
+|---|---|---|
+| **Pass** | `proceed` → Dev runs next | The clean path |
+| **Revise** | **`apply-fixes-and-re-review`** → Lead applies the blocking items, plan-reviewer re-runs as round 2 | Round-2 Pass → Dev. Round-2 Revise → loop to round 3 with stalemate detection. Round-2 Block → abort. Default is **NOT** "proceed" — that was a v1.6.0–v1.8.0.2 bug. |
+| **Block** | `abort` → edit spec or escalate | Don't push through |
+
+**Stalemate detection (round 3+):** if round 3's Revise verdict overlaps with round 2's blocking items, `--auto` pauses and surfaces: "Plan-reviewer is flagging the same items in round 3 that it flagged in round 2. The spec may need hand-editing rather than auto-revision." Default at this prompt is **pause**. The orchestrator does NOT auto-loop a 4th round.
+
+**Override option:** if you genuinely want to skip the round-2 re-review (rare; almost always wrong), `proceed-without-re-review` is available. The override is logged to the pipeline state file (`override: "skip-plan-review-round-2"`) for audit.
+
+### 6. Watch (don't intervene during) execution
+
+vbw:vbw-dev runs the plan with atomic commits. Don't review-as-you-go — let it finish. If you see permission denials surface (`EditPermissionDenied` / `HookFeedbackBlocked`), the agent should stop and surface; if it doesn't, kill the run and check the v1.4 permission-denial protocol.
+
+### 7. Decision: QA verdict
+
+vbw:vbw-qa returns Pass / Fail / Partial.
+
+| Verdict | What to do |
+|---|---|
+| **Pass** | Approve → continues to UAT (step 8) |
+| **Partial** | Read the verdict carefully. Often the right answer is **plan-amendment** (declare the deviation in SUMMARY.md) rather than re-running QA. Hand-driven amendment is one round; full re-execute is multiple agents. |
+| **Fail** | Pause hard. `/vbw:vibe --verify` for inline UAT loop, or escalate. **Do not re-run --auto on Fail** — the gate has spoken. |
+
+### 8. UAT
+
+Either:
+- `/vbw:vibe --verify` for the inline VBW UAT loop, or
+- Smoke locally + smoke against preview deploy
+
+Both are valid. Use `/vbw:vibe --verify` when you want the agent-mediated checklist; smoke directly when you trust the AC.
+
+### 9. Close the session — `/end-session` (paired with step 3's /start-session)
+
+```bash
+/end-session
+```
+
+What it does (v1.8.0+):
+- Refuses to run if you're on `dev` or `main` (guard against accidental direct-to-integration writes).
+- **Refreshes NEXT.md to `origin/<integration>` tip** — picks up any parallel-session updates so the recompute starts from a current base.
+- Reads the deferred NEXT.md queue from `~/.cache/pipekit/<repo>/pending-next-md.json` and applies/discards as appropriate.
+- Writes session log to `Logs/Sessions/YYYY-MM-DD_HHMM.md`.
+- Recomputes NEXT.md (next Approved issue / `/strategy-sync` / `/phase-plan`) on top of the refreshed base.
+- Commits log + NEXT.md to the **current feature branch**.
+
+The commit lands on the feature branch *before* the PR opens. Step 10 (`/launch --close`) then bundles everything into the single PR. **No cherry-pick; one PR per issue.**
+
+### 10. Open the PR — `/launch --close`
+
+```bash
+/launch RS-XX --close
+```
+
+Opens feature → dev PR with code + session log + NEXT.md update. Linear → UAT. The PR has everything in one place.
+
+### 11. Rebase-merge the PR (GitHub UI or `gh pr merge --rebase`)
+
+Atomic commits flow onto dev linearly. Auto-delete handles the remote branch.
+
+### 12. Smoke against dev preview (optional)
+
+```bash
+/g-test-vercel RS-XX           # project-side skill — pushes branch + smoke-tests preview URL
+```
+
+(Mostly relevant if you didn't run it during step 8. Otherwise skip.)
+
+### 13. Worktree cleanup
+
+This step has two parts because `git worktree remove` can't delete the directory you're sitting in.
+
+**Part A — exit the worktree session:**
+
+```bash
+exit       # leaves claude, drops to your shell at .worktrees/RS-XX-…
+```
+
+**Part B — go to the parent repo and finish:**
+
+```bash
+cd ~/Projects/<repo>           # parent repo, NOT the worktree
+claude                         # start (or attach to) your parent claude session
+```
+
+Then in the parent claude:
+
+```bash
+/branch finish RS-XX-edit-delete    # explicit slug = unambiguous
+```
+
+Or without the arg:
+
+```bash
+/branch finish                       # auto-detects merged worktrees; confirms with you
+```
+
+Auto-detect logic: `/branch finish` lists worktrees whose branch is merged on `origin`. If exactly one matches, it confirms. If multiple match, it asks you to pick.
+
+What it does:
+- Removes the worktree directory under `.worktrees/`.
+- Deletes the local branch (`-D` if needed — squash-merge breaks `-d`'s "fully merged" check, that's normal).
+- Remote branch is already gone (auto-delete-on-merge handled it when the PR was squash-merged).
+
+**Or** if you use claude-squad: TUI → select the session → `d`. Same outcome.
+
+---
+
+## Promote dev → main
+
+Separate flow. Run when you have one or more shipped issues on dev ready for production.
+
+```bash
+cd ~/Projects/<repo>
+git checkout dev && git pull --ff-only
+
+# Pre-deploy gate (whatever the project's gate is)
+pnpm check-types && pnpm lint && pnpm test && <project gates>
+
+# Open the promote PR
+gh pr create --base main --head dev \
+  --title "Promote dev → main (YYYY-MM-DD) — RS-XX[, RS-YY]" \
+  --body "<commits + verification>"
+```
+
+Squash-merge the PR. Then:
+
+```bash
+/g-promote-main --post-merge
+```
+
+Runs:
+- `supabase db push` (or project DB sync)
+- Vercel/prod smoke
+- Linear transitions: shipped issues → Done
+
+---
+
+## Recovery procedures
+
+### Phantom conflicts on dev → main PR
+
+Symptom: PR shows conflicts in files that should be identical, or files like `src/lib/...` show "add/add" against an old merge-base.
+
+Cause: pre-squash-flip merge-commit topology. Fixed permanently going forward, but legacy merge commits leave divergent ancestry.
+
+Fix:
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b promote-YYYY-MM-DD
+git merge origin/dev -X theirs --no-ff -m "Promote dev → main (YYYY-MM-DD)"
+# -X theirs takes dev's content (which is the truth — it has RS-XX merged in)
+pnpm <gate>          # confirm green
+git push -u origin promote-YYYY-MM-DD
+gh pr create --base main --head promote-YYYY-MM-DD --title "..."
+```
+
+Squash-merge that PR. The squash collapses to one commit on main; main and dev align cleanly going forward.
+
+### Stale git index lock
+
+`fatal: Unable to create '.git/index.lock': File exists.`
+
+```bash
+ps aux | grep -E '[g]it' | grep -v claude   # confirm no real git process
+rm <repo>/.git/index.lock                    # safe when nothing's running
+```
+
+### Plan-reviewer Block on round 2 (stalemate)
+
+Stop spinning. Edit the spec by hand, then `/launch RS-XX --auto` from scratch. Plan-reviewer can't reconcile a fundamentally broken spec — adding more rounds wastes agent budget.
+
+### State-file or NEXT.md write hook-blocked
+
+If you see `state-file writes are best-effort during scod stages — skipping silently`: you're on Pipekit < v1.7.0. Run `./scripts/sync-method.sh v1.7.0` and retry. v1.7.0 moved state out of repo so the hook can't block it.
+
+---
+
+## Decision tree at a glance
+
+```
+parent (on dev):
+   pick issue (cat NEXT.md or /linear-status)
+   │
+   /branch --linear RS-XX        ← creates worktree + Linear In Progress
+   │
+   cd .worktrees/<slug> && claude --dangerously-skip-permissions
+   │
+worktree (on feature branch):
+   /start-session                 ← v1.8.0.1+: paired with /end-session
+   │   (refreshes NEXT.md from origin/dev tip; orients on issue)
+   │
+   /launch RS-XX --auto           ← Standard tier
+      │
+      ├─ Plan-review verdict?
+      │    Pass → continue
+      │    Revise → feedback loop, re-review
+      │    Block → abort, edit spec, restart
+      │
+      ├─ (Dev runs autonomously)
+      │
+      ├─ QA verdict?
+      │    Pass → continue to UAT
+      │    Partial → plan-amendment usually
+      │    Fail → stop, diagnose, no auto-rerun
+      │
+      ├─ UAT (/vbw:vibe --verify or local smoke)
+      │
+      ├─ /end-session             ← v1.8.0+: BEFORE --close
+      │    (refuses on dev/main; refreshes NEXT.md;
+      │     commits log + NEXT.md to feature branch)
+      │
+      ├─ /launch RS-XX --close    ← opens single PR with everything
+      │
+      ├─ Rebase-merge PR (atomic commits flow onto dev)
+      │
+      └─ exit (back to parent)
+
+parent:
+   /branch finish                 ← removes worktree + local branch
+
+…then later, batch-promote dev → main:
+   /g-promote-main → squash → /g-promote-main --post-merge
+```
+
+---
+
+## What's NOT in this runbook (separate flows)
+
+- `/concept`, `/define`, `/strategy-create` — Stage 0 (project bootstrap), see `STARTUP.md`.
+- `/roadmap-create`, `/phase-plan` — milestone- and phase-level planning.
+- `/light-spec`, `/light-spec-revise`, `/spec-preflight` — spec authoring (precedes /launch).
+- `/strategy-sync`, `/release-changelog` — post-ship doc maintenance.
+- `/linear-todo-runner` — Quick-tier batch flow (own runbook needed eventually).
+
+For those, refer to `method.md` and the relevant skill files.
+
+---
+
+## When this runbook drifts
+
+Skill behavior changes occasionally. If a step here disagrees with a skill's actual prose, **the skill is the truth**. Open a PR against this runbook to bring it back in line.

--- a/skills/end-session/skill.md
+++ b/skills/end-session/skill.md
@@ -43,7 +43,7 @@ case "$CURRENT" in
     echo "  integration history. Run /end-session from inside the feature" >&2
     echo "  worktree, BEFORE /launch --close opens the PR." >&2
     echo "" >&2
-    echo "  See RUNBOOK.md § The loop, step 10." >&2
+    echo "  See RUNBOOK.md steps [5]–[6]." >&2
     exit 1
     ;;
 esac

--- a/skills/launch/skill.md
+++ b/skills/launch/skill.md
@@ -341,7 +341,7 @@ Do **not** auto-advance to `--close`. The user must explicitly invoke it. This i
 
 Invoked when the user returns with verify confirmed (either via `/vbw:vibe --verify` passed, or via project-precedent self-verification on non-VBW-native layouts).
 
-**v1.8.0+ ordering:** the canonical pattern is `/end-session` → `/launch --close`, both inside the worktree on the feature branch. /end-session writes the session log + NEXT.md to the feature branch first; /launch --close then opens the PR with code + log + NEXT.md bundled. One PR per issue. See `RUNBOOK.md` § The loop, steps 10–11.
+**v1.8.0+ ordering:** the canonical pattern is `/end-session` → `/launch --close`, both inside the worktree on the feature branch. /end-session writes the session log + NEXT.md to the feature branch first; /launch --close then opens the PR with code + log + NEXT.md bundled. One PR per issue. See `RUNBOOK.md` steps [5]–[7].
 
 If `/launch --close` is invoked **without** a preceding `/end-session`, proceed normally — the close path is independent. The session log will then need to land via the v1.7.0 cherry-pick workaround (or simply run `/end-session` later from a fresh chore branch off dev). Strongly prefer the new ordering.
 
@@ -515,7 +515,7 @@ After Steps 1–6 complete unchanged (gate validation, tier confirm, dependency 
 
    **Recommend `pause-for-end-session` for QA Pass.** The auto-chain stops here cleanly; the user runs `/end-session` (writes log + NEXT.md to the feature branch), then `/launch --close` (opens the single PR with everything bundled). One PR per issue, no cherry-pick.
 
-   `close-now` is preserved for users who want the old behavior — but warn them it triggers the cherry-pick workaround documented in RUNBOOK.md (cherry-pick the session log onto a chore branch off dev → second PR).
+   `close-now` is preserved for users who want the old behavior — but warn them it triggers the cherry-pick workaround documented in `RUNBOOK_legacy.md` (cherry-pick the session log onto a chore branch off dev → second PR).
 
    On `pause-for-end-session`, exit cleanly with NEXT.md pointing at `/end-session` (or, since /end-session is the next step regardless, just exit and let the user invoke it). Linear stays in Building. On `close-now`, continue to step 7 (legacy path). On `pause-here` (Fail/Partial), exit cleanly. On `re-execute-with-scope` (Fail/Partial), prompt for fix scope and re-spawn `vbw:vbw-dev` (loop back to step 4 with the new scope; do NOT re-run plan-review). On `abort`, exit.
 


### PR DESCRIPTION
The runbook had grown to scar tissue — recovery procedures, version notes, and explanatory prose accumulated over the v1.4 → v1.8.2 patch trail. New RUNBOOK.md is one page: ASCII flowchart of the loop top-to-bottom, side-by- side VBW / native paths at step 4, step↔skill cheat sheet, and a "rerun the skill" recovery rule. Old runbook preserved as RUNBOOK_legacy.md for the 2-week safety window during v2.0.0 redesign work.

Skill error messages updated to reference new step numbers; one cherry-pick workaround pointer redirected to RUNBOOK_legacy.md.