### PR TITLE
cleanup(sop): retire v1 vocabulary in SOPs + VBW_COMMANDS

### DIFF
--- a/VBW_COMMANDS.md
+++ b/VBW_COMMANDS.md
@@ -25,7 +25,7 @@ bash "$(find ~/.claude/plugins/cache/vbw-marketplace/vbw -maxdepth 1 -mindepth 1
 |---------|-------------|
 | `/vbw:status [--verbose] [--metrics]` | Display project progress dashboard with phase status, velocity metrics, and next action. |
 
-> **Deprecated (v1.35.0):** `/vbw:qa` and `/vbw:verify` were removed from the public help surface and absorbed into `/vbw:vibe --verify`. They still exist as hidden internal commands for direct invocation by `/launch`, but new work should route through `/vbw:vibe` for the integrated QA + UAT flow.
+> **Deprecated (VBW v1.35.0):** `/vbw:qa` and `/vbw:verify` were removed from the public help surface and absorbed into `/vbw:vibe --verify`. They still exist as hidden internal commands; in Pipekit v2, the `/verify` skill (or `pk verify`) is the canonical entry point and dispatches to VBW's verification path when `Backend: vbw`.
 
 ## Supporting — The Safety Net
 
@@ -62,7 +62,7 @@ VBW v1.35.0 added configurable lifecycle hooks via `.vbw-planning/config.json` u
 
 | Hook | When it fires | Pipekit usage |
 |------|---------------|----------------|
-| `post_archive` | After `/vbw:vibe --archive` completes | `scripts/pipekit-post-archive.sh` writes a `pending-strategy-sync` marker to Pipekit's out-of-repo state dir (resolved by `scripts/pipekit-state-dir.sh`); surfaced by `/start-session` |
+| `post_archive` | After `/vbw:vibe --archive` completes | `scripts/pipekit-post-archive.sh` writes a `pending-strategy-sync` marker to Pipekit's out-of-repo state dir (resolved by `scripts/pipekit-state-dir.sh`); surfaced by `pk doctor` and `/pipekit-help` on the next session |
 
 See `method.md` § Event Hook: Post-Archive → Strategy Sync for registration details.
 

--- a/method.md
+++ b/method.md
@@ -1,8 +1,8 @@
 # Pipekit
 
-**Last updated:** 2026-04-08 *(content predates v2 cut; see banner below)*
+**Last updated:** 2026-05-03 *(rewritten for v2.1.2)*
 
-> ⚠️ **v2 status (current as of v2.1.2):** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This file has had its v1 skill names replaced with v2 equivalents but the section *structure* still mirrors the v1 pipeline; a full structural rewrite is on the v2.1.x backlog. Stage 0 (foundation) and orthogonal skills (`/light-spec`, `/brainstorm`, `/pr-fix`, `/pr-security-review`, etc.) are unchanged in v2.
+> **v2.1.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >
 > **NEXT.md is retired.** v1 used `NEXT.md` at the project root as a machine-readable "what to do next" pointer. v2 replaces it with `pk next` (reads Linear directly + scopes to the current phase via `PHASES.md` as of v2.1.0). Consuming projects should:
 > - Delete any committed `NEXT.md` (`git rm NEXT.md`)
@@ -37,10 +37,15 @@ When ambiguity is detected, the pipeline sends work backward — not forward. A 
 Stage 0: Foundation (a contract, not a script)
   /concept → /define → /strategy-create → /startup → /vbw:init → /roadmap-create → /phase-plan
 
