### PR TITLE
Pipekit v2.1.1 — notepad convention (pk init seeds notepad.md, retires NEXT.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ DISCORD_POST.md
 .claude/
 temp/
 archive/scratch/
+
+# personal notepad — replaces v1 NEXT.md; free-form, never committed
+notepad.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.1.1 — 2026-05-02
+
+> Notepad convention: replaces retired v1 NEXT.md.
+
+### What changed
+
+- **`pk init` seeds a gitignored `notepad.md`** if one doesn't already exist, and ensures `.gitignore` excludes it. Free-form personal scratch space; never committed.
+- **`.gitignore` (pipekit's own)** adds `notepad.md` for pipekit-side development.
+- **`method.md` documents the convention** — NEXT.md is officially retired; consuming projects should delete any committed NEXT.md and rely on `pk next` for canonical "what's next?".
+- **`pk init` flags stale NEXT.md** if found, suggesting the cleanup command (does not auto-delete — user's call).
+
+### Why
+
+v1's `NEXT.md` was machine-readable state. v2's `pk next` (phase-aware as of v2.1.0) replaces that role. Consuming projects kept editing `NEXT.md` manually as a personal notepad, which created git-status churn + drift from any auto-source. `notepad.md` (gitignored) is the right shape for that use case.
+
+---
+
 ## v2.1.0 — 2026-05-02
 
 > Three improvements surfaced during rs-vault Phase 2.5 execution. Same-day v2.0.0 → v2.1.0.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,4 +1,4 @@
-# Pipekit Runbook (v2.1.0)
+# Pipekit Runbook (v2.1.1)
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -9,12 +9,13 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v2.1.0                (or latest tag)
+1. ./scripts/sync-method.sh v2.1.1                (or latest tag)
 2. Append "## V2" config block to method.config.md (see V2.md § examples)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. Wire Stop hook into .claude/settings.json       (paste from method/templates/v2/)
-5. ./bin/pk init     →  ./bin/pk doctor            (expect all green)
-6. ./bin/pk install                                (puts pk on $PATH globally)
+5. ./bin/pk init                                   (seeds notepad.md, checks config; expect all green)
+6. ./bin/pk doctor                                 (deeper diagnostic)
+7. ./bin/pk install                                (puts pk on $PATH globally)
 ```
 
 ---

--- a/bin/pk
+++ b/bin/pk
@@ -26,7 +26,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.1.0"
+PK_VERSION="2.1.1"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null
@@ -1016,6 +1016,39 @@ cmd_init() {
     echo "  ✗ \$$key_var not exported. Set in shell rc:"
     echo "    export $key_var=lin_api_xxx"
   fi
+  # Notepad convention (v2.1.1+) — seed a gitignored personal notepad if
+  # one doesn't already exist. Replaces v1's NEXT.md (which was machine-
+  # readable state — pk next is now canonical for "what to do next").
+  echo ""
+  echo "Notepad:"
+  local notepad="$root/notepad.md"
+  local gi="$root/.gitignore"
+  if [ ! -f "$notepad" ]; then
+    cat > "$notepad" <<NOTEPAD
+# Notepad
+
+Personal scratch — gitignored, never committed. Use freely.
+
+For "what should I do next?" run \`pk next\` (phase-aware as of pipekit v2.1.0).
+NOTEPAD
+    echo "  ✓ created notepad.md (gitignored, personal scratch)"
+  else
+    echo "  ✓ notepad.md already exists (kept as-is)"
+  fi
+  if [ -f "$gi" ] && ! grep -qE '^notepad\.md$' "$gi"; then
+    echo "" >> "$gi"
+    echo "# personal notepad — replaces v1 NEXT.md; free-form, never committed" >> "$gi"
+    echo "notepad.md" >> "$gi"
+    echo "  ✓ added 'notepad.md' to .gitignore"
+  elif [ -f "$gi" ]; then
+    echo "  ✓ .gitignore already excludes notepad.md"
+  fi
+  # If a stale NEXT.md is hanging around, flag it (don't auto-delete — user's call)
+  if [ -f "$root/NEXT.md" ]; then
+    echo "  ⚠ NEXT.md present — v1 artifact, retired in v2. Consider removing:"
+    echo "      git rm NEXT.md  &&  git commit -m 'chore: retire NEXT.md (use pk next)'"
+  fi
+
   echo ""
   echo "Next: pk doctor (deeper check) → pk next (find an issue) → pk branch <ID>"
 }

--- a/method.md
+++ b/method.md
@@ -3,6 +3,13 @@
 **Last updated:** 2026-04-08 *(content predates v2 cut; see banner below)*
 
 > ⚠️ **v2 transition (2026-05-02):** Pipekit's daily loop has been replaced by `bin/pk` + `/work` + `/verify`. The canonical operational doc is now [`RUNBOOK.md`](./RUNBOOK.md). References below to `/launch`, `/branch`, `/start-session`, `/end-session`, `/linear-status`, `/g-promote-*` describe the **retired v1 daily loop** — those skills now live under `archive/v1-skills/` and are no longer the recommended path. Stage 0 (foundation) and orthogonal skills (`/light-spec`, `/brainstorm`, `/pr-fix`, etc.) are unchanged. A full method.md rewrite is queued for v2.0.1.
+>
+> **NEXT.md is retired.** v1 used `NEXT.md` at the project root as a machine-readable "what to do next" pointer. v2 replaces it with `pk next` (which reads Linear directly + scopes to the current phase via `PHASES.md` as of v2.1.0). Consuming projects should:
+> - Delete any committed `NEXT.md` (`git rm NEXT.md`)
+> - Add `notepad.md` to `.gitignore` for personal free-form notes (never committed; replaces NEXT.md as a human scratch space)
+> - Use `pk next` for the canonical "what's next?" answer
+>
+> `pk init` (v2.1.1+) seeds a starter `notepad.md` and adds the gitignore line on first run. If a stale `NEXT.md` is present, `pk init` flags it but does not auto-delete.
 
 ## Overview
 


### PR DESCRIPTION
Folds the NEXT.md → notepad.md retirement into pipekit, so the convention travels via sync-method.sh to all consuming projects.

## What changed

- **`pk init` seeds `notepad.md`** if one doesn't already exist (gitignored, free-form personal scratch)
- **`pk init` ensures `.gitignore`** excludes notepad.md (idempotent — checks before adding)
- **`pk init` flags stale `NEXT.md`** if present, suggests the git rm command (no auto-delete)
- **pipekit's own `.gitignore`** adds notepad.md (for pipekit dev itself)
- **`method.md`** documents the convention in the v2 transition banner
- **`RUNBOOK.md`** title bumped to v2.1.1, setup steps clarified

## Why

NEXT.md was v1 machine-readable state. v2's `pk next` (phase-aware) replaces that role. But users still need a personal scratch space — notepad.md (gitignored) is the right shape. Companion to rs-vault PR #108 which retired NEXT.md in that consuming project.

After this merges + tagged + synced into consuming projects, `pk init` handles the convention end-to-end — no manual gitignore edits or file creation needed.

Squash-merge per ruleset, tag v2.1.1.