### PR TITLE
feat(skills): bake RS-64 lessons into /01-light-spec, /work, /pr-fix

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -303,6 +303,16 @@ Both work. Switch back at any time. v2 commands are non-colliding.
 - **Phase-aware `pk next`** — surfaces issues grouped by status within the current phase: In Progress, Approved, Needs Spec (with `/light-spec` hint per item), separated from "Other phases". Reads current phase from `PHASES.md`, scopes Linear queries by project ID from `linear-map.json`. Today's `pk next` only finds the first Approved issue anywhere — silent when current phase has none even though there's actionable work (`/light-spec` candidates). Surfaced 2026-05-02 during RS-63 execution: Phase 2.5 had RS-63 in flight + 6 Needs Spec issues but `pk next` was useless.
 - **Mid-loop Linear visibility for review + fix** — `pk ship --review` (or `/ship` when it lands) should post a Linear comment summarizing the antagonistic review (severity counts, recommendation, PR comment URL) when the review is posted. `/pr-fix` should post a Linear comment when triage completes (fixes applied, findings rejected with reason, deferrals). Today's gap: Linear sees `In Progress → UAT → Done` but no record of "review found 16 things, 1 was a false positive verified via MCP, 7 fixed, 8 deferred." That context lives only on the PR. Surfaced 2026-05-02 during RS-63 review/fix cycle.
 
+### Flowchart promotion (v2.0.1)
+
+When the visual-review and cross-spec-verify items below ship as actual code/skill changes, the flowchart in §"Per-issue flowchart" needs an update:
+
+- **Insert a new step between [4] Verify and [5] Ship**: visual-state verification — runs Playwright (or equivalent) against the worktree's running app at key user states, diffs against figma source. Optional gate (config: `Require visual review: true|false`). Catches the class of miss where components compile + tests pass but the integration didn't land (today's RS-64 example).
+- **Update [5b] Antagonistic PR review** to call out the cross-spec handoff check explicitly: reviewer must fetch predecessor specs (any "X will…" references) and verify each promise landed in this PR.
+- **Add a [5c] /pr-fix triage** step explicitly in the flowchart (currently implicit between 5b and merge).
+
+Today's flowchart shows steps 1–8 with 5b inserted but no visual review and no /pr-fix. After v2.0.1 ships, the chain becomes: 1 → 2 → 3 → 4 → **4b (visual)** → 5 → 5b → **5c (/pr-fix)** → 6 → 7 → 8.
+
 ### Surfaced 2026-05-02 PM (RS-64 cross-spec miss)
 
 A Phase 2.5 issue (RS-63) explicitly handed off integration work to its successor (RS-64) — *"RS-64 will replace the placeholder with real Drawer chrome + PropertyCard."* RS-64's PR shipped the components but never integrated them into `search-page.tsx`. Antagonistic review missed it (only had RS-64's AC to check). When the user later asked Claude in the worktree about the placeholder + provided a screenshot, Claude **rationalized the status quo** ("wiring harness for something to come later") rather than checking against intent. Three process gaps:

--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -69,6 +69,26 @@ Write the spec using the **Light Spec Template** below. Fill in every section.
 
 **Scope discipline:** Specs define WHAT, not HOW. Litmus test: if a statement can be rewritten as "change X line" or "use Y syntax," it is implementation detail — remove it. If a statement can be rewritten as "the system should [observable behavior]," it belongs in the spec. Do not include file paths to create, function signatures, or implementation patterns — VBW planning agents own the HOW.
 