-Stages 1-5: Development Pipeline (repeats per issue, contract-strict)
-  [Roadmap Review] → Light Spec → Agent Review → Human Review →
-  pk next → pk branch → /work → /verify → pk ship → [PR Review] →
-  pk done → pk promote → /pk-exit → [Strategy Sync]
+Development Pipeline (repeats per issue, contract-strict):
+
+  Stage 1: Spec          /light-spec → agent review → human review
+  Stage 2: Plan + Build  pk branch → /work    (→ /review-plan if vbw backend)
+  Stage 3: Verify + Ship /verify → pk ship    (→ /pr-fix | /pr-security-review) → UAT
+  Stage 4: Release       pk done → pk promote
+  Stage 5: Doc Loop      /strategy-sync       (after UAT)
+
+Per session (not per issue): /pk-exit          (last command of every Claude Code session)
 ```
 
 **Stage 0** is the *contract* the development pipeline depends on — a set of artifacts (concept, definition, strategy, config, VBW scaffold, Linear map, phase plan) that must exist before the daily loop is safe to run. It's not a script you run once; it's a pre-condition. *How* those artifacts come to exist depends on the project's entry mode (greenfield, brownfield, inherited — see [Entry Modes](#entry-modes) below). **Stages 1-5** consume the contract and repeat per issue.
@@ -65,24 +70,25 @@ Stage 0 is the foundation contract — a set of artifacts, not a script. The gre
 
 #### Stages 1-5: Development Pipeline
 
-| # | Step | Tool | Input | Output | Gate |
-|---|------|------|-------|--------|------|
-| 0 | **Roadmap Review** | `/roadmap-review` | ROADMAP, Linear state, PHASES.md | Health report: Stage 0 check, gaps, ordering, spec coverage, doc freshness | Stage 0 complete, plan coherent |
-| 1 | **Light Spec** | `/light-spec` + Linear | Feature idea or issue | Structured spec exploring codebase and Strategy docs | — |
-| 2 | **Agent Review** | Linear Spec Review Agent | Light spec | Pass/Revise verdict with readiness score | Spec must be unambiguous and decomposable without guessing |
-| 3 | **Human Review** | You in Linear | Agent-reviewed spec | Approved spec with product decisions locked | Human signs off on scope, decisions, and priority |
-| 4 | **Find next + branch** | `pk next` then `pk branch <ID>` | Approved spec | Worktree + branch created, Linear → In Progress | Spec exists, deps met |
-| 5 | **Plan + execute** | `/work <ID>` (dispatches to `vbw` or `native` per `method.config.md`) | Approved spec from Linear | Code committed against verify/done criteria. Replaces v1's `/launch` + `/vbw:vibe --plan` + `/vbw:vibe --execute` chain. | Verdict gate passes before code is written |
-| 6 | **Plan Review** | `/review-plan` (calls `plan-reviewer` agent) | PLAN.md (vbw backend only) | Validated plan or revision requests | Plan must be executable step-by-step without ambiguity |
-| 7 | **Verify** | `/verify` (or `pk verify`) | Completed work | Pre-deploy gate report (Pass / Partial / Fail) with per-AC table; QA subagent if `Require QA review: true` | All AC satisfied; gate green |
-| 8 | **Ship** | `pk ship [--review]` | Verify-passed worktree | Push, open PR, Linear → UAT. `--review` triggers antagonistic review. | User confirmed verify passed |
-| 8b | **PR review (opt-in)** | `/pr-fix` and/or `/pr-security-review` | PR diff + reviewer findings | Triage-complete; fixed/rejected/deferred summary in Linear | Critical/High findings resolved or explicitly deferred |
-| 9 | **UAT** | You (in browser / Linear) | Built feature | Accepted or rejected | Feature matches spec AC under real usage |
-| 10 | **Done + Promote** | `pk done <ID>` then `pk promote` (multi-tier) | Merged PR | Worktree cleanup, commits posted to Linear, Linear → Done. `pk promote` opens dev → main PR. | PR merged |
-| 11 | **Session log** | `/pk-exit` | Session end | `Logs/Sessions/<date>_<HHMM>.md` narrative | Last command of every Claude session |
-| 12 | **Strategy Sync** | `/strategy-sync` | Shipped features, current Strategy docs | Updated docs reflecting reality | Code is truth; diffs approved before apply |
+| # | Stage | Step | Tool | Output | Gate |
+|---|-------|------|------|--------|------|
+| 1 | 1 | **Light Spec** | `/light-spec` | Structured spec stored in Linear | — |
+| 2 | 1 | **Agent Review** | Spec Review Agent (in Linear) | Pass/Revise verdict with readiness score | Spec is unambiguous + decomposable without guessing |
+| 3 | 1 | **Human Review** | You, in Linear | Approved spec with product decisions locked | Human signs off on scope/decisions/priority |
+| 4 | 2 | **Branch** | `pk next` then `pk branch <ID>` | Worktree + branch created, Linear → In Progress | Spec approved, deps met |
+| 5 | 2 | **Work** | `/work <ID>` (vbw or native backend per `method.config.md`) | Code committed against verify/done criteria | Verdict gate passes before code is written |
+| 5b | 2 | **Plan Review** *(vbw backend, optional)* | `/review-plan` (spawns `plan-reviewer` agent) | Validated `PLAN.md` or revision requests | Plan executable step-by-step without ambiguity |
+| 6 | 3 | **Verify** | `/verify` (or `pk verify`) | Pre-deploy gate report — Pass / Partial / Fail with per-AC table; QA subagent if `Require QA review: true` | Gate green; AC satisfied |
+| 7 | 3 | **Ship** | `pk ship [--review]` | Branch pushed, PR open, Linear → UAT | Verify passed |
+| 7b | 3 | **PR Review** *(opt-in)* | `/pr-fix` and/or `/pr-security-review` | Triage summary in Linear (fixed / rejected / deferred) | Critical/High findings resolved or explicitly deferred |
+| 8 | 3 | **UAT** | You (browser / Linear) | Accepted or rejected against spec AC | Matches spec under real usage |
+| 9 | 4 | **Done** | `pk done <ID>` | Worktree+branch cleaned up; commits + diffstat posted to Linear; → Done | PR merged |
+| 10 | 4 | **Promote** | `pk promote` *(multi-tier projects only)* | Next-tier promotion PR per `Ship environments` (e.g., dev → beta → main) | — |
+| 11 | 5 | **Strategy Sync** | `/strategy-sync` | Updated Strategy docs reflecting reality | Code is truth; diffs human-approved before apply |
 
-**Feedback loops:** Steps 2, 6, 8, and 9 can send work backward. Agent review returns specs for revision. Plan review returns plans for rework. QA returns tasks to dev. UAT returns features to execution. The pipeline is linear by default, corrective when needed.
+**Feedback loops:** steps 2, 5b, 6, and 8 can send work backward. Agent review returns specs for revision. Plan review returns plans for rework. Verify returns tasks to dev. UAT returns features to execution. The pipeline is linear by default, corrective when needed.
+
+**Per session (not per issue):** `/pk-exit` writes the narrative session log to `Logs/Sessions/<date>_<HHMM>.md`. Run as the last command of every Claude Code session, regardless of where the issue stands.
 
 **Between phases:** `/phase-plan --next` selects the next batch of issues and promotes them to "Needs Spec." `/roadmap-review` validates before speccing begins.
 
@@ -178,19 +184,19 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 
 ---
 
-## Stage 2: Branch + Plan (Execution Quality Gate)
+## Stage 2: Plan + Build (Execution Quality Gate)
 
-**Steps:** 4–6 (`pk branch` → `/work` plan-verdict → `/review-plan`)
+**Steps:** 4–5b (`pk branch` → `/work` → optional `/review-plan` for vbw backend)
 
 **Tools:** `pk branch`, `/work`, `plan-reviewer` agent (via `/review-plan`)
 
-- `pk branch <ID>` creates the worktree + branch and transitions Linear to In Progress (idempotent)
-- Inside the worktree, `/work <ID>` reads the approved spec from Linear and produces a one-screen plan with a **verdict gate** (`proceed` / `revise: <feedback>` / `abort`) before any code is written
-- Tier inference (Quick / Standard / Heavy) drives which gates apply; the human always confirms tier before `/work` proceeds
-- For `Backend: vbw`, `/work` dispatches `vbw-lead` to generate `PLAN.md` and `vbw-dev` to execute. For `Backend: native`, `/work` plans + executes in the current Claude session (with parallel `Agent` calls for grounding)
-- `/review-plan` (Pipekit skill) spawns the `plan-reviewer` agent against any generated `PLAN.md` — independent stress-test of scope, atomicity, dependencies, success criteria, and risks. Run between vbw-lead's plan and vbw-dev's execution.
+- **`pk branch <ID>`** sets up the worktree + branch and transitions Linear to In Progress. Idempotent — rerun is safe.
+- **`/work <ID>`** does plan + execute in one skill, gated by a **verdict** (`proceed` / `revise: <feedback>` / `abort`) before any code is written. Tier (Quick / Standard / Heavy) is human-confirmed before the verdict step. Backend dispatch is per `method.config.md`:
+  - `Backend: vbw` → `/work` spawns `vbw-lead` (plan) and `vbw-dev` (execute) with `PLAN.md` as the contract.
+  - `Backend: native` → `/work` plans + executes in your current Claude session, using parallel `Agent` calls only for grounding.
+- **`/review-plan`** *(vbw backend, optional)* spawns the `plan-reviewer` agent against `PLAN.md` between `vbw-lead`'s output and `vbw-dev`'s execution — independent stress-test of scope, atomicity, dependencies, success criteria, and risks.
 
-**Output:** Code committed against verify/done criteria (or `PLAN.md` + execution for `vbw` backend)
+**Output:** Code committed against verify/done criteria (or `PLAN.md` + execution for the `vbw` backend)
 
 **Gate:** Plan must be executable step-by-step without ambiguity or rework. No task should require the dev agent to make product decisions.
 
@@ -198,35 +204,42 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 
 ## Stage 3: Verify + Ship (Build Quality Gate)
 
-**Steps:** 7–9 (`/verify` → `pk ship` → UAT)
+**Steps:** 6–8 (`/verify` → `pk ship` → optional PR review → UAT)
 
-**Tools:** `/verify` (or `pk verify`), `pk ship`, optional `/pr-fix` and `/pr-security-review`, Human
+**Tools:** `/verify`, `pk ship`, optional `/pr-fix` and `/pr-security-review`, Human
 
-- `/verify` runs the project's pre-deploy gate from `method.config.md` (types + lint + test). Returns Pass / Partial / Fail with a per-AC table. If `Require QA review: true`, also spawns the QA subagent for goal-backward verification.
-- `pk ship` pushes the feature branch, opens the PR against the integration branch from config, and transitions Linear → UAT (or → In Review)
-- `pk ship --review` additionally posts a Linear comment flagging review-in-flight and prints the antagonistic reviewer invocation. The reviewer plays devil's advocate vs `/work` + `/verify` (which validate spec adherence) — finding cross-cutting concerns the spec didn't think to mention
-- For migrations / RLS / SECURITY DEFINER / auth surface, run `/pr-security-review` instead of (or alongside) the generic reviewer
-- After review findings, `/pr-fix` triages: fixed / rejected / deferred, with a Linear comment summary
-- Human performs UAT against the spec's AC in the running app
+- **`/verify`** runs the pre-deploy gate from `method.config.md` (types + lint + test). Returns Pass / Partial / Fail with a per-AC table. If `Require QA review: true`, also spawns the QA subagent for goal-backward verification.
+- **`pk ship`** pushes the feature branch, opens the PR against the integration branch from config, and transitions Linear → UAT.
+- **`pk ship --review`** posts a Linear comment flagging review-in-flight and prints the antagonistic reviewer invocation. The reviewer plays devil's advocate vs `/work` + `/verify` (which validate spec adherence) — surfaces cross-cutting concerns the spec didn't think to mention.
+- **`/pr-security-review`** is the right tool for migrations / RLS / SECURITY DEFINER / auth surface (use instead of, or alongside, the generic reviewer).
+- **`/pr-fix`** triages review findings into fixed / rejected / deferred and posts a summary comment to Linear.
+- Human performs **UAT** in the running app (preview URL) against the spec's AC.
 
-**Output:** Shippable feature merged to integration branch
+**Output:** Verified PR open and UAT-accepted in Linear, ready for the human to merge.
 
-**Gate:** Feature must match spec behaviour and pass real usage. All AC checkboxes satisfied.
+**Gate:** Feature matches spec behavior under real usage. All AC checkboxes satisfied. Critical/High review findings resolved or explicitly deferred.
 
 ---
 
 ## Stage 4: Release
 
-**Steps:** 10 (`pk done` → `pk promote`)
+**Steps:** 9–10 (`pk done` → `pk promote`)
 
 Every step forward is a PR. No direct merges between long-lived branches. Promotion is owned by `pk promote`, configured per project via `Ship environments` in `method.config.md` (e.g., `dev,main` or `dev,beta,main`).
 
-- `pk done <ID>` (after PR merge) cleans up the worktree and branch, posts commits + diffstat to Linear, and transitions the issue to Done
-- `pk promote` opens the next-tier promotion PR (dev → beta or beta → main) for multi-tier projects
-- CI enforces pre-deploy gate at each PR; for Supabase projects, the `db-pr-check.yml` workflow validates migrations on PR open and `db-migrate.yml` applies them on merge to main
-- Vercel deploys preview on PR open and prod on merge to main automatically
+**Order of operations** (after Stage 3's UAT passes):
 
-**Output:** Production release
+1. Human merges the PR (squash) once UAT is green.
+2. **`pk done <ID>`** cleans up the worktree + branch, posts commits + diffstat to Linear, and transitions the issue to Done.
+3. **`pk promote`** opens the next-tier promotion PR (dev → beta, beta → main) for multi-tier projects. Skipped for `Promote to main: false`.
+
+**Auto-machinery** firing on PR open / main merge (Pipekit owns none of these — they're project infrastructure):
+
+- **CI** enforces the pre-deploy gate at each PR.
+- **Vercel** deploys preview on PR open and prod on main merge.
+- **GitHub Actions** (Supabase projects only): `db-pr-check.yml` validates migrations on PR open against ephemeral postgres; `db-migrate.yml` applies them on main merge. Lift the workflow pair from rs-vault if your project doesn't have them yet.
+
+**Output:** Production release.
 
 **Gate:** CI passes, pre-deploy gate passes, smoke tests pass.
 

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -28,8 +28,8 @@ dev  (active development)
 | **Preview** | PR branches | Per-PR preview URLs |
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `main`
-**Promotion skills:** `/g-promote-dev`, `/g-promote-main`
-**Linear transitions:** merge to `main` → issues move to Done
+**Promotion mechanism:** `pk ship` opens the feature → `dev` PR (Linear → UAT). `pk promote` opens the `dev` → `main` PR.
+**Linear transitions:** `pk ship` → UAT; `pk done` (post-`main`-merge) → Done.
 
 ### Three-Tier (dev → beta → main)
 
@@ -50,8 +50,8 @@ dev  (active development)
 | **Preview** | PR branches | Per-PR preview URLs |
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `beta` → PR to `main`
-**Promotion skills:** `/g-promote-dev`, `/g-promote-beta`, `/g-promote-main`
-**Linear transitions:** merge to `beta` → issues move to UAT; merge to `main` → issues move to Done
+**Promotion mechanism:** `pk ship` opens the feature → `dev` PR. `pk promote` walks the chain (`dev` → `beta`, `beta` → `main`) per `Ship environments` in `method.config.md`.
+**Linear transitions:** `pk ship` → UAT; merge to `beta` keeps issue in UAT; `pk done` (post-`main`-merge) → Done.
 
 ### Branch Naming (both models)
 
@@ -134,70 +134,83 @@ All worktrees share the same git history, remotes, and object store — they're 
 
 ### Creating a Worktree
 
-Use the `/branch` skill for the full workflow (creates worktree + branch + optional Linear link):
+Use `pk branch <ID>` (Linear-issue-based). The worktree + branch + Linear → In Progress transition all happen idempotently.
 
+```bash
+pk branch RS-42        # creates feature/RS-42-<3-word-slug>, worktree at .worktrees/RS-42-<slug>
 ```
-/branch feature-name
-/branch --fix bug-name
-/branch --hotfix urgent-fix
-```
+
+The branch name and slug are derived from the Linear issue title; you don't pick them. For non-Linear work (hotfixes, scratch experiments), use plain `git worktree add` — see Hotfix Procedure below.
 
 ### Managing Worktrees
 
 ```bash
 git worktree list                             # List active worktrees
-git worktree remove ../project-feature-name   # Remove after merge
+pk done <ID>                                  # After PR merge — cleans up worktree+branch, posts to Linear
 ```
 
 ### Rules
 
 - Each branch can only be checked out in **one** worktree at a time
 - Main worktree stays on `dev` or `main`, not feature branches
