### PR TITLE
fix(skills): drop NEXT.md writes from 7 active skills (functional v2 cleanup)

### DIFF
--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -264,9 +264,9 @@ When you encounter these situations, take the safer path:
 - **Implicit decisions** → Put it in the Decisions section (defined or `[TBD]`). Context is not a contract — downstream agents can't read your mind.
 - **Assuming API behavior** → Check the installed version. Training data may not reflect the project's actual dependencies.
 
-## NEXT.md Output
+## Next-step output
 
-After the spec is drafted and posted to Linear, overwrite `NEXT.md` at the project root pointing to `/launch {issue-id}` if the spec is approved, or the next spec to draft if this one is still pending human review. See the NEXT.md convention in `sop/Skills_SOP.md`. Inline `➜ Next:` and `NEXT.md` content must match — emit them together.
+After the spec is drafted and posted to Linear, emit an inline `➜ Next:` line in your terminal output pointing to `pk branch {issue-id}` if the spec is approved (the user will then `/work {issue-id}` from inside the worktree), or the next spec to draft if this one is still pending human review. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ## Related Skills
 

--- a/skills/02-light-spec-revise/skill.md
+++ b/skills/02-light-spec-revise/skill.md
@@ -247,15 +247,15 @@ Do **not** apply Non-Blocking Improvements silently or in bulk.
 
 3. Offer to re-trigger the Spec Review Agent using the same manual-paste pattern as `/light-spec` Phase 6. Output the ready-to-paste trigger comment and remind the user: _"Paste in Linear's UI, not via MCP — the mention has to be a structured node for the agent to fire."_
 
-### Phase 10 — NEXT.md output
+### Phase 10 — Next-step output
 
-Overwrite `NEXT.md` at the project root:
+Emit an inline `➜ Next:` line in your terminal output:
 
-- If the revision is expected to pass on next review → `/launch PROJ-XXX`
+- If the revision is expected to pass on next review → `pk branch PROJ-XXX` (then `/work PROJ-XXX` inside the worktree)
 - If another pass is likely (some Unresolved blockers remain, or the user deferred fixes) → `/light-spec-revise PROJ-XXX`
-- If stalemate was surfaced and the user chose override → `/launch PROJ-XXX` (override clears the path)
+- If stalemate was surfaced and the user chose override → `pk branch PROJ-XXX` (override clears the path)
 
-Emit inline `➜ Next:` line matching `NEXT.md` content. See the NEXT.md convention in `sop/Skills_SOP.md`.
+Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ---
 
@@ -282,5 +282,5 @@ The skill MUST NEVER:
 ## Related Skills
 
 - `/light-spec` — creates the spec; Phase 6 sets up the feedback loop this skill closes.
-- `/launch` — consumes `Pass`-verdict specs for planning + execution.
+- `pk branch` + `/work` — consumes `Pass`-verdict specs for planning + execution (v2 daily loop).
 - `/spec-validator` — heavier validator for full Strategy docs (not Light Specs).

--- a/skills/06-linear-todo-runner/skill.md
+++ b/skills/06-linear-todo-runner/skill.md
@@ -185,13 +185,13 @@ When any background agent completes:
 1. Move issue to "UAT" via `mcp__linear-server__save_issue` with `stateId: {UAT state ID from method.config.md}`
 2. Post a Linear comment with: branch name, commit summary, pre-deploy gate results
 3. Log the branch for PR creation
