### PR TITLE
feat(skills): interactive walkthrough for spec open questions + improvements

### DIFF
--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -103,8 +103,39 @@ Before presenting to the user, audit every section:
 ### Phase 4 — Present and Iterate
 
 1. Show the draft spec to the user.
-2. Ask: _"Want to refine anything before I push this to Linear?"_
-3. Iterate until the user approves.
+2. **If the spec has any items in `## Risks & Open Questions`** — walk through them interactively before publishing:
+
+   ```
+   This spec has N open question(s). Walk through with recommendations? (default Y)
+   ```
+
+   If yes (default), **for each open question**, call the `AskUserQuestion` tool — one question per call so each gets its own dialog. Structure:
+
+   - `header`: short chip (≤12 chars) summarizing the question topic — e.g., "Save view"
+   - `question`: the full question, ending with `?`
+   - `options`: 2–4 mutually-exclusive choices. **First option is your recommendation** with `(Recommended)` suffix on the label. Each option's `description` carries the reasoning + trade-off (1–2 sentences).
+   - The "Other" option is auto-provided by the tool — do not include manually.
+
+   Standard option set per question (adapt as needed):
+
+   | Label | Description |
+   |---|---|
+   | `<recommended action> (Recommended)` | Why this is the best fit + the trade-off the user accepts by picking it. |
+   | `Keep as TBD` | Leave in Risks & Open Questions; defer to planning or implementation. |
+   | `Drop / out of scope` | Remove from this spec entirely. Use when the question reveals the item shouldn't ship in this issue. |
+
+   Add a fourth option only when there's a genuinely distinct alternative to the recommendation (e.g., "Persist now" vs "Persist later") — don't pad to four.
+
+   **After the user answers**, edit the spec inline:
+   - **Recommended / different answer:** move the question from Risks & Open Questions to Decisions, with the chosen path as the resolution
+   - **Keep as TBD:** leave it in Risks & Open Questions; mark `[TBD]`
+   - **Drop / out of scope:** remove the related Requirements/AC entries; note in Notes that the item was dropped
+
+3. Re-present the updated spec (one final read-through) with the new Decisions section visible.
+4. Ask: _"Want to refine anything else before I push this to Linear?"_
+5. Iterate until the user approves.
+
+**Why interactive walk-through:** open questions left in the spec body get visually skimmed and silently shipped as "implicit." Forcing each through `AskUserQuestion` turns every TBD into a deliberate decision (committed / deferred / dropped) — same lesson family as the behavioral-AC discipline above. No question gets lost in prose.
 
 ### Phase 5 — Publish to Linear
 

--- a/skills/02-light-spec-revise/skill.md
+++ b/skills/02-light-spec-revise/skill.md
@@ -109,8 +109,19 @@ Parse bulleted lists (`*` or `-` prefix) into per-item strings.
 **If Verdict is `Pass`:**
 
 1. Report: _"Latest agent verdict is **Pass** (score: X/10). No revision needed."_
-2. If Non-Blocking Improvements exist, offer to apply them opt-in **per item** (see Phase 7 rules).
-3. Exit if user declines.
+2. If Non-Blocking Improvements exist, walk through them interactively — **one `AskUserQuestion` call per improvement**, with options:
+
+   | Label | Description |
+   |---|---|
+   | `Apply (Recommended)` (or label adjusted to recommendation) | Why this improvement is worth folding in + what it changes in the spec. |
+   | `Defer to follow-up issue` | Skip in this spec; capture as a follow-up Linear issue if the improvement is meaningful but out of scope. |
+   | `Drop` | Reject the suggestion; note rationale in spec's Notes section. |
+
+   For each improvement, the recommendation defaults to **Apply** unless the improvement contradicts an existing decision. Reasoning lives in the description.
+
+   After all improvements: re-present the spec, confirm, then publish per Phase 7 rules.
+
+3. Exit if user declines all and there are no remaining improvements.
 
 **If Verdict is `Revise`:**
 


### PR DESCRIPTION
Adds interactive UI dialogs (via AskUserQuestion) for two friction points in spec authoring:

## /01-light-spec — Phase 4 walkthrough

When the spec has any Risks & Open Questions, the skill now:

1. Asks if user wants interactive walkthrough (default yes)
2. For each open question: one AskUserQuestion call with options:
   - **<recommendation> (Recommended)** — first option, with reasoning + trade-off in description
   - **Keep as TBD** — defer
   - **Drop / out of scope** — remove from spec
   - (Other — auto-provided by tool for free-text)
3. Edits spec inline based on answer
4. Re-presents updated spec before publishing

## /02-light-spec-revise — Phase 3 walkthrough

On Pass verdicts with Non-Blocking Improvements, walks each through AskUserQuestion (Apply / Defer / Drop) — replaces the previous "offer opt-in per item" stub with a concrete interactive UI.

## Why

Open questions left in spec body get visually skimmed and silently shipped as "implicit" — same lesson family as the presence-only AC discipline added earlier today (PR #35). Forcing each through AskUserQuestion makes every TBD a deliberate decision.

Lands BEFORE rs-vault /light-spec round for RS-75/76/66/67/68/69 so Daisy gets the interactive UX immediately.

Squash-merge per ruleset.