+**Acceptance Criteria discipline (behavioral, not presence-only):** Every AC must verify *observable behavior*, not *element presence*. A spec that ships ACs like "component X exists" / "function Y is called" lets implementations pass tests without actually working — surfaced 2026-05-02 by RS-63/64 in rs-vault, where tests + 7-check gate + antagonistic review all passed but the running app was 60% broken (search bar non-functional, panel didn't animate, Notes save unwired, History tab placeholder, integration step skipped).
+
+Bad → Better examples:
+
+| ❌ Presence-only AC | ✅ Behavioral AC |
+|---|---|
+| "Component `<Search>` exists" | "Given /page renders, when user types 'SW3' in the search input, then results filter to addresses containing 'SW3' within 300ms" |
+| "Save button calls `onSave`" | "Given user clicks Save, when fetch resolves, then DB row contains the value AND UI shows 'saved' state AND reloading the page shows the persisted value" |
+| "Tabs render" | "Given drawer is open, when user clicks each of the 4 tabs, then each tab renders its real content (not 'coming soon' placeholder)" |
+| "Token `--color-x` exists in globals.css" | "Given page renders at 1440px viewport, when computed style of `.foo` is read, then `background-color` resolves to `var(--color-x)`" |
+| "Animation duration matches `--duration-base`" | "Given user clicks toggle, when panel transitions, then `getAnimations()` reports duration ≈ 180ms AND visual state changes from collapsed to expanded" |
+
+For UI surfaces, **at least one AC must be a visual or computed-style assertion** — not just unit-test presence. If the spec is design-driven, reference the figma source explicitly and require pixel-diff or computed-style verification.
+
+**Cross-spec handoff awareness:** If this spec references another issue with phrases like *"X will replace…"*, *"X consumes…"*, *"X provides…"*, that's a load-bearing handoff promise. Either:
+- Include the handoff *itself* as an AC in the predecessor's spec ("The integration in file Y is updated to use the new component, replacing the placeholder"), OR
+- Mark it explicitly in the successor's spec as a required integration step ("This issue must update file Y to consume…").
+
+Don't leave handoff promises buried in prose. Today's miss (RS-64) shipped because RS-63 said "RS-64 will replace the placeholder" but RS-64's AC didn't include the integration step. Both passed; the app was broken.
+
 ### Phase 3.5 — Planning Readiness Check
 
 Before presenting to the user, audit every section:
@@ -196,6 +216,10 @@ Thoughts that mean "slow down and widen scope." Paired with `.claude/rules/pipek
 | "The POC shows the answer already" | POC is reference, not spec. Translate observable behaviors into testable requirements; don't assume the planner reads POC code. |
 | "Authority is obvious from context" | It isn't. Specs without an explicit authoritative layer (DB, utils, API) are the #1 cause of spec revision. Name it. |
 | "I'll skip the review agent, the spec is clear" | Clear-seeming specs fail planning review most often — the clarity is in your head, not on the page. Run the review. |
+| "AC says `<Component> exists` and that's enough" | Presence ≠ behavior. The thing under test is what the user sees and does. Replace with behavioral AC: input → expected output, observable in the running app. |
+| "AC says `onSave callback fires`" | Mock-tests are not user-tests. Add an end-to-end AC: data persists, UI reflects, page reload shows it. |
+| "Integration into `<other-file>` is implied" | Implicit integration steps were the RS-64 miss. If the spec touches one component but requires updating another to use it, name the second update as an explicit AC. |
+| "Visual matches figma" (without measurable check) | Unmeasurable. Replace with: pixel-diff threshold (e.g. < 5% at 1440px), or computed-style assertions on key tokens, or both. |
 
 ---
 

--- a/skills/pr-fix/skill.md
+++ b/skills/pr-fix/skill.md
@@ -54,6 +54,22 @@ git diff dev...HEAD --stat
 git log dev..HEAD --oneline
 ```
 
+### 1.2.5 Cross-spec handoff scan
+
+If the PR's Linear issue (or referenced sibling issues) contains phrases like *"X will replace…"*, *"X consumes…"*, *"X provides…"*, that's a load-bearing handoff promise. **Predecessor specs may carry ACs that this PR is responsible for landing**, even if the PR's own spec doesn't list them.
+
+For each cross-spec reference found in the issue:
+
+1. Fetch the predecessor's spec via Linear MCP
+2. Extract any "this issue's successor will…" handoff promises
+3. **Verify each promise landed in the diff:**
+   - "Wires X into Y" → grep the diff for `Y` references that introduce `X`
+   - "Replaces placeholder Z" → grep the diff for `Z` removal AND replacement
+   - "Persists data via W" → confirm a Server Action / migration / RLS rule for W exists
+4. **Any unfulfilled handoff is a Critical finding** — same severity as a missing AC, regardless of whether the current PR's own AC list passes.
+
+This catches the class of miss surfaced 2026-05-02 by RS-64 in rs-vault: the PR shipped its own ACs cleanly but never delivered the integration step its predecessor (RS-63) had promised. Both passed; the app was broken.
+
 ### 1.3 Synthesize Intent
 
 Write a 2-3 sentence **intent statement**: what the PR is doing and why, derived from title, body, commit messages, and diff shape. This anchors the entire review.

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -274,6 +274,36 @@ Use Task tool with:
 
 Print the review verbatim.
 
+## Step 6.5 — Behavioral self-check before declaring complete
+
+Before printing the hand-off, verify the work *behaviorally* — not just that tests pass. Tests-pass + 7-check-gate-green is necessary but not sufficient: see RS-63/64 in rs-vault (2026-05-02), where every check passed but the running app was 60% broken.
+
+For UI changes — if the spec touched any user-visible surface:
+- **Run the app locally** (or check the existing dev server) and verify the changed surface renders correctly.
+- **Click the new affordances.** If the spec says "Save button persists notes," click Save and confirm the data round-trips. Don't trust callback-fire mocks.
+- **Diff against the design source** if one exists (`resources/<handoff>/...`). Note any deviations in the hand-off summary.
+
+For integration changes — if the spec promised "X will replace Y" or "this updates Z to consume W":
+- **Grep the integration site** to verify the swap landed. Example: if the spec says "wire `<NewComponent>` into `<page.tsx>`", grep for both `<NewComponent>` (should be present) and `<OldComponent>` (should be absent).
+- **Don't ship if the predecessor's promised handoff is still un-integrated.** That's the RS-64 miss in concrete form.
+
+If something fails this self-check, **surface it in the hand-off summary** — don't paper over. The user paces; they decide whether to ship-with-known-gap or revise.
+
+### Anti-rationalization guard
+
+If the user asks during execution about visible state — *"is this correct?"*, *"why does it look like this?"*, *"shouldn't there be X here?"* — and provides a screenshot or describes what they see:
+
+**Default behavior: skepticism + verification, not defense.**
+
+1. **Re-read the relevant section of the spec** (don't paraphrase from memory)
+2. **Grep the integration site** (don't infer from comments)
+3. **Compare what's shown to what the spec says**
+4. **Surface any gap honestly**, even if a comment in the code "explains" the current state as intentional (placeholder comments are load-bearing only when the predecessor's spec doesn't promise replacement)
+
+Do **not** generate plausible-sounding rationale that fits the visible artifact. RS-64's miss got worse because Claude pattern-matched on a placeholder comment header and explained the missing integration as "wiring harness for something to come later" — when in fact RS-63's spec said "RS-64 will replace the placeholder." The integration was promised; the comment was misleading; rationalizing made the user trust a broken state.
+
+When in doubt, default to: *"Let me check the spec and the integration site before I answer."*
+
 ## Step 7 — Hand off, don't auto-ship
 
 Print:


### PR DESCRIPTION
Turns the v2.0.1 backlog descriptions into actual skill behavior — lands BEFORE rs-vault specs RS-75/76 (visual + functional parity issues), so the new specs benefit from the discipline.

## Three skill changes

### /01-light-spec — behavioral ACs + cross-spec awareness

- **Acceptance Criteria discipline:** every AC must verify *observable behavior*, not *element presence*. Bad/better examples table covering: search filtering, save persistence, tab content, token resolution, animation timing.
- **Cross-spec handoff awareness:** "X will replace…" references are load-bearing. Must be in predecessor AC OR explicit in successor AC. Don't leave handoff promises buried in prose.
- **4 new Red Flags:** presence-only ACs, mock-only Save tests, implicit integration steps, unmeasurable visual claims.

### /work — behavioral self-check + anti-rationalization guard

- **Step 6.5 (NEW):** before declaring complete, manually verify behavior. For UI: run app, click affordances. For integration: grep the integration site.
- **Anti-rationalization guard:** when user asks about visible state with screenshot, default to skepticism + verification, not defense. Don't generate plausible-sounding rationale that fits the artifact.

### /pr-fix — cross-spec handoff scan

- **Phase 1.2.5 (NEW):** fetch predecessor specs, extract "X will…" promises, verify each landed in diff. Unfulfilled handoff = Critical finding regardless of own AC list.

## Why this lands now

User is about to /light-spec RS-75 + RS-76 (rs-vault Phase 2.5 visual + functional parity issues — the fix-forwards from today's RS-64 miss). Updating skills BEFORE the next spec round means the new specs benefit from the discipline rather than repeating the gap.

Docs/prose only. No code paths changed. Squash-merge per ruleset.