-- Run dependency install in each new worktree
-- Clean up worktrees after branches are merged
+- Run dependency install in each new worktree (`pk branch` symlinks `.env` / `.env.local` / `.mcp.json`)
+- Use `pk done <ID>` to clean up after merge — it handles worktree removal + Linear transition in one step
 
 ---
 
 ## Workflow: Feature Development to Production
 
-### Step 1: Create Feature Branch
+### Step 1: Branch from Linear
+
+```bash
+pk next                # surfaces the next Approved issue (phase-aware)
+pk branch <ID>         # worktree + branch + Linear → In Progress
+cd .worktrees/<ID>-<slug>
+claude --dangerously-skip-permissions
+```
+
+### Step 2: Plan + Execute
 
 ```
-/branch feature-name
+/work <ID>             # plan-verdict gate, then execute (vbw or native backend per method.config.md)
 ```
 
-### Step 2: Develop
+### Step 3: Verify
 
-Write code on the feature branch. Include database migrations if needed.
-
-### Step 3: Test on Preview
-
-Push branch to get a preview URL. Every push updates the preview automatically.
-
-### Step 4: Open PR to Dev
-
-Run pre-deploy gate, then create PR:
 ```
-/g-promote-dev   (or your project's equivalent)
+/verify                # runs § Pre-Deploy Gate from method.config.md; QA subagent if Require QA review=true
 ```