-4. **Write pipeline state file (v1.6.0+, relocated v1.7.0):** resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and write `$STATE_DIR/pipeline-state/<issue-id>.json` per `sop/Skills_SOP.md` § Pipeline state file with `stage: "linear-todo-runner"`, `verdict: "Pass"`, `next_command: "/g-test-vercel"` (or whatever the project's post-UAT pointer is), `cwd`, `timestamp`. Path is out-of-repo so no hook block; write should always succeed.
+4. **Write pipeline state file:** resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and write `$STATE_DIR/pipeline-state/<issue-id>.json` per `sop/Skills_SOP.md` § Pipeline state file with `stage: "linear-todo-runner"`, `verdict: "Pass"`, `cwd`, `timestamp`. Path is out-of-repo so no hook block; write should always succeed.
 
 **On failure (agent reports errors or AC not met):**
 1. Move issue back to "Approved" via `mcp__linear-server__save_issue` with `stateId: {Approved state ID from method.config.md}`
 2. Post a Linear comment with the failure reason and any partial progress
 3. Log as failed
-4. **Write pipeline state file (v1.6.0+, relocated v1.7.0):** `$STATE_DIR/pipeline-state/<issue-id>.json` (with `STATE_DIR` resolved as above) with `stage: "linear-todo-runner"`, `verdict: "Fail"`, `next_command: "/01-light-spec-revise <issue-id>"` (or `/light-spec-revise` depending on diagnosis), `cwd`, `timestamp`.
+4. **Write pipeline state file:** `$STATE_DIR/pipeline-state/<issue-id>.json` (with `STATE_DIR` resolved as above) with `stage: "linear-todo-runner"`, `verdict: "Fail"`, `cwd`, `timestamp`. The Linear comment from step 2 captures the diagnosis; the next-action recommendation is rendered by `/pipekit-help` against the failed-state record, not pre-baked into the file.
 
 **Then refill:**
 1. Re-evaluate the queue — check if any previously-blocked issues are now unblocked (their blockers may have just completed)

--- a/skills/phase-plan/skill.md
+++ b/skills/phase-plan/skill.md
@@ -244,14 +244,14 @@ When you encounter these situations, take the safer path:
 - **Splitting a milestone across many phases** → If you're splitting across 4+ phases, the milestone itself may be too big — consider breaking it up in Linear.
 - **Stale issues in "Needs Spec"** → If an issue has been in "Needs Spec" for >3 days, investigate. Either spec it or swap it out for something ready.
 
-## NEXT.md Output
+## Next-step output
 
-After phase planning completes, overwrite `NEXT.md` at the project root pointing to the highest-leverage first `/01-light-spec` call. Include why that issue was picked, what parallelizes after it, and what's blocked until it lands. See the NEXT.md convention in `sop/Skills_SOP.md`. The inline `➜ Next:` message and `NEXT.md` content must be identical — emit them together.
+After phase planning completes, emit an inline `➜ Next:` line in your terminal output pointing to the highest-leverage first `/01-light-spec` call. Include why that issue was picked, what parallelizes after it, and what's blocked until it lands. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ## Related
 
 - `/roadmap-create` — previous step: creates the roadmap and populates Linear
 - `/roadmap-review` — run after phase planning to validate before speccing
 - `/light-spec` — next step: spec the first issue in the phase
-- `/launch` — executes specced issues (uses milestones for gating, not phases)
-- `/linear-status` — quick board view (complementary to `--status`)
+- `/work` — executes specced issues (uses milestones for gating, not phases)
+- `pk status` / `pk next` — quick board view (complementary to `--status`)

--- a/skills/review-plan/skill.md
+++ b/skills/review-plan/skill.md
@@ -81,8 +81,7 @@ or manually copy from your Pipekit checkout (templates/agents/plan-reviewer.md
 in older syncs, agents/plan-reviewer.md in current).
 
 Falling back to direct presentation: I'll show the PLAN.md structure
-and let you review manually. Note this is the same fallback /launch
-used to take when plan-reviewer was a phantom dependency.
+and let you review manually.
 ```
 
 ### Step 4 — Spawn the plan-reviewer agent
@@ -145,47 +144,19 @@ Based on the verdict:
 
 Always quote the agent's own Fast Path to Pass section verbatim — those are the concrete moves the user has to make.
 
-### Step 7 — NEXT.md update (with VBW active-plan deferral)
+### Step 7 — Next-step output
 
-Per the SOP `NEXT.md` schema in `sop/Skills_SOP.md`. Compose the intended file content with timestamp `{YYYY-MM-DD HH:MM local}` and writer `/review-plan`.
-
-Pointer logic:
+Emit an inline `➜ Next:` line in your terminal output. Pointer logic:
 
 - **Pass** → `/vbw:vibe --execute {phase-slug}`
 - **Revise** → `/vbw:vibe --execute {phase-slug}` (with note about non-blocking improvements)
 - **Block** → either `/vbw:vibe --plan {phase-slug}` (if Lead-revise scope) or `/02-light-spec-revise PROJ-XXX` (if spec/framing scope)
 
-Inline `➜ Next:` is **always emitted** to the terminal. The file write may be deferred — see below.
+Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
-#### Deferral check (v1.6.0+)
+### Step 8 — Pipeline state file
 
-Before writing `NEXT.md`, run the active-plan scope detection from `sop/Skills_SOP.md` § Deferral mechanism. `/review-plan` is the canonical case for deferral: it runs *inside* VBW's active-plan scope (the plan it just reviewed is the active plan), so VBW's file-guard hook will block a direct `NEXT.md` write unless the consuming project has adopted the `always_allow` allowlist (#12 Option B, upstream-coordinated).
-
-```bash
-ACTIVE_PLAN=""
-for plan in .vbw-planning/phases/*/[0-9]*-PLAN.md; do
-  [ -f "$plan" ] || continue
-  if grep -qE "^(files_modified:|## files_modified)" "$plan" 2>/dev/null; then
-    ACTIVE_PLAN="$plan"
-    break
-  fi
-done
-
-DEFER_NEXT_MD=0
-if [ -n "$ACTIVE_PLAN" ] && ! grep -q "NEXT\.md" "$ACTIVE_PLAN"; then
-  DEFER_NEXT_MD=1
-fi
-```
-
-If `DEFER_NEXT_MD=1`: resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR"`, write the queue file at `$STATE_DIR/pending-next-md.json` with the schema in the SOP. Mention briefly in your output: `"NEXT.md write deferred (VBW scope) — will apply on /end-session."`
-
-If `DEFER_NEXT_MD=0`: write `NEXT.md` directly at the project root.
-
-Inline `➜ Next:` and the eventual NEXT.md contents (whether written directly or via the queue) must match.
-
-#### Pipeline state file (v1.6.0+)
-
-After the verdict is delivered, resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR/pipeline-state"`, and write `$STATE_DIR/pipeline-state/<issue-id>.json` per the SOP schema (`stage: "review-plan"`, verdict, next_command, cwd, timestamp). Issue ID resolution mirrors Step 2's spec resolution; if no Linear ID, use the phase slug. The path is out-of-repo (v1.7.0+) so no hook block; write should always succeed.
+After the verdict is delivered, resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR/pipeline-state"`, and write `$STATE_DIR/pipeline-state/<issue-id>.json` per the SOP schema (`stage: "review-plan"`, verdict, cwd, timestamp). Issue ID resolution mirrors Step 2's spec resolution; if no Linear ID, use the phase slug. The path is out-of-repo so no hook block; write should always succeed.
 
 ---
 
@@ -216,7 +187,7 @@ Thoughts that mean "slow down on the review." Paired with `.claude/rules/pipekit
 
 | Skill | Relationship |
 |-------|-------------|
-| `/launch` | Validates Linear gates, then user runs `/vbw:vibe --plan`, then `/review-plan`. `/launch` no longer spawns plan-reviewer directly (Tier 1 / Option 3 split). |
+| `/work` (vbw backend) | Spawns `vbw-lead` to produce `PLAN.md`; the user then runs `/review-plan` between vbw-lead's output and vbw-dev's execution. `/work` does not spawn plan-reviewer directly. |
 | `/vbw:vibe --plan` | Produces the `PLAN.md` this skill reviews. |
 | `/vbw:vibe --execute` | Next step after Pass / Revise. |
 | `/02-light-spec-revise` | Route here when plan-reviewer's Block verdict points at spec-level issues (framing, missing AC, scope ambiguity). |
@@ -281,6 +252,4 @@ proceed to Dev with these two improvements applied during execution.
 ➜ Next: /vbw:vibe --execute rs-14-login-routes
    (apply the two non-blocking improvements during execution; verify-step
    sharpening can land in the same task commit)
-
-NEXT.md updated.
 ```

--- a/skills/roadmap-create/skill.md
+++ b/skills/roadmap-create/skill.md
@@ -293,9 +293,9 @@ When you encounter these situations, take the safer path:
 - **Untraceable requirements** → Every requirement should trace to a strategy doc section. If it doesn't, either the strategy docs need updating or the requirement is an orphan.
 - **Flat issue lists** → Create the full Linear hierarchy (Initiatives/Projects/Milestones). Issues without structure become unsortable quickly.
 
-## NEXT.md Output
+## Next-step output
 
-After roadmap creation completes, overwrite `NEXT.md` at the project root pointing to `/roadmap-review` (for validation) or `/phase-plan` (if validation already passed). See the NEXT.md convention in `sop/Skills_SOP.md`. Inline `➜ Next:` and `NEXT.md` content must match — emit them together.
+After roadmap creation completes, emit an inline `➜ Next:` line in your terminal output pointing to `/roadmap-review` (for validation) or `/phase-plan` (if validation already passed). Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ## Related
 

--- a/skills/startup/skill.md
+++ b/skills/startup/skill.md
@@ -137,11 +137,11 @@ Foundation OK.
   Current phase: {phase name from PHASES.md}
   Issues in flight: {N from PHASES.md current phase}
 
-➜ Next: /start-session  (review past progress and capture intentions)
+➜ Next: pk next  (phase-aware: groups Linear by status with per-group hints)
    or:   /light-spec PROJ-XXX  (begin speccing an issue from the current phase)
 ```
 
-Read `.vbw-planning/PHASES.md` to extract the current phase name and issue list. If multiple issues are in flight (status In Progress / Building), recommend `/linear-status` instead so the user can pick.
+Read `.vbw-planning/PHASES.md` to extract the current phase name and issue list. If multiple issues are in flight (status In Progress / Building), recommend `pk status` instead so the user sees the full board.
 
 **If anything is missing:**
 
@@ -157,15 +157,15 @@ Run /pipekit-help for a state-aware next-step recommendation.
 
 List every missing artifact with its retrofit suggestion. Do **not** auto-run any retrofit skill — present options and let the user choose.
 
-### Emit `NEXT.md`
+### Emit inline `➜ Next:`
 
-Whether the check passes or fails, write `NEXT.md` at the project root with the recommended next command and a one-line reason (matching the on-screen `➜ Next:`). See `sop/Skills_SOP.md` § NEXT.md convention.
+Whether the check passes or fails, emit an inline `➜ Next:` line in your terminal output with the recommended next command and a one-line reason. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear once the foundation contract is satisfied.
 
 ---
 
 ## Mode Routing
 
-`/startup` accepts a `--mode={greenfield,brownfield,inherited}` flag. If absent, auto-detect by inspecting project state, then **always confirm with the user** before proceeding (same pattern as tier resolution in `/launch` Step 1.5 — never auto-pick).
+`/startup` accepts a `--mode={greenfield,brownfield,inherited}` flag. If absent, auto-detect by inspecting project state, then **always confirm with the user** before proceeding (same pattern as tier resolution in `/work` — never auto-pick).
 
 ### Auto-detection rules
 
@@ -180,7 +180,7 @@ Evaluate top-down; first match wins:
 
 ### Confirmation prompt
 
-Mirror the wording from `skills/launch/skill.md` Step 1.5:
+Mirror the wording from `skills/work/skill.md` Step 1.5:
 
 ```
 Auto-detected entry mode: {mode}
@@ -275,7 +275,7 @@ Walk through tech stack decisions from `STARTUP.md` Step 2:
 
 This decision determines:
 - Which environments to configure in Step 4
-- Which promotion skills to create in Step 9 (no `/g-promote-beta` needed for two-tier)
+- Which `Ship environments` value to set in `method.config.md` (`dev,main` for two-tier; `dev,beta,main` for three-tier — `pk promote` walks the chain)
 - How Linear status transitions work on merge (see `sop/Git_and_Deployment.md`)
 
 **Output:** Tech stack + git architecture decisions recorded in `method.config.md`
@@ -581,7 +581,7 @@ To tell skeleton vs. populated: check for Linear issue IDs or strategy doc refer
 **Critical reminder:** Do NOT run `/vbw:vibe` as an alternative to `/roadmap-create`. VBW's own output after `/vbw:init` suggests it as a path — but in Pipekit it's a dead end. The Pipekit flow is:
 
 ```
-/vbw:init (skeleton) → /roadmap-create (merges + populates Linear) → /phase-plan → /light-spec → /launch → VBW execution
+/vbw:init (skeleton) → /roadmap-create (merges + populates Linear) → /phase-plan → /light-spec → pk branch → /work (vbw or native backend)
 ```
 
 **Output:** ROADMAP.md populated (merged with VBW's phase structure), Linear board seeded with initiatives, projects, milestones, and issues
@@ -716,4 +716,4 @@ Next steps:
   This applies to `method.config.md`, `CLAUDE.md`, strategy docs, and any file where alternatives were presented. A document should never look like two conflicting decisions are both active.
 - **App code lives in `src/`.** All application code (framework, components, API routes, etc.) goes in a `src/` subdirectory. The project root is reserved for Pipekit files (`method.config.md`, `concept-brief.md`, `project-definition.md`, `Strategy/`, `.vbw-planning/`, `method/`, `.claude/`), config files (`.gitignore`, `.env`, `package.json`, `tsconfig.json`), and scripts. This keeps Pipekit's methodology layer cleanly separated from the application. When initializing a framework (Next.js, Remix, etc.), configure it to use `src/` as the source directory.
 - **Resumable.** The tracker + artifact checks make `/startup` fully resumable across sessions. A new session reads the tracker and picks up exactly where the last one stopped.
-- **Emit `NEXT.md` after every step.** When completing any step (including mid-`/startup` step transitions), overwrite `NEXT.md` at the project root with the next command the user should run and why. See the NEXT.md convention in `sop/Skills_SOP.md`. Inline `➜ Next:` and `NEXT.md` content must match — they're emitted together.
+- **Emit inline `➜ Next:` after every step.** When completing any step (including mid-`/startup` step transitions), emit an inline `➜ Next:` line in your terminal output with the next command the user should run and why. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear once the foundation contract is satisfied.


### PR DESCRIPTION
## Summary

PR 5 of the pre-Piper-migration scrub series. **This is a functional fix, not just docs.** Seven active skills still wrote `NEXT.md` (or referenced retired skills in their `next_command` field) — when run in v2 consuming projects, they would have polluted the project root with `NEXT.md` droppings (a file v2 explicitly retired in favor of `pk next` reading Linear directly).

The PR 1-4 series cleaned the docs surface but left the actual skill files unchanged. PR 5 closes that gap for functionally-broken skills; PR 6 (next, separate) handles the remaining prose-only cross-references.

## What's broken without this fix

When a Piper user runs any of these skills in v2:

| Skill | Behavior without fix |
|---|---|
| `/startup` | Writes NEXT.md after every step — dirty git status from day 1 of the bootstrap |
| `/roadmap-create` | Writes NEXT.md after roadmap creation |
| `/phase-plan` | Writes NEXT.md after phase planning |
| `/01-light-spec` | Writes NEXT.md after spec drafted |
| `/02-light-spec-revise` | Writes NEXT.md after spec revision |
| `/review-plan` | Writes NEXT.md after plan review (or queues to deprecated `pending-next-md.json` via the deferral mechanism) |
| `/06-linear-todo-runner` | Writes `next_command: "/g-test-vercel"` to pipeline-state — references a retired skill |

## Per-commit changes

7 atomic commits, one per skill (smallest fix first → biggest last for momentum):

1. **`fix(skill:linear-todo-runner)`** — drop `next_command` field from pipeline-state writes (retired skill names: `/g-test-vercel`, `/01-light-spec-revise`)
2. **`fix(skill:phase-plan)`** — § NEXT.md Output → § Next-step output (inline only); Related links updated to v2
3. **`fix(skill:roadmap-create)`** — § NEXT.md Output → § Next-step output
4. **`fix(skill:light-spec)`** — § NEXT.md Output → § Next-step output; next-pointer `/launch {issue-id}` → `pk branch {issue-id}`
5. **`fix(skill:light-spec-revise)`** — Phase 10 NEXT.md Output → Phase 10 Next-step output; next-pointers `/launch PROJ-XXX` → `pk branch PROJ-XXX`; Related Skills updated
6. **`fix(skill:startup)`** — § Emit NEXT.md (×2 places: foundation check + cross-cutting rule) → § Emit inline ➜ Next:; foundation-OK case ➜ Next: text recommends `pk next` (not retired `/start-session`); multi-issue branch recommends `pk status` (not `/linear-status`); Mode Routing reference updated; VBW pipeline diagram updated
7. **`fix(skill:review-plan)`** — biggest single fix. Drops Step 7's entire NEXT.md write + active-plan deferral mechanism (~40 lines: schema composition, bash detection block, DEFER_NEXT_MD flag, queue-write to `pending-next-md.json`). Promotes pipeline-state-file subsection to top-level Step 8 with `next_command` removed. Drops trailing "NEXT.md updated." line in Example Session.

## Pattern across the 7 fixes

- **Drop the NEXT.md file write** entirely
- **Keep the inline `➜ Next:` line** — it was already paired with the file write per the v1 NEXT.md convention; v2 retains only the inline part
- **Update next-pointer values** where they referenced retired skills (`/launch` → `pk branch` + `/work`; `/start-session` → `pk next`; `/linear-status` → `pk status`)
- **Add explicit "do not write a NEXT.md file"** instructions where helpful, so future readers don't reintroduce the pattern

## Test plan

- [ ] `grep -rln 'overwrite.*NEXT\.md\|pending-next-md\|DEFER_NEXT_MD' skills/` returns empty (verified — only "do not write NEXT.md" instructional matches remain, all in correct context)
- [ ] No skill file instructs the agent to write `NEXT.md` to a project root
- [ ] Pipeline-state schema in skills matches the schema in `sop/Skills_SOP.md` (no `next_command` field — that was dropped in PR #44 SOP rewrite)
- [ ] No execution change beyond "stop writing NEXT.md" — Linear transitions, agent invocations, verdict logic all preserved

## Followup

- **PR 6 — Prose cleanup.** 8 skills with stale cross-references in their "Related" sections / explanatory prose (`brainstorm`, `brainstorm-review`, `task-processor`, `06-linear-todo-runner` cross-refs, `10-strategy-sync`, `release-changelog`, `spec-preflight`, `linear`). Don't break execution — just reference retired skill names in cross-references. Next PR.
- **`scripts/pipekit-next-step-nudge.sh`** still hardcodes v1 trigger regex (flagged in PR #44's `Skills_SOP.md` callout) — separate script-change PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)