### PR TITLE
Pipekit v2.1.0 — /pr-security-review skill + phase-aware pk next + Linear visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.1.0 — 2026-05-02
+
+> Three improvements surfaced during rs-vault Phase 2.5 execution. Same-day v2.0.0 → v2.1.0.
+
+### What changed
+
+- **`/pr-security-review` skill** (new) — security-focused antagonistic PR review for migrations, RLS policies, SECURITY DEFINER functions, GRANT/REVOKE, auth code, and Server Actions on privileged tables. 30+ rubric items across 6 surface categories. Different from `/security-review` (periodic repo audit) and `/pr-fix` (broad PR review). Surfaced by RS-74 (rs-vault saved_searches migration) where neither existing skill fit the security-focused PR-diff need.
+- **Phase-aware `pk next`** — reads `## Current Phase:` from `.vbw-planning/PHASES.md`, matches to `linear-map.json` project entry via `Phase X.Y` prefix (handles em-dash vs colon separator drift), groups Linear results by status: In Progress / Approved / Needs Spec, with per-group next-action hints. Surfaces "Other phases: N Approved outside" footer. Falls back to legacy global behaviour when no phase context is available. Surfaced by Phase 2.5 having 6 Needs Spec issues + RS-63 In Progress while old `pk next` reported nothing.
+- **Mid-loop Linear visibility for `pk ship --review` + `/pr-fix`** — `pk ship --review` now posts a Linear comment flagging the review-in-flight; `/pr-fix` Phase 6.6 posts a triage-complete summary with fixed/rejected/deferred counts. Closes the gap where Linear sees `In Progress → UAT → Done` but no record of the review/fix cycle's findings.
+
+### v2.1 backlog still open (deferred to v2.1.x or v2.2)
+
+- `resources/` vs `temp/` portable convention + `pk branch` worktree resource sync
+- Cross-spec handoff verification at flowchart level (skill prose already shipped in v2.0; flowchart promotion deferred)
+- Visual + functional verification step in flowchart (Playwright + diff infra — too big for same-day cut)
+- "Defended status quo" guardrail at flowchart level (already in `/work` prose; flowchart promotion deferred)
+- `/ship` skill auto-dispatch (subagent boundary — see `temp/ship-skill-spec.md`)
+
+---
+
 ## v2.0.0 — 2026-05-02
 
 > Cut to v2 after RS-63 proved the v2 ↔ VBW handshake on a Heavy spike (rs-vault). v1 daily-loop skills retired to `archive/v1-skills/`. v2 is now the canonical Pipekit.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,4 +1,4 @@
-# Pipekit Runbook (v2.0.0)
+# Pipekit Runbook (v2.1.0)
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -9,11 +9,12 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v2.0.0-alpha.12       (or latest tag)
+1. ./scripts/sync-method.sh v2.1.0                (or latest tag)
 2. Append "## V2" config block to method.config.md (see V2.md § examples)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. Wire Stop hook into .claude/settings.json       (paste from method/templates/v2/)
 5. ./bin/pk init     →  ./bin/pk doctor            (expect all green)