+
+### Step 4: Open PR to Dev (with optional review)
+
+```
+pk ship                # push, open PR against integration branch from config, Linear → UAT
+pk ship --review       # additionally posts review-in-flight to Linear and prints reviewer invocation
+```
+
+For migrations / RLS / SECURITY DEFINER / auth, use `/pr-security-review` instead of (or alongside) the generic reviewer. After review findings, `/pr-fix` triages.
 
 ### Step 5: Merge to Dev
 
-PR is reviewed, approved, and merged. Feature available on dev.
+PR is reviewed, approved, and merged (squash). Feature available on dev. Vercel preview is automatic; for Supabase projects, GitHub Actions `db-pr-check.yml` validates migrations on PR open and `db-migrate.yml` applies them on `main` merge.
 
-Clean up: `/branch finish` from within the worktree.
+```
+pk done <ID>           # cleanup worktree+branch, post commits/diffstat to Linear, → Done (after main merge)
+```
 
 ### Step 6: Promote to Production
 
-**Two-tier:** PR from `dev` → `main`. After merge, referenced Linear issues move to **Done**.
+```
+pk promote             # opens dev → main (two-tier) or dev → beta → main (three-tier) PR per Ship environments
+```
 
-**Three-tier:** PR from `dev` → `beta` (issues → UAT), then PR from `beta` → `main` (issues → Done).
+After `main` merge, referenced Linear issues move to **Done** (via `pk done`).
 
 See **Batch vs Per-Issue Promotion** below for when to ship one issue at a time vs. accumulate several before promoting.
 
 ### Batch vs Per-Issue Promotion
 
-`/launch --close` and the `/g-promote-*` skills support both patterns. The default for feature-heavy phases is **batch**; the default for hotfixes is **per-issue**. Choose deliberately — different work has different risk profiles.
+`pk ship` and `pk promote` support both patterns: ship one issue at a time, or let several land on dev before promoting. The default for feature-heavy phases is **batch**; the default for hotfixes is **per-issue**. Choose deliberately — different work has different risk profiles.
 
 #### When to per-issue (ship now)
 
@@ -236,18 +249,16 @@ If none of these have triggered, keep accumulating.
 
 #### DB migration timing during accumulation
 
-The migration application moment depends on your project's Supabase setup:
+The migration application moment depends on your project's Supabase setup. v2's canonical pattern is the rs-vault GitHub Actions pair (`db-pr-check.yml` + `db-migrate.yml`), which decouples migration apply from the promotion skill entirely:
 
-| Setup | Migrations apply at | Test on dev preview? |
-|-------|---------------------|----------------------|
-| **Single shared DB** (no dev/prod split) | `/g-promote-main` only — main is the only path that runs `supabase db push` | No — schema doesn't exist on dev preview until main lands |
-| **Single shared DB + `supabase db push` in `/g-promote-dev`** | At each `/g-promote-dev` (forward-mutates shared DB) | Yes — dev preview tests against migrated schema |
-| **Separate dev + prod DBs** (piper pattern) | Each `/g-promote-{dev,beta,main}` runs `supabase db push --project-ref <env-ref>` | Yes — each env has its own DB, no shared mutation |
-| **Supabase branching** (per-PR ephemeral DBs) | At PR open via Vercel-Supabase integration | Yes — each PR has its own DB branch |
+| Setup | Migrations validate at | Migrations apply at | Test on dev preview? |
+|-------|------------------------|---------------------|----------------------|
+| **GitHub Actions (rs-vault pattern, recommended)** | PR open → ephemeral postgres reset (`db-pr-check.yml`) | `main` merge → `db-migrate.yml` runs `supabase db push` | No — schema applies at main merge; dev preview validates against ephemeral postgres |
+| **Separate dev + prod DBs** (piper pattern) | Per-environment GitHub Actions or manual `supabase db push --project-ref <env-ref>` post-merge | Per environment | Yes — each env has its own DB, no shared mutation |
+| **Supabase branching** (per-PR ephemeral DBs) | PR open → Vercel-Supabase integration spins up a branch DB | Per branch DB | Yes — each PR has its own DB branch |
+| **Single shared DB** (no dev/prod split) | Manual or via single GitHub Action on main merge | Main merge only | No — schema doesn't exist on dev preview until main lands |
 