+6. ./bin/pk install                                (puts pk on $PATH globally)
 ```
 
 ---
@@ -27,11 +28,18 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        │
        ▼
   ┌──────────────────────────────────────────────────────────┐
-  │ [1] Find next issue                                      │
-  │     ./bin/pk next                                        │
-  │     • reads Linear (Approved, prio desc) + git state     │
-  │     • prints next issue + suggested command              │
-  │     • optional: ./bin/pk status   (full board view)      │
+  │ [1] Find next issue   (phase-aware as of v2.1.0)         │
+  │     pk next                                              │
+  │     • reads "## Current Phase:" from PHASES.md           │
+  │     • matches to linear-map.json project entry           │
+  │     • groups Linear results by status:                   │
+  │         In Progress  (with /work hint)                   │
+  │         Approved     (with pk branch hint)               │
+  │         Needs Spec   (with /light-spec hint)             │
+  │     • surfaces "Other phases: N Approved outside" footer │
+  │     • falls back to global "next Approved" when no       │
+  │       PHASES.md or linear-map.json present               │
+  │     • optional: pk status   (full unscoped board view)   │
   └──────────────────────────────────────────────────────────┘
        │
        ▼
@@ -87,25 +95,73 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        ▼
   ┌──────────────────────────────────────────────────────────┐
   │ [5b] Antagonistic PR review  (RECOMMENDED — opt-in)      │
-  │      ./bin/pk ship --review     OR                       │
-  │      Invoke pr-review-toolkit:code-reviewer manually     │
+  │      pk ship --review                                    │
   │                                                          │
-  │      • Spawns reviewer subagent against the diff         │
-  │      • Rubric: auth correctness, brand hygiene, test     │
-  │        coverage gaps, prod-posture invariants,           │
-  │        unspec'd-but-needed cross-cutting concerns        │
-  │      • Posts findings as PR review comment via gh REST   │
+  │      • Prints reviewer subagent invocation               │
+  │      • Posts a Linear comment flagging review-in-flight  │
+  │        (v2.1.0 — closes mid-loop visibility gap)         │
+  │      • You paste invocation into Claude session;         │
+  │        agent reviews + posts findings as PR comment      │
   │      • Severity-ranked: Critical / High / Medium / Low   │
   │                                                          │
-  │      Why: catches things /work and /verify don't —       │
-  │      they validate spec adherence, the reviewer plays    │
-  │      devil's advocate. RS-60 ship found 1 critical +     │
-  │      3 high real issues this way. Don't skip on          │
-  │      anything auth/security/financial.                   │
+  │      Rubric: auth correctness, brand hygiene, test       │
+  │      coverage gaps, prod-posture invariants, unspec'd-   │
+  │      but-needed cross-cutting concerns. The reviewer     │
+  │      plays devil's advocate vs /work + /verify which     │
+  │      validate spec adherence.                            │
   │                                                          │
-  │      alpha.12 status: --review prints the invocation     │
-  │      template; you copy-run it. alpha.13 will auto-      │
-  │      dispatch the subagent and post directly.            │
+  │      Don't skip on anything auth/security/financial.     │
+  │      Status: --review prints the invocation template;    │
+  │      auto-dispatch is on the v2.1+ backlog.              │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [5c] /pr-fix triage   (RECOMMENDED — after 5b findings)  │
+  │      /pr-fix                                             │
+  │                                                          │
+  │      • Reads PR review comments + diff                   │
+  │      • Cross-spec handoff scan (v2.0.1 skill prose):     │
+  │        fetches predecessor specs via Linear MCP, checks  │
+  │        every "X will…" promise landed in this PR;        │
+  │        unfulfilled handoff = Critical regardless of own  │
+  │        AC list                                           │
+  │      • Confidence scoring per finding (verify before     │
+  │        applying — Critical findings have a verification  │
+  │        bar, see Calibration notes below)                 │
+  │      • Interactive: user picks which to fix / reject /   │
+  │        defer                                             │
+  │      • Applies fixes as separate commits, validates      │
+  │        gate, force-pushes to PR                          │
+  │      • Posts Linear comment with triage summary          │
+  │        (fixed N / rejected N / deferred N) — v2.1.0      │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [5d] /pr-security-review  (OPT-IN — security surface)    │
+  │      /pr-security-review                                 │
+  │                                                          │
+  │      Run when the PR touches ANY of:                     │
+  │      • supabase/migrations/** or *.sql files             │
+  │      • SECURITY DEFINER function definitions             │
+  │      • CREATE POLICY / ALTER POLICY (RLS)                │
+  │      • GRANT / REVOKE statements                         │
+  │      • auth code, middleware, session handling           │
+  │      • Server Actions on privileged tables (audit_log,   │
+  │        profiles, auth.users)                             │
+  │                                                          │
+  │      Surface-specific rubrics: M1-M8 migrations, R1-R6   │
+  │      RLS, S1-S8 SECURITY DEFINER, G1-G3 GRANT/REVOKE,    │
+  │      A1-A5 auth, P1-P4 server actions on privileged.    │
+  │                                                          │
+  │      Different from pk ship --review (broad/generic)     │
+  │      and /security-review (periodic repo audit). Run     │
+  │      ALONGSIDE 5b for security-sensitive PRs — they      │
+  │      cover different surface area.                       │
+  │                                                          │
+  │      Posts findings to PR + Linear summary comment.      │
+  │      v2.1.0 added — surfaced by RS-74 (rs-vault).        │
   └──────────────────────────────────────────────────────────┘
        │
        ▼
@@ -159,19 +215,23 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 
 | # | Step | Command | Where | Auth |
 |---|---|---|---|---|
-| 1 | Find next | `./bin/pk next` | parent, dev | reads Linear |
-| 1 | Quick status | `./bin/pk status` | parent | reads Linear |
-| 2 | Branch | `./bin/pk branch <ID>` | parent, dev | writes Linear (In Progress) |
+| 1 | Find next (phase-aware) | `pk next` | parent, dev | reads PHASES.md + Linear |
+| 1 | Quick status | `pk status` | parent | reads Linear (full board, unscoped) |
+| 2 | Branch | `pk branch <ID>` | parent, dev | writes Linear (In Progress) |
 | 3 | Plan + execute | `/work <ID>` | worktree | reads Linear |
 | 3 | (Variant) | `/work <ID> --deep` | worktree | reads Linear; spawns 3 grounding agents |
-| 4 | Verify | `/verify` or `./bin/pk verify` | worktree | local-only |
-| 5 | Ship | `./bin/pk ship` | worktree | push + gh pr create + writes Linear (UAT) |
-| 5 | (Variant) | `./bin/pk ship --env=<env>` | worktree | + targets specific environment |
-| **5b** | **Antagonistic review** | **`./bin/pk ship --review`** | **worktree** | **spawns code-reviewer agent → posts findings to PR** |
-| 7 | Cleanup | `./bin/pk done <ID>` | parent, dev | writes Linear (Done) + removes worktree |
-| 8 | Promote | `./bin/pk promote` | parent, dev | dev → main batch |
-| meta | Diagnose | `./bin/pk doctor` | anywhere | config + API ping |
-| meta | Bootstrap | `./bin/pk init` | repo root | walks setup |
+| 3 | (Variant) | `/work <ID> --backend=vbw\|native` | worktree | per-invocation backend override (v2.0) |
+| 4 | Verify | `/verify` or `pk verify` | worktree | local-only |
+| 5 | Ship | `pk ship` | worktree | push + gh pr create + writes Linear (UAT) |
+| 5 | (Variant) | `pk ship --env=<env>` | worktree | + targets specific environment |
+| **5b** | **Antagonistic review** | **`pk ship --review`** | **worktree** | **prints reviewer invocation; posts Linear "review in flight" comment (v2.1.0)** |
+| **5c** | **/pr-fix triage** | **`/pr-fix`** | **worktree** | **interactive findings triage; cross-spec handoff scan; posts Linear summary (v2.1.0)** |
+| **5d** | **/pr-security-review (opt-in)** | **`/pr-security-review`** | **worktree** | **security-focused PR review for migrations / RLS / SECURITY DEFINER / auth (v2.1.0)** |
+| 7 | Cleanup | `pk done <ID>` | parent, dev | writes Linear (Done) + removes worktree + posts journal highlights |
+| 8 | Promote | `pk promote [--stash\|--take-remote]` | parent, dev | dev → main batch (v2.0 added flag) |
+| meta | Diagnose | `pk doctor` | anywhere | config + API ping |
+| meta | Bootstrap | `pk init` | repo root | walks setup |
+| meta | Install | `pk install` | repo root | symlinks pk onto $PATH (v2.0) |
 | meta | View journal | `./bin/pk log` | worktree, feature | local-only |
 | meta | Linear Agent | `./bin/pk delegate <ID> <prompt>` | anywhere | posts @Linear-mentioned comment |
 | meta | Help | `./bin/pk help` | anywhere | — |
@@ -296,37 +356,25 @@ Both work. Switch back at any time. v2 commands are non-colliding.
 - `pk promote --stash` / `--take-remote` flags for local-edit conflict resolution
 - REST-first ordering in `pk_gh_pr_view` / `pk_gh_pr_create` (was burning GraphQL quota)
 
-### v2.1 candidates
+### Shipped in v2.1.0 (2026-05-02 PM)
+
+- ✅ **Phase-aware `pk next`** — reads current phase from PHASES.md + linear-map.json; groups by status (In Progress / Approved / Needs Spec) with per-group next-action hints; "Other phases" footer.
+- ✅ **`/pr-security-review` skill** — security-focused antagonistic PR review for migrations, RLS, SECURITY DEFINER, GRANT/REVOKE, auth, and Server Actions on privileged tables. 30+ rubric items across 6 surface categories.
+- ✅ **Mid-loop Linear visibility for `pk ship --review` + `/pr-fix`** — both now post Linear comments. `pk ship --review` flags review-in-flight; `/pr-fix` Phase 6.6 posts triage-complete summary.
+
+### v2.1.x / v2.2 candidates (still backlog)
 
 - **`resources/` vs `temp/` portable convention** — `resources/` for committed reference materials (design handoffs, spec dependencies); `temp/` fully gitignored for ephemera. Bake into `method.md`, `templates/`, and consuming-project bootstrap. Surfaced 2026-05-02 when RS-63's `/work` couldn't see the design handoff (lived in parent's `temp/`, gitignored, didn't travel to worktree).
 - **`pk branch` worktree-aware resource sync** — copy `resources/` (and any `.pkignore`-listed paths) into new worktrees so gitignored-but-needed files travel with the work. Companion to the convention above.
-- **Phase-aware `pk next`** — surfaces issues grouped by status within the current phase: In Progress, Approved, Needs Spec (with `/light-spec` hint per item), separated from "Other phases". Reads current phase from `PHASES.md`, scopes Linear queries by project ID from `linear-map.json`. Today's `pk next` only finds the first Approved issue anywhere — silent when current phase has none even though there's actionable work (`/light-spec` candidates). Surfaced 2026-05-02 during RS-63 execution: Phase 2.5 had RS-63 in flight + 6 Needs Spec issues but `pk next` was useless.
-- **Mid-loop Linear visibility for review + fix** — `pk ship --review` (or `/ship` when it lands) should post a Linear comment summarizing the antagonistic review (severity counts, recommendation, PR comment URL) when the review is posted. `/pr-fix` should post a Linear comment when triage completes (fixes applied, findings rejected with reason, deferrals). Today's gap: Linear sees `In Progress → UAT → Done` but no record of "review found 16 things, 1 was a false positive verified via MCP, 7 fixed, 8 deferred." That context lives only on the PR. Surfaced 2026-05-02 during RS-63 review/fix cycle.
 
-### Flowchart promotion (v2.1)
+### Flowchart promotion (still pending — v2.1.x or v2.2)
 
-When the visual-review and cross-spec-verify items below ship as actual code/skill changes, the flowchart in §"Per-issue flowchart" needs an update:
+v2.1.0 added [5c] /pr-fix and [5d] /pr-security-review explicitly to the flowchart. Two items still pending:
 
-- **Insert a new step between [4] Verify and [5] Ship**: visual-state verification — runs Playwright (or equivalent) against the worktree's running app at key user states, diffs against figma source. Optional gate (config: `Require visual review: true|false`). Catches the class of miss where components compile + tests pass but the integration didn't land (today's RS-64 example).
-- **Update [5b] Antagonistic PR review** to call out the cross-spec handoff check explicitly: reviewer must fetch predecessor specs (any "X will…" references) and verify each promise landed in this PR.
-- **Add a [5c] /pr-fix triage** step explicitly in the flowchart (currently implicit between 5b and merge).
-- **Add a [5d] /pr-security-review** opt-in step (see new skill candidate below) — fires on PRs touching `supabase/migrations/`, `*.sql`, or `SECURITY DEFINER` functions.
+- **Insert a new step between [4] Verify and [5] Ship**: visual-state verification — runs Playwright (or equivalent) against the worktree's running app at key user states, diffs against figma source. Optional gate (config: `Require visual review: true|false`). Catches the class of miss where components compile + tests pass but the integration didn't land (RS-64 example). **Deferred** because this needs new infra (Playwright + diff library + figma-source resolver) — too big for the v2.1.0 same-day cut.
+- **"Defended status quo" guardrail at flowchart level** — already in `/work` skill prose (Step 6.5), but could be promoted to a dedicated flowchart step. Lower priority since the prose is already in.
 
-Today's flowchart shows steps 1–8 with 5b inserted but no visual review, no /pr-fix, no security review. After v2.1 ships, the chain becomes: 1 → 2 → 3 → 4 → **4b (visual)** → 5 → 5b → **5c (/pr-fix)** → **5d (/pr-security-review, opt-in)** → 6 → 7 → 8.
-
-### v2.1 — new skill: /pr-security-review
-
-**Gap surfaced 2026-05-02 PM by RS-74:** rs-vault has `/security-review` (a periodic codebase audit) and `pr-review-toolkit:review-pr` (a generic antagonistic review), but **nothing purpose-built for "security-focused review of THIS PR's diff."** Migration PRs (new RLS policies, `SECURITY DEFINER` functions, audit-log access) need a focused skill that bakes in the right rubric.
-
-Proposed `/pr-security-review` scope:
-
-- Fires on PRs touching: `supabase/migrations/**`, `*.sql`, files containing `SECURITY DEFINER`, `auth.uid()` references, RLS policy definitions
-- Loads a security-specific antagonistic prompt (RLS correctness, search_path hardening, function gate semantics, action allowlist coverage, PII / admin-only data leak vectors, type regen accuracy)
-- Posts findings as a PR review comment via `gh api -X POST .../pulls/<N>/reviews` — same shape as `pk ship --review`, separate prompt
-- Caller can run it in addition to `pk ship --review` (they cover different surface area) or instead, depending on PR shape
-- Companion to `/pr-fix` — its triage flow already verifies findings before applying
-
-This is **different from `/security-review`** (periodic repo-wide audit) and **different from `pr-review-toolkit:review-pr`** (broad PR review). Same skill family as `/pr-fix` — focused, PR-diff-scoped, opinionated rubric.
+After those land, final shape will be: 1 → 2 → 3 → 4 → **4b (visual)** → 5 → 5b → 5c → 5d → 6 → 7 → 8.
 
 ### Surfaced 2026-05-02 PM (RS-64 cross-spec miss)
 

--- a/bin/pk
+++ b/bin/pk
@@ -153,6 +153,65 @@ pk_linear_issue() {
   pk_linear_gql "$q" "$(jq -n --arg id "$id" '{id:$id}')" | jq -r '.data.issue // empty'
 }
 
+# Read the current phase name from .vbw-planning/PHASES.md by extracting
+# the heading text after "## Current Phase:". Returns empty if no PHASES.md
+# or no current-phase heading. Used by phase-aware pk next.
+pk_current_phase_name() {
+  local root phases
+  root=$(pk_repo_root)
+  phases="$root/.vbw-planning/PHASES.md"
+  [ -f "$phases" ] || return 0
+  grep -m1 -E '^## Current Phase:' "$phases" 2>/dev/null \
+    | sed -E 's/^## Current Phase:[[:space:]]*//; s/[[:space:]]+$//'
+}
+
+# Match the current phase name to a linear-map.json project entry and return
+# its Linear project ID (UUID). Returns empty if no match.
+#
+# Matching is fuzzy because PHASES.md and linear-map.json may use different
+# separators ("Phase 2.5 — Vault Redesign" vs "Phase 2.5: Vault Redesign").
+# Strategy: normalize both sides to a "phase-key" by extracting the leading
+# "Phase X.Y" or "Phase X" token and lowercasing the rest for substring match.
+pk_current_phase_project_id() {
+  local root map name
+  root=$(pk_repo_root)
+  map="$root/.vbw-planning/linear-map.json"
+  [ -f "$map" ] || return 0
+  name=$(pk_current_phase_name)
+  [ -z "$name" ] && return 0
+  # Extract leading phase token (e.g. "Phase 2.5" from "Phase 2.5 — Foo")
+  local phase_token
+  phase_token=$(echo "$name" | grep -oE '^Phase [0-9]+(\.[0-9]+)?' | head -1)
+  jq -r --arg name "$name" --arg token "$phase_token" '
+    .projects // {} | to_entries | map(.value)
+    | map(select(
+        .name == $name
+        or ($token != "" and (.name | startswith($token)))
+      ))
+    | .[0].id // empty
+  ' "$map" 2>/dev/null
+}
+
+# Get issues in a state for the current team, scoped to a Linear project ID.
+# Same shape as pk_linear_issues_in_state but adds project filter. Empty
+# project_id falls back to the unscoped query.
+pk_linear_issues_in_state_project() {
+  local state="$1" project_id="$2"
+  local team
+  team=$(pk_team_name)
+  if [ -z "$team" ]; then
+    echo "ERROR: Team name not set in method.config.md" >&2
+    return 1
+  fi
+  if [ -z "$project_id" ]; then
+    pk_linear_issues_in_state "$state"
+    return $?
+  fi
+  local q='query($team: String!, $state: String!, $project: ID!) { issues(filter: {team: {name: {eq: $team}}, state: {name: {eq: $state}}, project: {id: {eq: $project}}}, orderBy: updatedAt, first: 25) { nodes { identifier title state { name } } } }'
+  pk_linear_gql "$q" "$(jq -n --arg team "$team" --arg state "$state" --arg project "$project_id" '{team:$team, state:$state, project:$project}')" \
+    | jq -r '.data.issues.nodes // []'
+}
+
 # Get issues in a state for current team. State name like "Approved".
 pk_linear_issues_in_state() {
   local state="$1"
@@ -400,10 +459,69 @@ cmd_next() {
     echo "Switch to $integration first:  git checkout $integration"
     return 0
   fi
+  # Phase-aware mode if PHASES.md + linear-map.json are present and a
+  # current phase is defined. Falls back to the global "next Approved
+  # anywhere" behaviour when no phase context is available.
+  local phase_name phase_project
+  phase_name=$(pk_current_phase_name)
+  phase_project=$(pk_current_phase_project_id)
+
+  if [ -n "$phase_name" ] && [ -n "$phase_project" ]; then
+    echo "On $current — Phase: $phase_name"
+    echo ""
+    local in_progress approved needs_spec ip_count ap_count ns_count
+    in_progress=$(pk_linear_issues_in_state_project "In Progress" "$phase_project" 2>/dev/null || echo "[]")
+    approved=$(pk_linear_issues_in_state_project "Approved" "$phase_project" 2>/dev/null || echo "[]")
+    needs_spec=$(pk_linear_issues_in_state_project "Needs Spec" "$phase_project" 2>/dev/null || echo "[]")
+    ip_count=$(echo "$in_progress" | jq 'length')
+    ap_count=$(echo "$approved" | jq 'length')
+    ns_count=$(echo "$needs_spec" | jq 'length')
+
+    if [ "$ip_count" -gt 0 ]; then
+      echo "In Progress ($ip_count):"
+      echo "$in_progress" | jq -r '.[] | "  \(.identifier) — \(.title)"'
+      echo ""
+    fi
+    if [ "$ap_count" -gt 0 ]; then
+      echo "Approved — ready for pk branch ($ap_count):"
+      echo "$approved" | jq -r '.[] | "  \(.identifier) — \(.title)"'
+      local next_id
+      next_id=$(echo "$approved" | jq -r '.[0].identifier')
+      echo ""
+      echo "Run:  pk branch $next_id"
+      echo ""
+    fi
+    if [ "$ns_count" -gt 0 ]; then
+      echo "Needs Spec — run /light-spec to advance ($ns_count):"
+      echo "$needs_spec" | jq -r '.[] | "  \(.identifier) — \(.title)"'
+      echo ""
+      if [ "$ap_count" = "0" ]; then
+        local first_ns
+        first_ns=$(echo "$needs_spec" | jq -r '.[0].identifier')
+        echo "Run:  /light-spec $first_ns   (or batch the queue)"
+        echo ""
+      fi
+    fi
+    if [ "$ip_count" = "0" ] && [ "$ap_count" = "0" ] && [ "$ns_count" = "0" ]; then
+      echo "Phase $phase_name has no In Progress / Approved / Needs Spec issues."
+      echo "Check  pk status  for the full board, or update PHASES.md to the next phase."
+    fi
+
+    # Other phases — surface Approved work outside current phase
+    local global_approved global_count outside_count
+    global_approved=$(pk_linear_issues_in_state "Approved" 2>/dev/null || echo "[]")
+    global_count=$(echo "$global_approved" | jq 'length')
+    outside_count=$((global_count - ap_count))
+    if [ "$outside_count" -gt 0 ]; then
+      echo "Other phases: $outside_count Approved issue(s) outside current phase. Use  pk status  to see all."
+    fi
+    return 0
+  fi
+
+  # Legacy fallback — no phase context available
   echo "On $current — looking for next Approved issue in Linear..."
-  local approved
+  local approved count
   approved=$(pk_linear_issues_in_state "Approved" 2>/dev/null || echo "[]")
-  local count
   count=$(echo "$approved" | jq 'length')
   if [ "$count" = "0" ]; then
     echo "No Approved issues. Check  pk status  for the full board."

--- a/bin/pk
+++ b/bin/pk
@@ -26,7 +26,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.0.0"
+PK_VERSION="2.1.0"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null
@@ -712,8 +712,20 @@ Branch: $current
 INSTRUCTIONS
     echo ""
     echo "Run /pr-review-toolkit:review-pr or invoke pr-review-toolkit:code-reviewer"
-    echo "agent with the above instructions. (Automated subagent dispatch from"
-    echo "shell is alpha.13 — for now, copy the instructions into a Claude session.)"
+    echo "agent with the above instructions. Once the review posts, the reviewer"
+    echo "(or follow-up /pr-fix) should also post a Linear comment summarizing"
+    echo "severity counts + verdict + PR URL — see pk_linear_comment helper."
+    echo ""
+    echo "(Automated subagent dispatch + auto Linear post is on the v2.1+"
+    echo "backlog — see RUNBOOK § Backlog for /ship skill spec.)"
+
+    # Best-effort: post a Linear comment now flagging that an antagonistic
+    # review is in flight. Closes the visibility gap where Linear only sees
+    # In Progress → UAT → Done with no record of the review having happened.
+    pk_linear_comment "$issue" "**Antagonistic review requested** — \`pk ship --review\`
+
+PR: $pr_url
+Reviewer subagent invocation printed in pk output. Findings will land as a PR review comment; check the PR for results." || true
   fi
 }
 

--- a/skills/pr-fix/skill.md
+++ b/skills/pr-fix/skill.md
@@ -329,6 +329,32 @@ git push
 - [ ] Merge when ready
 ```
 
+### 6.6 Post Linear comment (visibility)
+
+After fixes are pushed, post a Linear comment on the PR's linked issue summarizing the triage. This closes the mid-loop visibility gap — Linear sees `In Progress → UAT → Done` today, but the *what happened with this review* context lives only on the PR.
+
+Identify the Linear issue from:
+- The PR title's `<TEAM>-<N>:` prefix (e.g. `RS-73: …`), OR
+- The PR body's `Closes <TEAM>-<N>` line, OR
+- The current branch name's `feature/<TEAM>-<N>-…` token.
+
+Post via `pk_linear_comment <ISSUE-ID> "<body>"` (the helper `pk done` uses), or via the Linear MCP `mcp__linear-server__save_comment` tool. Body format:
+
+```markdown
+**`/pr-fix` triage complete** (PR #<N>)
+
+- **Fixed:** <count> (commits <sha1>..<shaN>)
+  - <list each finding briefly>
+- **Rejected:** <count>
+  - <each, with reason — e.g. "C1 — AG Grid var() support verified via MCP">
+- **Deferred:** <count>
+  - <each, with follow-up issue link if opened>
+
+PR: <pr-url>
+```
+
+If the PR has no linked Linear issue (no `<TEAM>-<N>` reference anywhere), skip this step silently — print `(no Linear issue linked; skipping comment)` and continue.
+
 ---
 
 ## Edge Cases

--- a/skills/pr-security-review/skill.md
+++ b/skills/pr-security-review/skill.md
@@ -1,0 +1,230 @@
+---
+name: pr-security-review
+description: Security-focused antagonistic review of a PR diff. Purpose-built for migrations, RLS policies, SECURITY DEFINER functions, auth changes — surfaces RLS correctness gaps, search_path attacks, PII leak vectors, action-allowlist coverage, gate-bypass patterns. Different from /security-review (periodic repo audit) and /pr-fix (broad PR review).
+---
+
+# /pr-security-review — Security-focused PR review
+
+## Triggers
+
+- `/pr-security-review` (uses current branch's PR)
+- `/pr-security-review <PR-number>`
+- `/pr-security-review --pr <number>`
+- Auto-suggest when running `/pr-fix` on a PR whose diff matches the security surface (see § Auto-trigger conditions below)
+
+## Purpose
+
+Run an antagonistic security-focused review of a specific PR's diff and post findings as a PR review comment via `gh api`. Companion to `/pr-fix` for triage.
+
+This skill is **purpose-built for the security-sensitive surface**. Use it when generic antagonistic review (`pk ship --review`) is too broad and `/security-review` (periodic repo audit) is the wrong shape.
+
+## When to use this skill
+
+Run `/pr-security-review` when the PR touches **any** of:
+
+- `supabase/migrations/**` or `*.sql` files
+- Code referencing `auth.uid()`, `is_approved_active_user()`, or other gate functions
+- New or modified `SECURITY DEFINER` functions
+- New or modified RLS policies (`CREATE POLICY`, `ALTER POLICY`)
+- New `GRANT` / `REVOKE` statements
+- Authentication code paths (`/api/auth`, middleware, session handling)
+- Server Actions that read or write privileged tables (`audit_log`, `profiles`, etc.)
+- Any code that constructs SQL strings dynamically
+
+## When NOT to use this skill
+
+- Pure UI / styling PRs — use `pk ship --review` instead (generic antagonistic)
+- Periodic codebase-wide security audits — use `/security-review` (different skill, different shape)
+- Broad PR review covering many dimensions — use `pr-review-toolkit:review-pr`
+
+## Auto-trigger conditions
+
+When `/pr-fix` runs on a PR, it should suggest `/pr-security-review` as a sibling step if **any** of these match the diff:
+
+```bash
+git diff $(git merge-base HEAD origin/dev)..HEAD --name-only | \
+  grep -qE '(supabase/migrations/|\.sql$|SECURITY DEFINER|CREATE POLICY|ALTER POLICY|REVOKE|GRANT)'
+```
+
+Or content-based:
+
+```bash
+git diff $(git merge-base HEAD origin/dev)..HEAD | \
+  grep -qE 'SECURITY DEFINER|auth\.uid\(\)|CREATE POLICY|REVOKE EXECUTE|GRANT EXECUTE'
+```
+
+## Execution Steps
+
+### Phase 1 — Identify PR + diff
+
+```bash
+PR_NUM=${1:-$(gh pr view --json number --jq .number)}
+PR_URL=$(gh api repos/$(gh repo view --json nameWithOwner --jq .nameWithOwner)/pulls/$PR_NUM --jq .html_url)
+BASE_SHA=$(gh pr view $PR_NUM --json baseRefOid --jq .baseRefOid)
+git diff $BASE_SHA...HEAD --stat
+```
+
+If no PR found for the current branch, refuse with: `No PR found. Open a PR first via 'pk ship'.`
+
+### Phase 2 — Classify security surface
+
+Identify which of the following surfaces the diff touches. Each surface gets its own dedicated rubric in Phase 3.
+
+| Surface | Detection | Rubric loaded |
+|---|---|---|
+| **Migration** | files under `supabase/migrations/` | M1–M8 below |
+| **RLS policies** | `CREATE POLICY` / `ALTER POLICY` / `DROP POLICY` in diff | R1–R6 below |
+| **SECURITY DEFINER functions** | `SECURITY DEFINER` keyword in diff | S1–S8 below |
+| **GRANT/REVOKE** | grant/revoke statements in diff | G1–G3 below |
+| **Auth code** | files matching `auth/`, `middleware`, `session` | A1–A5 below |
+| **Server Actions on privileged tables** | actions that read/write `audit_log`, `profiles`, `auth.users` | P1–P4 below |
+
+A PR can touch multiple surfaces. Load all relevant rubrics.
+
+### Phase 3 — Run the rubric
+
+Spawn a `pr-review-toolkit:code-reviewer` subagent (or invoke directly) with a security-first prompt that includes **only the rubric items relevant to the detected surfaces**. Each finding must include severity (Critical / High / Medium / Low / Nit), file:line citation, and concrete remediation.
+
+#### Migration rubric (M1–M8)
+
+- **M1** — All schema changes are idempotent (`IF NOT EXISTS`, `OR REPLACE`, `DROP POLICY IF EXISTS` before `CREATE POLICY`). Non-idempotent migrations break `supabase db reset` and replay.
+- **M2** — No `DROP TABLE` / `DROP COLUMN` without an explicit data-migration plan. Schema-loss migrations require a separate written rationale.
+- **M3** — New columns with `NOT NULL` constraint either have a default OR a backfill in the same migration. Otherwise the migration fails on existing data.
+- **M4** — Foreign keys explicitly specify `ON DELETE` behavior. Defaults can cascade-delete unexpectedly.
+- **M5** — New tables enable RLS (`ALTER TABLE … ENABLE ROW LEVEL SECURITY`) and have at least one explicit policy. Tables without policies + RLS enabled = no access for anyone (often the wrong default).
+- **M6** — `pg_trgm`, `unaccent`, or other extensions are added with explicit version pinning if available.
+- **M7** — Type regeneration (`supabase gen types typescript`) is in the diff if the schema changes. Code that consumes the new schema needs the types.
+- **M8** — Migration filename uses the project's timestamp convention; no out-of-order timestamps that would break `supabase db push --include-all`.
+
+#### RLS rubric (R1–R6)
+
+- **R1** — Each policy uses `auth.uid()` (or equivalent gate) and does NOT use `current_user` or other server-side identifiers that bypass auth.
+- **R2** — `USING` clause filters reads; `WITH CHECK` clause filters writes. Both required where applicable. A policy with only `USING` for INSERT/UPDATE silently lets users insert rows they couldn't read.
+- **R3** — The policy's filter actually restricts to the intended subject. Common bug: `USING (true)` left from a development scaffold.
+- **R4** — Tables that should be admin-only have a policy that checks role or membership, not just `is_approved_active_user()`.
+- **R5** — When DELETE policy is absent, deletion is denied — verify this matches intent. If user-initiated deletion is expected, the policy must be explicit.
+- **R6** — Policies have descriptive names following project convention (e.g. `<table>_<verb>_<scope>`), not generic names that obscure intent.
+
+#### SECURITY DEFINER rubric (S1–S8)
+
+- **S1** — `SET search_path = public, pg_temp` (or stricter) is set on the function. Without this, an attacker can shadow function calls via search_path manipulation.
+- **S2** — `revoke all on function … from public` is paired with `grant execute on function … to <intended-role>` — public execute is the default and almost always wrong for SECURITY DEFINER.
+- **S3** — The function's body checks an authorization gate at entry (`is_approved_active_user()`, role check, ownership check). SECURITY DEFINER bypasses RLS — the body is the last line of defense.
+- **S4** — Returned columns are explicitly enumerated. `SELECT *` from a privileged table inside a SECURITY DEFINER function is a leak vector.
+- **S5** — If the function reads from an admin-only table (e.g. `audit_log`), it sanitizes the projection: no full email, no internal IDs, no JSONB payload, no sensitive fields. Whitelist the columns.
+- **S6** — If the function joins or filters on user-controlled input, it uses parameter binding — no string concatenation into dynamic SQL.
+- **S7** — Action allowlists (e.g. for `homepage_team_activity`) cover **every** admin-only action from the audit log. Walk the audit_log enum / action types and verify each is either allowed or denied explicitly.
+- **S8** — `LANGUAGE sql` vs `plpgsql` — `STABLE` / `IMMUTABLE` markers are correct. Wrong markers can cause unsafe inlining or wrong query plans.
+
+#### GRANT/REVOKE rubric (G1–G3)
+
+- **G1** — Every `GRANT EXECUTE` is to the narrowest role that needs it (typically `authenticated`, sometimes `service_role`). `GRANT … TO PUBLIC` on privileged functions is almost always a bug.
+- **G2** — `REVOKE` precedes `GRANT` for SECURITY DEFINER functions, since `EXECUTE` defaults to PUBLIC on creation.
+- **G3** — No `GRANT` on `audit_log`, `auth.users`, or other privileged base tables to non-admin roles. Reads should go through SECURITY DEFINER projection functions.
+
+#### Auth rubric (A1–A5)
+
+- **A1** — Middleware checks happen before any privileged read/write. Order matters.
+- **A2** — Session refresh / cookie handling does not log session tokens or full email addresses.
+- **A3** — Password / token comparison uses constant-time equality (avoids timing attacks).
+- **A4** — Pending / deactivated users are blocked at every entry point, not just one (gate consistency: DB-layer + middleware + UI).
+- **A5** — Error messages don't leak whether an email exists in the system (avoids account enumeration).
+
+#### Server Actions on privileged tables (P1–P4)
+
+- **P1** — Actions that write to `audit_log` are server-only and never accept user input as the action type or actor.
+- **P2** — Actions that read from privileged tables go through SECURITY DEFINER projection functions, not direct queries.
+- **P3** — Actions validate the caller's identity (`auth.uid()`) and authorization separately. Authentication ≠ authorization.
+- **P4** — Actions return only the data the caller is entitled to see, even if the underlying query reads more (project the result before returning).
+
+### Phase 4 — Post review
+
+Format the findings as a structured PR review comment:
+
+```markdown
+## Security review — PR #<N>
+
+**Surface(s) reviewed:** Migration, SECURITY DEFINER, RLS
+
+**Verdict:** Hold | Approve with notes | Approve
+
+**Findings:** N Critical · N High · N Medium · N Low · N Nit
+
+### Critical (block merge)
+- **C1** — `<file>:<line>` — <issue>. **Remediation:** <action>.
+- ...
+
+### High (fix before merge unless waived)
+- ...
+
+### Medium / Low / Nit
+- ...
+
+### Out-of-scope observations (FYI, no action required)
+- ...
+```
+
+Post via:
+
+```bash
+gh api -X POST repos/<owner>/<repo>/pulls/<N>/reviews \
+  -f event=COMMENT -f body="<full markdown above>"
+```
+
+### Phase 5 — Linear visibility
+
+Post a Linear comment on the PR's linked issue with the review summary:
+
+```
+**Security review posted** (PR #<N>)
+- Surface(s): <list>
+- Findings: N Critical · N High · N Medium · N Low · N Nit
+- Verdict: <verdict>
+- PR comment: <url>
+```
+
+Use `pk_linear_comment "<ISSUE-ID>" "<summary>"` (the same helper `pk done` uses).
+
+### Phase 6 — Hand off to /pr-fix
+
+Print:
+
+```
+✓ Security review posted to PR #<N>: <url>
+✓ Linear updated.
+
+Next:
+  /pr-fix       — triage findings + apply fixes (recommended)
+  Review on GitHub manually if you'd rather pick which to fix yourself.
+
+Critical findings should NOT be merged without fix or explicit waive rationale.
+```
+
+## Severity guidance
+
+| Severity | Definition | Examples |
+|---|---|---|
+| **Critical** | Direct exploit path or data leak. Block merge. | RLS missing, `GRANT EXECUTE TO PUBLIC` on SECURITY DEFINER, payload field returned in sanitized projection |
+| **High** | Significant risk; fix before merge unless explicit waive. | Action allowlist missing one admin event, `search_path` not pinned, error message leaks account existence |
+| **Medium** | Real risk but contained or unlikely to exploit immediately. | Naming inconsistency in policies, missing `WITH CHECK` on UPDATE, type regen missing |
+| **Low** | Best-practice gap, not exploit-grade. | Missing comment on policy intent, no test for empty-result fallback |
+| **Nit** | Style / preference. | Function name not following project convention |
+
+## What this skill does NOT do
+
+- Doesn't fix anything — that's `/pr-fix`'s job
+- Doesn't replace `/security-review` — that's the periodic repo-wide audit
+- Doesn't replace `pk ship --review` — that's broader / non-security-focused
+- Doesn't run static analysis tools (semgrep, etc.) — out of scope; could be a v2.2 follow-on
+
+## Related
+
+- `/pr-fix` — triage findings (the natural next step)
+- `pk ship --review` — generic antagonistic review (run alongside for non-security dimensions)
+- `/security-review` — periodic codebase-wide audit (different skill, different shape)
+- `pr-review-toolkit:code-reviewer` — the underlying agent this skill drives
+
+## Calibration notes
+
+- **Critical findings have a verification bar.** Today's RS-63 antagonistic review marked one finding Critical that turned out to be a false positive (AG Grid var() support, verified via MCP). Same discipline applies here: a Critical finding should be verifiable against authoritative source (Postgres docs, Supabase docs, project conventions). Don't merge a panic Critical without verifying.
+- **Surface a "questionable but not blocking" finding** under Out-of-scope observations rather than inflating it to High. Reviewer fatigue is real.


### PR DESCRIPTION
Three improvements from today's rs-vault Phase 2.5 execution surfaced as backlog gaps; this PR ships the trio same-day.

## What's in v2.1.0

### 1. `/pr-security-review` skill (new)

Security-focused antagonistic PR review for migrations, RLS policies, `SECURITY DEFINER` functions, GRANT/REVOKE, auth code, and Server Actions on privileged tables. 30+ rubric items across 6 surface categories.

Different from:
- `/security-review` (periodic repo audit)
- `/pr-fix` (broad PR review)
- `pk ship --review` (generic antagonistic, no security focus)

Surfaced by rs-vault RS-74 (saved_searches migration + SECURITY DEFINER functions) where none of the existing skills fit.

### 2. Phase-aware `pk next`

Reads `## Current Phase:` from `.vbw-planning/PHASES.md`, matches to `linear-map.json` via `Phase X.Y` prefix (handles em-dash vs colon drift), groups results by status:
- In Progress (with /work hint)
- Approved (with pk branch hint)
- Needs Spec (with /light-spec hint when no Approved exists)

"Other phases: N Approved outside" footer surfaces global work without polluting current-phase focus. Legacy global fallback when no phase context.

Surfaced by Phase 2.5 having 6 Needs Spec issues + RS-63 In Progress while old `pk next` was useless.

### 3. Mid-loop Linear visibility

- `pk ship --review`: posts a Linear comment flagging review-in-flight with PR URL
- `/pr-fix` Phase 6.6 (NEW): posts a Linear comment with triage-complete summary

Closes the gap where Linear saw `In Progress → UAT → Done` but no record of "review found 16 things, 1 false positive verified via MCP, 7 fixed, 8 deferred."

## Verification

Phase-aware `pk next` tested live against rs-vault Phase 2.5: surfaces 5 Approved issues in current phase + flags 5 outside.

## v2.1 backlog deferred

Captured in CHANGELOG for v2.1.x or v2.2: `resources/` portable convention, visual verification step (needs Playwright infra), `/ship` auto-dispatch, flowchart promotion of skill-prose changes already shipped.

Squash-merge per ruleset. Tag v2.1.0 after merge.