-Read your project's `/g-promote-*` skills to determine which mode you're in. If a project's `/g-promote-dev` doesn't reference `supabase db push` and there's only one Supabase project, you're in **mode 1** — migration-bearing issues block batch promotion to dev (the migration won't apply until main).
-
-When mode 1 is the friction, the fix is project-specific: either add `supabase db push` to `/g-promote-dev` (forward-mutation accepted in pre-ship projects), or stand up separate dev/prod Supabase projects (mode 3).
+Read your project's `.github/workflows/` to determine which mode you're in. Lift the rs-vault workflow pair (`db-migrate.yml` + `db-pr-check.yml`) if you don't have migration CI yet — it requires `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, `SUPABASE_PROJECT_REF` GitHub secrets and decouples the migration concern from `pk ship` entirely. Pair migration PRs with `/pr-security-review`.
 
 #### Three-tier specifics (dev → beta → main)
 
@@ -262,13 +273,13 @@ Beta is the UAT environment in three-tier. Don't promote partial beta — if RS-
 
 #### Pre-deploy gate at each promotion
 
-Run the pre-deploy gate **before** each `/g-promote-*` step, not just before the first one:
+Run the pre-deploy gate **before** each promotion hop, not just before the first one. `/verify` (or `pk verify`) is the canonical entry point and reads § Pre-Deploy Gate from `method.config.md`:
 
-- Before `/g-promote-dev`: gate must pass on the feature branch
-- Before `/g-promote-beta` (three-tier): gate must pass on dev
-- Before `/g-promote-main`: gate must pass on dev (two-tier) or beta (three-tier)
+- Before `pk ship` (feature → dev): gate must pass on the feature branch (handled inline by `/verify`)
+- Before `pk promote dev → beta` (three-tier): gate must pass on dev tip
+- Before `pk promote dev → main` (two-tier) or `pk promote beta → main` (three-tier): gate must pass on the source branch
 
-The gate at each boundary catches integration-level regressions that wouldn't show on the originating feature branch. Don't skip "because it passed earlier."
+The gate at each boundary catches integration-level regressions that wouldn't show on the originating feature branch. CI also enforces the gate at PR open — don't skip "because it passed earlier."
 
 #### Rollback per tier
 
@@ -288,13 +299,18 @@ After any promotion, verify the deployment (smoke tests, health check).
 
 ## Hotfix Procedure
 
+Hotfixes don't fit `pk branch <ID>` (which is Linear-issue-based and targets `dev`); they branch from `main` and merge back to `main`. Use plain git:
+
 ```bash
-# 1. Create hotfix
-/branch --hotfix describe-the-fix
+# 1. Create hotfix worktree off main
+git worktree add ../<project>-hotfix-<slug> -b hotfix/<slug> main
+cd ../<project>-hotfix-<slug>
 
-# 2. Fix, commit, push, PR to main
+# 2. Fix, commit, push
+git push -u origin hotfix/<slug>
+gh pr create --base main --title "hotfix(<scope>): <desc>" --body "..."
 
-# 3. After merge, cherry-pick back immediately
+# 3. After merge, cherry-pick back to long-lived branches
 # Two-tier:
 git checkout dev && git pull && git cherry-pick <hash> && git push origin dev
 
@@ -303,8 +319,11 @@ git checkout dev && git pull && git cherry-pick <hash> && git push origin dev
 git checkout beta && git pull && git cherry-pick <hash> && git push origin beta
 
 # 4. Clean up
-/branch finish
+cd ../<project>
+git worktree remove ../<project>-hotfix-<slug>
 ```
+
+If the hotfix corresponds to a Linear issue, post the merge commit back to that issue manually — `pk done` is for `pk branch`-created branches.
 
 ---
 
@@ -346,7 +365,7 @@ Migrations are forward-only. To undo: create a new migration that reverses the c
 1. **Every step forward is a PR.** No direct merges between long-lived branches.
 2. **Main is always deployable.** Only merge tested, validated code.
 3. **All PRs target dev** (except hotfixes, which target main).
-4. **Use the promotion skills.** They automate pre-deploy gates and Linear transitions.
+4. **Use `pk ship` and `pk promote`.** They automate pre-deploy gates and Linear transitions; route everything through them so Linear stays in sync.
 5. **Test on preview before opening a PR.**
 6. **Commit often, push when stable.** Small commits are easier to debug.
 7. **Never force push to main.** Use `--force-with-lease` on feature branches only.

--- a/sop/Session_Management_SOP.md
+++ b/sop/Session_Management_SOP.md
@@ -34,7 +34,7 @@ Pipekit's pipeline maps naturally onto session boundaries. Treat each pipeline s
 | `/roadmap-create` | Fresh session | Different context from infrastructure; reads strategy docs anew |
 | `/phase-plan` | Fresh session | Distinct from roadmap creation |
 | `/light-spec` per issue | Fresh session per issue | Each spec is a bounded AI-to-AI contract |
-| `/launch` → VBW execution | VBW manages its own context | Don't try to orchestrate from the main session |
+| `/work` (vbw backend) → vbw-dev execution | VBW manages its own context | Don't try to orchestrate from the main session — let `/work` dispatch and read state on completion |
 | `/strategy-sync` post-ship | Fresh session | Compares codebase to strategy docs, needs clean context |
 
 **Rule of thumb:** when you start a new pipeline step, start a new session. The tracker files (`{folder-name}-startup.md`, `method.config.md`, `.vbw-planning/ROADMAP.md`, `Strategy/`) carry state across sessions — you don't need Claude's memory to carry it.
@@ -110,7 +110,7 @@ For Opus 4.7 running Pipekit work:
 |-----------|-------------|-----------|
 | `/startup` orchestration | `xhigh` (default) | Complex multi-step with decisions and document synthesis |
 | `/light-spec`, `/roadmap-create` | `xhigh` | Intelligence-sensitive AI-to-AI contracts |
-| `/linear-status`, `/phase-plan --status` | `high` | Lookup/summary tasks |
+| `pk status`, `pk next`, `/phase-plan --status` | `high` | Lookup/summary tasks |
 | `/update-method` routine syncs | `medium` | Mechanical, low ambiguity |
 | `/06-linear-todo-runner` worker agents | `xhigh` | Each worker executes a full spec — needs high capability |
 

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -26,46 +26,53 @@ Skills are convenience wrappers. They automate the same conventions documented i
 
 These skills work across any project that follows the method. They read `method.config.md` for project-specific values.
 
-| Skill | Purpose | Pipeline Stage |
-|-------|---------|---------------|
+| Command / Skill | Purpose | Pipeline Stage |
+|-----------------|---------|---------------|
 | `/concept` | Project-level ideation — produce a concept brief | Stage 0: Foundation |
 | `/define` | Distill concept into full project definition | Stage 0: Foundation |
 | `/strategy-create` | Bootstrap strategy docs from project definition | Stage 0: Foundation |
 | `/roadmap-create` | Create ROADMAP.md and populate Linear | Stage 0: Foundation |
 | `/phase-plan` | Select and manage execution phases | Stage 0: Foundation / Ongoing |
-| `/roadmap-review` | Pre-pipeline health check (Stage 0 gate) | Stage 0 → Stage 1 gate |
-| `/brainstorm` | Feature-level feasibility exploration | Stage 1: Definition |
-| `/brainstorm-review` | Triage untriaged Linear issues | Stage 1: Definition |
-| `/light-spec` | Structured spec generation with agent review | Stage 1: Definition |
-| `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detect stalemate loops | Stage 1: Definition |
-| `/spec-preflight` | Empirical pre-flight checks on a Linear issue's spec — verifies file paths, line refs, phase-detect baseline, Linear status against reality. Read-only. | Stage 1 / pre-Launch gate |
-| `/launch` | Formalized trigger: gates → routing → execution | Stage 2: Launch & Planning |
-| `/linear-todo-runner` | Batch execution of specced issues | Stage 3: Execution |
-| `/linear` | Linear issue workflow | Anytime |
-| `/linear-status` | Quick triage view of board status | Anytime |
-| `/sync-linear` | Bidirectional VBW ↔ Linear sync | Anytime |
-| `/branch` | Create worktree + branch + optional Linear link | Anytime |
-| `/start-session` | Review past progress, capture intentions | Anytime |
-| `/end-session` | Session wrap-up: changelog, Linear updates | Anytime |
-| `/strategy-sync` | Update Strategy docs after shipping | Stage 5: Documentation |
-| `/pr-fix` | Precision PR review + fix workflow | Anytime |
-| `/security-review` | Security review | Anytime |
-| `/spec-validator` | Validate spec completeness | Stage 1: Definition |
-| `/skill-index` | Sync skill index after changes | Anytime |
-| `/task-processor` | Process Linear tasks systematically | Stage 3: Execution |
 | `/startup` | Full project bootstrap orchestrator | Stage 0 (all steps) |
+| `/roadmap-review` | Pre-pipeline health check (Stage 0 gate) | Stage 0 → Stage 1 gate |
+| `/brainstorm` | Feature-level feasibility exploration | Stage 1: Spec |
+| `/brainstorm-review` | Triage untriaged Linear issues | Stage 1: Spec |
+| `/light-spec` | Structured spec generation with agent review | Stage 1: Spec |
+| `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detect stalemate loops | Stage 1: Spec |
+| `/spec-preflight` | Empirical pre-flight checks on a specced Linear issue (file paths, line refs, phase-detect baseline, Linear status). Read-only. | Stage 1 → Stage 2 gate |
+| `pk next` | Phase-aware: groups Linear results by status (In Progress / Approved / Needs Spec) | Stage 2: Plan + Build |
+| `pk branch <ID>` | Worktree + branch + Linear → In Progress (idempotent) | Stage 2: Plan + Build |
+| `/work <ID>` | Plan + execute. Dispatches to `vbw` or `native` backend per `method.config.md`. | Stage 2: Plan + Build |
+| `/review-plan` | Spawns `plan-reviewer` agent against `PLAN.md` (vbw backend). | Stage 2: Plan + Build |
+| `/verify` (or `pk verify`) | Pre-deploy gate (types + lint + test); QA subagent if `Require QA review: true` | Stage 3: Verify + Ship |
+| `pk ship [--review]` | Push, open PR, Linear → UAT. `--review` flags review-in-flight + prints reviewer invocation. | Stage 3: Verify + Ship |
+| `/pr-fix` | Triage PR review findings: fixed / rejected / deferred, with Linear summary | Stage 3: Verify + Ship |
+| `/pr-security-review` | Security-focused antagonistic review for migrations / RLS / SECURITY DEFINER / auth | Stage 3: Verify + Ship |
+| `pk done <ID>` | Post-merge cleanup: worktree+branch, commits to Linear, → Done | Stage 4: Release |
+| `pk promote` | Multi-tier: open dev → main (or dev → beta → main) PR per `Ship environments` | Stage 4: Release |
+| `/strategy-sync` | Update Strategy docs after shipping | Stage 5: Doc Loop |
+| `/pk-exit` | Narrative session log to `Logs/Sessions/<date>_<HHMM>.md` | Per session |
+| `pk status` | Full unscoped Linear board view | Anytime |
+| `pk doctor` | Diagnostic: config validity, Linear API access, worktree dir, stale artifacts | Anytime |
+| `pk init` | One-time per consuming project: seeds `notepad.md`, `Logs/Sessions/`, checks config | One-time setup |
+| `/linear` | Linear issue workflow helper | Anytime |
+| `/sync-linear` | Bidirectional VBW ↔ Linear sync | Anytime |
+| `/pipekit-help` | Read project state, recommend next pipeline step | Anytime |
+| `/spec-validator` | Validate spec completeness | Stage 1: Spec |
+| `/security-review` | Periodic repo security audit (different from `/pr-security-review`) | Anytime |
+| `/skill-index` | Sync skill index after changes | Anytime |
+| `/task-processor` | Process Linear tasks systematically | Stage 2: Plan + Build |
 | `/pipekit-update` | Pull latest Pipekit from GitHub into project | Anytime |
 | `/release-changelog` | Generate draft CHANGELOG entry from git commits between tags. Output to stdout for human review + edit. | Pipekit-internal release work |
 
 ### Project-Specific Skills (stay in each project)
 
-These are tied to your stack, infrastructure, or deployment pipeline:
+In v2, the daily delivery loop (push, PR, promote, migrate) is covered by `pk ship`, `pk promote`, Vercel hooks, and GitHub Actions (`db-migrate.yml` + `db-pr-check.yml` for Supabase). Project-specific skills are limited to things that genuinely depend on your domain or schema:
 
-- Promotion skills (`/g-promote-dev`, `/g-promote-beta`, `/g-promote-main`)
-- Deploy/verify skills (`/g-deploy`, `/g-test-vercel`)
-- Migration skills (`/migrate`)
-- Scaffold skills (`/component`)
-- Data management skills (`/reset-user`)
+- Component scaffolding (`/component`) — monorepo with shared UI
+- Test data reset (`/reset-user`) — auth + user system
+- Test data seeding (`/seed-data`) — repeatable fixtures
+- Schema export (`/export-schema`) — sharing schema with non-Pipekit consumers
 
 ---
 
@@ -91,63 +98,30 @@ description: One-line description of what the skill does
 3. **Use Linear MCP tools** for issue management (`mcp__linear-server__*`)
 4. **Use VBW agents** for planning and execution (`vbw:vbw-lead`, `vbw:vbw-dev`, `vbw:vbw-qa`)
 
-### The `NEXT.md` Convention
+### "What's next?" in v2 — `pk next` reads Linear
 
-Every Pipekit skill that produces a meaningful state transition (completes a pipeline step, promotes issues, ships a feature, etc.) MUST do two things in lockstep:
+v2 retired the v1 `NEXT.md` mirror. The single source of truth for "what should I do next?" is **Linear**, accessed via:
 
-1. **Print `➜ Next:` inline** in the terminal — tells the current user what command to run next and why.
-2. **Overwrite `NEXT.md` at the project root** with the same content — gives tomorrow's user (or a new session) the same pointer.
+- **`pk next`** — phase-aware (reads `## Current Phase:` from `PHASES.md`, matches to `linear-map.json`, groups Linear issues by status with per-group hints). Falls back to global "next Approved" when no phase context.
+- **`pk status`** — full unscoped board view.
+- **`/pipekit-help`** — recommends next pipeline step based on project state (push-based replacement for "what skill do I run now?").
 
-Because both are written by the same code path in the same skill run, drift is impossible. The file is fresh whenever the user closed the session.
+Skills should **not** write a `NEXT.md` file. Skills MAY still print `➜ Next:` inline at the end of their output as a courtesy hint to the current user, but the persistence layer is Linear, not a sidecar markdown file.
 
-**Required `NEXT.md` schema:**
+`pk init` (v2.1.1+) seeds a gitignored `notepad.md` at the project root for personal free-form notes (replaces NEXT.md as a human scratch space). It is never committed and never auto-written by skills.
 
-```markdown
-# Next Step
+#### Pipekit machine-local state directory
 
-**Last updated:** {YYYY-MM-DD HH:MM local} by {skill name}
-
-## Recommended next command
-`{command}`
-
-## Why this one
-{1-3 sentences on why this is the highest-leverage next action}
-
-## Parallelizable after this (optional)
-- {other commands that can run in parallel once this one starts}
-
-## Blocked, do later (optional)
-- {commands that depend on this one completing first}
-```
-
-Always include both date and time in the `Last updated` line. A bare date hides multi-session days (common when shipping more than one issue) and makes it ambiguous whether `NEXT.md` is fresh or held over from morning. Local time is fine — users read this in their terminal, not machine-parse it.
-
-**Which skills must write `NEXT.md`:**
-- `/startup` — after each step completes (always point to the next step or `/start-session` if done)
-- `/roadmap-create` — after roadmap is populated, point to `/phase-plan` or `/roadmap-review`
-- `/phase-plan` — after phase is planned, point to `/01-light-spec {first issue}`
-- `/01-light-spec` — after spec is drafted and approved, point to `/launch {issue}` or the next issue
-- `/launch` — after gates pass, point to VBW execution or the next issue to spec
-- `/strategy-sync` — after docs are updated, point to the next unshipped issue
-- `/end-session` — after session log is written, recompute based on Linear state (next Approved issue, `/strategy-sync` if pending marker exists, or `/phase-plan` if phase complete). Prevents stale NEXT.md pointing at a just-shipped issue.
-
-**`NEXT.md` lives at the project root** (not in `.vbw-planning/` — that directory is hidden and confusing for users). Visible alongside `concept-brief.md`, `project-definition.md`, `method.config.md`.
-
-**`/start-session` reads and displays it** automatically at session start, so users don't need to navigate to the file.
-
-#### Pipekit machine-local state directory (v1.7.0+)
-
-Pipekit's ephemeral, per-machine state (NEXT.md defer queue, pipeline-state records, strategy-sync marker) lives **outside** the repo at:
+Pipekit's ephemeral, per-machine state (post-archive marker, per-issue pipeline-state records) lives **outside** the repo at:
 
 ```
 ${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>/
-├── pending-next-md.json           # NEXT.md defer queue (see below)
 ├── pending-strategy-sync          # post-archive marker (see /strategy-sync)
 └── pipeline-state/
     └── <issue-id>.json            # per-skill transition state
 ```
 
-**Why out-of-repo (#13):** v1.6.0 placed these files at `<repo>/.pipekit/`, which sits inside the repo and gets blocked by VBW's file-guard hook the same way `NEXT.md` does. The defer mechanism only worked for non-VBW-scoped writers — exactly the case it was *not* meant to fix. v1.7.0 moves the directory outside the repo entirely. VBW's file-guard never inspects paths outside the project, so writes succeed unconditionally.
+**Why out-of-repo:** earlier Pipekit placed these files at `<repo>/.pipekit/`, which sits inside the repo and got blocked by VBW's file-guard hook during active-plan scope. Moving the directory outside the repo lets VBW's file-guard ignore it entirely, so writes succeed unconditionally.
 
 **Resolving the path:** every skill that reads/writes Pipekit state uses the helper:
 
@@ -158,80 +132,28 @@ mkdir -p "$STATE_DIR"
 
 `scripts/pipekit-state-dir.sh` resolves `${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>` (basename derived from `git rev-parse --show-toplevel`). All file paths below are *relative to* `$STATE_DIR`.
 
-**Migration from v1.6.0:** consuming projects with a populated `<repo>/.pipekit/` should one-shot move it: `mkdir -p "$(bash scripts/pipekit-state-dir.sh)" && mv .pipekit/* "$(bash scripts/pipekit-state-dir.sh)/" && rmdir .pipekit`. The files are ephemeral so a clean wipe is also fine — the queue and state files self-recreate on next write.
-
-#### NEXT.md deferral mechanism for VBW active-plan scope (v1.6.0+, relocated v1.7.0)
-
-A Pipekit skill that wants to write `NEXT.md` while the user is inside a VBW active-plan scope will be blocked by VBW's file-guard hook (NEXT.md is Pipekit-owned but not in the active plan's `files_modified` field). Per `method.md` § VBW / Pipekit Ownership Model, NEXT.md is unambiguously Pipekit's — but VBW's hook can't tell that, so the write fails and the audit trail is lost.
-
-**The fix:** any Pipekit skill that updates `NEXT.md` from a context that may run under VBW's active-plan scope (`/review-plan`, `/launch --close`, others) must run a deferral check before writing.
-
-```bash
-# Detect active VBW plan scope. Look for files_modified field in any
-# *-PLAN.md inside .vbw-planning/phases/<active>/ — VBW's file-guard
-# hook checks against this field.
-ACTIVE_PLAN=""
-for plan in .vbw-planning/phases/*/[0-9]*-PLAN.md; do
-  [ -f "$plan" ] || continue
-  if grep -qE "^(files_modified:|## files_modified)" "$plan" 2>/dev/null; then
-    ACTIVE_PLAN="$plan"
-    break
-  fi
-done
-
-DEFER_NEXT_MD=0
-if [ -n "$ACTIVE_PLAN" ] && ! grep -q "NEXT\.md" "$ACTIVE_PLAN"; then
-  # Active scope exists AND NEXT.md is not whitelisted in the plan.
-  # Defer the write instead of risking a hook block.
-  DEFER_NEXT_MD=1
-fi
-```
-
-**If `DEFER_NEXT_MD=1`**, queue the intended NEXT.md content to `$STATE_DIR/pending-next-md.json` (resolved via `scripts/pipekit-state-dir.sh`) instead of writing the file. Schema:
-
-```json
-{
-  "queued_at": "2026-04-29T14:32:00-04:00",
-  "writer": "/review-plan",
-  "active_plan": ".vbw-planning/phases/02-search-data-management/02-05-PLAN.md",
-  "content": "# Next Step\n\n**Last updated:** 2026-04-29 14:32 local by /review-plan\n\n## Recommended next command\n`/vbw:vibe --execute 02-search-data-management`\n..."
-}
-```
-
-`pending-next-md.json` holds the most recent deferred write; later deferrals overwrite earlier ones (NEXT.md tracks the *current* recommended next action — there is no value in queueing history).
-
-**Inline `➜ Next:` is NOT deferred** — only the file write. The user still sees the next-command line in the terminal output of the current skill. The deferred file write is purely the persistence/audit layer.
-
-**Apply on session-end:** `/end-session` (and any non-VBW-scoped Pipekit skill that touches NEXT.md) checks for `$STATE_DIR/pending-next-md.json` and applies the queued content atomically before its own NEXT.md logic runs. If `/end-session`'s own recompute supersedes the queued recommendation (the session shipped past the queued point), the queue is cleared without writing. The queue file is deleted post-apply — no persistent cruft.
-
-**Graceful degradation:** if VBW lands an upstream `always_allow` allowlist for the file-guard hook (Option B in #12), this Pipekit-side queue mechanism becomes redundant but does not break — `NEXT.md` writes succeed inline, the deferral check finds no active scope (because the allowlist short-circuits the hook), and the queue file is never created. Both paths coexist safely.
-
-#### Pipeline state file (v1.6.0+, relocated v1.7.0)
+#### Pipeline state file
 
 Each pipeline skill that completes a meaningful state transition writes a small JSON file to `$STATE_DIR/pipeline-state/<issue-id>.json` capturing the transition:
 
 ```json
 {
   "issue_id": "RS-19",
-  "stage": "review-plan",
+  "stage": "work",
   "timestamp": "2026-04-29T14:32:00-04:00",
   "verdict": "Pass",
-  "next_command": "/vbw:vibe --execute 02-search-data-management",
   "cwd": "/Users/x/Projects/rs-vault"
 }
 ```
 
 Fields:
 - `issue_id` — Linear ID (or phase slug for VBW-only flows)
-- `stage` — skill name minus the leading slash (`launch`, `review-plan`, `linear-todo-runner`, `launch-close`)
+- `stage` — skill / `pk` subcommand name (`work`, `verify`, `ship`, `done`, `review-plan`, etc.)
 - `timestamp` — ISO-8601 with offset
 - `verdict` — for skills that produce one (`Pass` / `Revise` / `Block` / `Fail`); `null` for transitions without a verdict
-- `next_command` — the inline `➜ Next:` text (must match what was emitted to terminal and to NEXT.md)
 - `cwd` — absolute path of the project root at the time of write
 
-The state file is consumed by `/launch --auto` to track auto-chain progress and (deferred to a future minor) by `/pipekit-resume` to recover cross-session. Skills overwrite their own most-recent record — this is a state file, not an event log. The whole tree lives under `$STATE_DIR` (out-of-repo), so nothing needs gitignoring.
-
-Because the directory sits outside the repo, state-file writes are no longer subject to VBW's file-guard hook. Writes succeed unconditionally during VBW-scoped stages — no deferral, no silent drop. (Pre-v1.7.0 best-effort behavior is removed; if a write now fails, it's a real bug.)
+The state file is consumed by `pk *` commands (e.g., `pk done` reads transition history when posting the Linear close comment) and by `/pipekit-help` for state-aware recommendations. Skills overwrite their own most-recent record — this is a state file, not an event log. The whole tree lives under `$STATE_DIR` (out-of-repo), so nothing needs gitignoring.
 
 ---
 
@@ -262,7 +184,7 @@ Defaults we've found to work well:
 | Execution (`vbw:vbw-dev`, batch runners) | `sonnet` |
 | Verification (`vbw:vbw-qa`) | `sonnet` |
 
-Add an escape hatch (e.g., a `--deep` flag) when the skill routes to an execution agent that sometimes needs heavier reasoning — race conditions, silent failures, cross-layer bugs. See `skills/launch/skill.md` for a worked example.
+Add an escape hatch (e.g., a `--deep` flag) when the skill routes to an execution agent that sometimes needs heavier reasoning — race conditions, silent failures, cross-layer bugs. See `skills/work/skill.md` for a worked example (`/work --deep` adds spec-validator + plan-review + security-review subagents).
 
 This defaults-plus-flag pattern is the forerunner of Anthropic's model-use decision tree (in beta). When that ships, individual skills should migrate to it; this SOP section will point there instead.
 
@@ -278,7 +200,9 @@ To update: `./scripts/sync-method.sh [tag]`
 
 ## Next-Step Nudges (Opt-In Stop Hook)
 
-Pipekit ships `scripts/pipekit-next-step-nudge.sh` — a Stop hook that suggests `/pipekit-help` after a pipeline-relevant skill finishes. The hook is **opt-in** (not registered automatically) and **scoped by behavior** (silent unless the most recent assistant turn invoked `/launch`, `/light-spec`, `/light-spec-revise`, `/review-plan`, `/strategy-sync`, or `/vbw:vibe`).
+Pipekit ships `scripts/pipekit-next-step-nudge.sh` — a Stop hook that suggests `/pipekit-help` after a pipeline-relevant skill finishes. The hook is **opt-in** (not registered automatically) and **scoped by behavior** (silent unless the most recent assistant turn invoked a tracked skill).
+
+> **Known follow-up:** the script's hardcoded skill list still references v1 names (`/launch`, etc.) and needs updating to v2 (`/work`, `/verify`, `pk ship`, `pk done`). Tracked separately from this docs PR.
 
 To enable, add this to `.claude/settings.local.json`:
 
@@ -309,7 +233,7 @@ Some files in a Pipekit project are **canonical** — they encode conventions th
 
 Protection is enforced by **hook**, not by skill prose. A `PreToolUse` hook on `Edit` and `Write` blocks the call when the target path matches the protected set; the agent receives `EditPermissionDenied` (or `HookFeedbackBlocked`, depending on the hook variant). This is intentional: hooks win over `bypassPermissions` mode because hook-level guards are the project's last line of defense, and orchestrator-spawned agents are not exempt from project policy.
 
-The corresponding skill-side discipline (since v1.4.0): every skill that spawns an agent expected to call `Edit`/`Write` includes a **permission-denial-stop instruction** in the agent's task description (see `skills/06-linear-todo-runner/skill.md` § Permission-denial protocol and the parallel block in `skills/launch/skill.md`). Without that instruction, agents tend to retry on denial, exhaust attempts, and report partial progress — the user only finds out the work was blocked after burning turns. With it, the agent stops on first denial and surfaces the denied path, intended change, and rationale, so the user can either grant the exception (revise hook), redirect the work, or abort the issue.
+The corresponding skill-side discipline: every skill that spawns an agent expected to call `Edit`/`Write` includes a **permission-denial-stop instruction** in the agent's task description (see `skills/06-linear-todo-runner/skill.md` § Permission-denial protocol and the parallel block in `skills/work/skill.md`). Without that instruction, agents tend to retry on denial, exhaust attempts, and report partial progress — the user only finds out the work was blocked after burning turns. With it, the agent stops on first denial and surfaces the denied path, intended change, and rationale, so the user can either grant the exception (revise hook), redirect the work, or abort the issue.
 
 When you add a new skill that spawns file-editing agents, copy the permission-denial block verbatim. When you protect a new path with a hook, document the protection in `method.config.md` so future readers know which paths are agent-write-locked and why.
 


### PR DESCRIPTION
## Summary

PR 3 of the pre-Piper-migration scrub series. **Stacked on PR #43** (set base accordingly). Cleans up SOPs and `VBW_COMMANDS.md`. `GUIDE.md` is the heaviest single file and gets its own PR 4 to follow.

Net change: **+76 / -180** (mostly the v1 NEXT.md infrastructure deletion in `Skills_SOP.md`).

## Per-file changes

- **`VBW_COMMANDS.md`** (2 refs) — `/vbw:qa` deprecation note + post-archive hook surfacer updated to v2 vocabulary
- **`sop/Session_Management_SOP.md`** (2 refs) — pipeline-step row + effort table row updated. The SOP itself stays — its content (compact vs clear, rewind, subagents, effort levels) is still core v2 guidance.
- **`sop/Git_and_Deployment.md`** (19 refs) — substantial rewrite of Two-Tier / Three-Tier flows, Worktree creation, Workflow Steps 1-6, DB migration timing table (now describes the rs-vault GitHub Actions pattern as canonical), pre-deploy gate boundaries, Hotfix Procedure (replaces v1 `/branch --hotfix` syntax with explicit git worktree commands since hotfixes don't fit `pk branch <ID>`'s Linear-issue-based shape).
- **`sop/Skills_SOP.md`** (34 refs) — biggest job:
  - Skills inventory table rewritten end-to-end (drops v1 daily-loop skills, adds the v2 daily loop + orthogonal skills)
  - **Deletes the entire "NEXT.md Convention" + "NEXT.md deferral mechanism" sections** (~90 lines combined) — both are moot in v2 because there is no NEXT.md
  - Replaces with a brief "What's next? in v2 — pk next reads Linear" section
  - Trims "Pipekit machine-local state directory" to drop NEXT.md queue references; "Pipeline state file" schema updated (drops next_command field)
  - "Project-Specific Skills" list updated: drops `/g-promote-*`, `/g-deploy`, `/g-test-vercel`, `/migrate` (subsumed by v2 + GitHub Actions); keeps `/component`, `/reset-user`, `/seed-data`, `/export-schema`

## Known follow-ups (not in this PR)

- **`scripts/pipekit-next-step-nudge.sh`** still hardcodes v1 skill names in its trigger regex (`/launch`, `/light-spec-revise`, etc.). Stop-hook nudge currently won't fire on v2 commands. Tracked as a script-change PR — flagged inline in `Skills_SOP.md` so future readers know.
- **PR 4:** `GUIDE.md` cleanup (1215 lines, 27 v1 refs, several sections need rewrite-not-rename — Stage 2 Launch section, skills reference table, UAT section). Substantial enough to deserve its own PR.

## Test plan

- [ ] Read `Skills_SOP.md` cold — skills inventory should map cleanly to the v2 daily loop in RUNBOOK.md; "What's next? in v2" section should be self-consistent (no dangling NEXT.md references except in the explicit "what was retired" callout)
- [ ] Read `Git_and_Deployment.md` Workflow + Hotfix sections — should reference only `pk *` commands or explicit `git` commands; no `/launch`, `/branch`, `/g-promote-*`
- [ ] Verify `grep -nE '/(branch|launch|...)\b' sop/*.md VBW_COMMANDS.md` returns only the explanatory historical-context matches
- [ ] No code/skill changes — pure docs cleanup; no CI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)