### PR TITLE
docs(skills): retire v1 cross-refs in 10 skill files (prose v2 cleanup)

### DIFF
--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -264,9 +264,9 @@ When you encounter these situations, take the safer path:
 - **Implicit decisions** → Put it in the Decisions section (defined or `[TBD]`). Context is not a contract — downstream agents can't read your mind.
 - **Assuming API behavior** → Check the installed version. Training data may not reflect the project's actual dependencies.
 
-## NEXT.md Output
+## Next-step output
 
-After the spec is drafted and posted to Linear, overwrite `NEXT.md` at the project root pointing to `/launch {issue-id}` if the spec is approved, or the next spec to draft if this one is still pending human review. See the NEXT.md convention in `sop/Skills_SOP.md`. Inline `➜ Next:` and `NEXT.md` content must match — emit them together.
+After the spec is drafted and posted to Linear, emit an inline `➜ Next:` line in your terminal output pointing to `pk branch {issue-id}` if the spec is approved (the user will then `/work {issue-id}` from inside the worktree), or the next spec to draft if this one is still pending human review. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ## Related Skills
 

--- a/skills/02-light-spec-revise/skill.md
+++ b/skills/02-light-spec-revise/skill.md
@@ -247,15 +247,15 @@ Do **not** apply Non-Blocking Improvements silently or in bulk.
 
 3. Offer to re-trigger the Spec Review Agent using the same manual-paste pattern as `/light-spec` Phase 6. Output the ready-to-paste trigger comment and remind the user: _"Paste in Linear's UI, not via MCP — the mention has to be a structured node for the agent to fire."_
 
-### Phase 10 — NEXT.md output
+### Phase 10 — Next-step output
 
-Overwrite `NEXT.md` at the project root:
+Emit an inline `➜ Next:` line in your terminal output:
 
-- If the revision is expected to pass on next review → `/launch PROJ-XXX`
+- If the revision is expected to pass on next review → `pk branch PROJ-XXX` (then `/work PROJ-XXX` inside the worktree)
 - If another pass is likely (some Unresolved blockers remain, or the user deferred fixes) → `/light-spec-revise PROJ-XXX`
-- If stalemate was surfaced and the user chose override → `/launch PROJ-XXX` (override clears the path)
+- If stalemate was surfaced and the user chose override → `pk branch PROJ-XXX` (override clears the path)
 
-Emit inline `➜ Next:` line matching `NEXT.md` content. See the NEXT.md convention in `sop/Skills_SOP.md`.
+Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ---
 
@@ -282,5 +282,5 @@ The skill MUST NEVER:
 ## Related Skills
 
 - `/light-spec` — creates the spec; Phase 6 sets up the feedback loop this skill closes.
-- `/launch` — consumes `Pass`-verdict specs for planning + execution.
+- `pk branch` + `/work` — consumes `Pass`-verdict specs for planning + execution (v2 daily loop).
 - `/spec-validator` — heavier validator for full Strategy docs (not Light Specs).

--- a/skills/06-linear-todo-runner/skill.md
+++ b/skills/06-linear-todo-runner/skill.md
@@ -185,13 +185,13 @@ When any background agent completes:
 1. Move issue to "UAT" via `mcp__linear-server__save_issue` with `stateId: {UAT state ID from method.config.md}`
 2. Post a Linear comment with: branch name, commit summary, pre-deploy gate results
 3. Log the branch for PR creation
-4. **Write pipeline state file (v1.6.0+, relocated v1.7.0):** resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and write `$STATE_DIR/pipeline-state/<issue-id>.json` per `sop/Skills_SOP.md` § Pipeline state file with `stage: "linear-todo-runner"`, `verdict: "Pass"`, `next_command: "/g-test-vercel"` (or whatever the project's post-UAT pointer is), `cwd`, `timestamp`. Path is out-of-repo so no hook block; write should always succeed.
+4. **Write pipeline state file:** resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)` and write `$STATE_DIR/pipeline-state/<issue-id>.json` per `sop/Skills_SOP.md` § Pipeline state file with `stage: "linear-todo-runner"`, `verdict: "Pass"`, `cwd`, `timestamp`. Path is out-of-repo so no hook block; write should always succeed.
 
 **On failure (agent reports errors or AC not met):**
 1. Move issue back to "Approved" via `mcp__linear-server__save_issue` with `stateId: {Approved state ID from method.config.md}`
 2. Post a Linear comment with the failure reason and any partial progress
 3. Log as failed
-4. **Write pipeline state file (v1.6.0+, relocated v1.7.0):** `$STATE_DIR/pipeline-state/<issue-id>.json` (with `STATE_DIR` resolved as above) with `stage: "linear-todo-runner"`, `verdict: "Fail"`, `next_command: "/01-light-spec-revise <issue-id>"` (or `/light-spec-revise` depending on diagnosis), `cwd`, `timestamp`.
+4. **Write pipeline state file:** `$STATE_DIR/pipeline-state/<issue-id>.json` (with `STATE_DIR` resolved as above) with `stage: "linear-todo-runner"`, `verdict: "Fail"`, `cwd`, `timestamp`. The Linear comment from step 2 captures the diagnosis; the next-action recommendation is rendered by `/pipekit-help` against the failed-state record, not pre-baked into the file.
 
 **Then refill:**
 1. Re-evaluate the queue — check if any previously-blocked issues are now unblocked (their blockers may have just completed)

--- a/skills/06-linear-todo-runner/skill.md
+++ b/skills/06-linear-todo-runner/skill.md
@@ -319,9 +319,9 @@ Set `blocked_by` relations in Linear to enforce the correct execution order.
 
 - **`/task-processor`** — Single-issue interactive pickup. Use for hands-on work. The runner is for batch automation.
 - **`/linear PROJ-XXX`** — Full end-to-end lifecycle for one issue. Use for failed issues that need manual attention.
-- **`/linear-status`** — Quick board view. Run before the runner to see what's queued.
+- **`pk status`** / **`pk next`** — Quick board view. Run before the runner to see what's queued.
 - **`/sync-linear`** — Sync VBW ↔ Linear. Run after the runner to update VBW state.
-- **`/branch`** — The runner uses `isolation: "worktree"` (Claude Code temporary worktrees), not the `/branch` skill's `{worktree prefix from method.config.md}<description>/` pattern.
+- **`pk branch`** — The runner uses `isolation: "worktree"` (Claude Code temporary worktrees), not `pk branch`'s `.worktrees/<ID>-<slug>/` pattern. Use `pk branch` for hands-on single-issue work; the runner is for parallel batch automation.
 
 ---
 

--- a/skills/10-strategy-sync/skill.md
+++ b/skills/10-strategy-sync/skill.md
@@ -41,7 +41,7 @@ Read the project's strategy doc manifest from `method.config.md` under `## Strat
 
 Use the **Purpose** field to determine the tone and depth of updates. Use the **Audience** field to calibrate language level (stakeholder docs stay simple, developer docs include technical detail).
 
-If a Changelog doc exists in the manifest, it is excluded from sync content — it's maintained by `/end-session`. However, this skill adds a single changelog entry recording what was synced.
+If a Changelog doc exists in the manifest, it is excluded from sync content — Changelog entries are owned separately (`/release-changelog` for release notes, `/pk-exit` for per-session logs at `Logs/Sessions/`). However, this skill adds a single Changelog entry recording what was synced.
 
 **If no Strategy Docs table exists in `method.config.md`:** warn the user and suggest running `/strategy-create` to set up the manifest.
 
@@ -201,5 +201,5 @@ Run at these moments:
 - See `method.md` — this skill is the post-pipeline documentation step
 - `/strategy-create` — bootstraps the docs this skill updates
 - `/roadmap-review` — flags doc staleness; run this skill to resolve it
-- `/end-session` — maintains the Changelog doc (if one exists); this skill handles all other strategy docs
+- `/release-changelog` — generates release-level Changelog entries from git commits; complementary to this skill which keeps Strategy docs current
 - `/light-spec` — the specs that feed into this skill's comparison logic

--- a/skills/brainstorm-review/skill.md
+++ b/skills/brainstorm-review/skill.md
@@ -84,7 +84,7 @@ Disposition:
 4. Route by complexity tier (matches `/brainstorm` tier mapping):
    - **Low → Quick:** move to "Approved" — ready for `pk branch {issue}` + `/work {issue}` (no spec)
    - **Medium → Standard:** move to "Needs Spec" — ready for `/light-spec {issue}`
-   - **High → Heavy:** move to "Needs Spec" — `/light-spec` mandatory, full VBW route via `/launch`
+   - **High → Heavy:** move to "Needs Spec" — `/light-spec` mandatory, full VBW route via `/work` (with `Backend: vbw`)
 5. Set priority (ask user)
 6. Assign to correct project/initiative
 

--- a/skills/brainstorm/skill.md
+++ b/skills/brainstorm/skill.md
@@ -53,7 +53,7 @@ Immediately after creating the issue, force a disposition decision:
 - Route by complexity tier (see Complexity Guidelines for tier mapping):
   - **Quick (Low)** → move to "Approved". Inform: _"Ready for `pk branch {issue}` then `/work {issue}` — no spec needed."_
   - **Standard (Medium)** → move to "Needs Spec". Inform: _"Ready for `/light-spec {issue}`, then `pk branch {issue}` + `/work {issue}`."_
-  - **Heavy (High)** → move to "Needs Spec". Inform: _"Heavy tier — run `/light-spec {issue}` first; `/launch` will route through full VBW planning."_
+  - **Heavy (High)** → move to "Needs Spec". Inform: _"Heavy tier — run `/light-spec {issue}` first; `/work` will route through full VBW planning (Backend: vbw)."_
 
 **If Later:**
 - Ask for a **trigger type** from the grammar below (parsable triggers are what let `/roadmap-review` auto-surface this later — prose triggers get flagged as manual-review)
@@ -93,9 +93,9 @@ If the disposition is **Now** and the brainstorm is broad, cut to v1 scope:
 
 ## Complexity Guidelines
 
-Each complexity level maps to a `/launch` tier. The tier determines whether a spec is required and which execution path runs.
+Each complexity level maps to a `/work` tier. The tier determines whether a spec is required and which execution path runs.
 
-| Complexity | `/launch` Tier | Effort | Examples | Spec? |
+| Complexity | `/work` Tier | Effort | Examples | Spec? |
 |------------|----------------|--------|----------|-------|
 | **Low** | Quick | ~2-4h | UI-only, simple CRUD, existing infrastructure | No — straight to `pk branch` + `/work` |
 | **Medium** | Standard | ~6-10h | New API endpoint, combines existing systems | Yes — `/light-spec` first |

--- a/skills/linear/skill.md
+++ b/skills/linear/skill.md
@@ -37,7 +37,7 @@ The workflow has 5 phases. At each phase transition, update the Linear issue sta
 
 ### Phase 2: Implement
 
-1. **Create a worktree** using the `/branch` skill or manually:
+1. **Create a worktree** using `pk branch <ID>` (Linear-issue-based, recommended) or manually:
    - Branch from `dev` (default) or `main` (hotfixes only)
    - Worktree at `{worktree prefix from method.config.md}<description>/`
    - Use the appropriate prefix:
@@ -83,7 +83,7 @@ The workflow has 5 phases. At each phase transition, update the Linear issue sta
 
 ### Phase 5: Cleanup
 
-1. **Clean up the worktree** using `/branch finish` or manually:
+1. **Clean up the worktree** using `pk done <ID>` (Linear-issue-based, recommended) or manually:
    ```bash
    # From main repo directory
    git worktree remove {worktree prefix from method.config.md}<description>/
@@ -125,8 +125,9 @@ Keep Linear comments concise and useful:
 
 ## Related
 
-- Branch skill: `/branch` — creates worktree + branch + optional Linear link
+- Branch + worktree: `pk branch <ID>` — creates worktree + branch + Linear → In Progress (idempotent)
+- v2 daily loop: `pk next` → `pk branch` → `/work` → `/verify` → `pk ship` → `pk done` → `/pk-exit` (recommended path; this skill is the manual hands-on alternative)
 - Batch processing: `/linear-todo-runner` — rolling parallel queue for multiple issues
-- Promotion: `/g-promote-dev` → `/g-promote-beta` → `/g-promote-main`
-- Session management: `/start-session`, `/end-session`
+- Promotion: `pk ship` (feature → integration branch) + `pk promote` (walks the chain per `Ship environments` in `method.config.md`)
+- Session log: `/pk-exit` — narrative session log to `Logs/Sessions/<date>_<HHMM>.md` (last command of every Claude Code session)
 - Git workflow: See CLAUDE.md "Branch Strategy"

--- a/skills/phase-plan/skill.md
+++ b/skills/phase-plan/skill.md
@@ -244,14 +244,14 @@ When you encounter these situations, take the safer path:
 - **Splitting a milestone across many phases** → If you're splitting across 4+ phases, the milestone itself may be too big — consider breaking it up in Linear.
 - **Stale issues in "Needs Spec"** → If an issue has been in "Needs Spec" for >3 days, investigate. Either spec it or swap it out for something ready.
 
-## NEXT.md Output
+## Next-step output
 
-After phase planning completes, overwrite `NEXT.md` at the project root pointing to the highest-leverage first `/01-light-spec` call. Include why that issue was picked, what parallelizes after it, and what's blocked until it lands. See the NEXT.md convention in `sop/Skills_SOP.md`. The inline `➜ Next:` message and `NEXT.md` content must be identical — emit them together.
+After phase planning completes, emit an inline `➜ Next:` line in your terminal output pointing to the highest-leverage first `/01-light-spec` call. Include why that issue was picked, what parallelizes after it, and what's blocked until it lands. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ## Related
 
 - `/roadmap-create` — previous step: creates the roadmap and populates Linear
 - `/roadmap-review` — run after phase planning to validate before speccing
 - `/light-spec` — next step: spec the first issue in the phase
-- `/launch` — executes specced issues (uses milestones for gating, not phases)
-- `/linear-status` — quick board view (complementary to `--status`)
+- `/work` — executes specced issues (uses milestones for gating, not phases)
+- `pk status` / `pk next` — quick board view (complementary to `--status`)

--- a/skills/pipekit-help/skill.md
+++ b/skills/pipekit-help/skill.md
@@ -54,8 +54,8 @@ Resolve the *latest* phase by mtime of `.vbw-planning/phases/*/PLAN.md`. Don't i
    ```
 5. If no rule matches, print:
    ```
-   ➜ Next: /linear-status
-     Why: state didn't match any known rule — start from the board view
+   ➜ Next: pk status
+     Why: state didn't match any known rule — start from the full board view
    ```
 
 ## Rules of engagement
@@ -78,8 +78,8 @@ Resolve the *latest* phase by mtime of `.vbw-planning/phases/*/PLAN.md`. Don't i
 ```
 
 ```
-➜ Next: /launch PROJ-247 --close
-  Why: VERIFICATION.md present and current branch matches PROJ-247
+➜ Next: pk ship
+  Why: /verify passed and current branch matches PROJ-247 — ready to push + open PR
 ```
 
 ## Customization

--- a/skills/pipekit-help/state-rules.md
+++ b/skills/pipekit-help/state-rules.md
@@ -26,8 +26,8 @@ The foundation contract (see `method.md` § Foundation Contract) is the set of a
 
 **Match:** All foundation-contract artifacts present AND no commits in the last 14 days on the current branch AND no `PLAN.md` / `REVIEW.md` / `VERIFICATION.md` markers in the latest phase.
 
-**Recommend:** `/start-session`
-**Why:** Foundation is intact and nothing is mid-flight — review past progress and capture session intentions before picking work. (Run `/startup --mode=inherited` if you want an explicit foundation audit first.)
+**Recommend:** `pk next`
+**Why:** Foundation is intact and nothing is mid-flight — `pk next` is the phase-aware entry point that groups Linear by status with per-group hints. (Run `/startup --mode=inherited` if you want an explicit foundation audit first.)
 
 ### 1d. Partial foundation — diagnose first
 
@@ -45,10 +45,10 @@ The foundation contract (see `method.md` § Foundation Contract) is the set of a
 
 ## 3. Verification done, ready to close
 
-**Match:** Latest phase has `VERIFICATION.md` AND no Linear `--close` has been recorded for the matching issue (heuristic: branch name contains a `PROJ-XXX` token AND most recent commit on this branch is post-VERIFICATION.md timestamp).
+**Match:** Latest phase has `VERIFICATION.md` AND no PR has been opened for the matching issue (heuristic: branch name contains a `PROJ-XXX` token AND most recent commit on this branch is post-VERIFICATION.md timestamp AND `gh pr list --head <branch>` returns empty).
 
-**Recommend:** `/launch <issue> --close`
-**Why:** QA passed; the only remaining step is the Pipekit close transition to UAT.
+**Recommend:** `pk ship`
+**Why:** QA passed; the only remaining step is push + open PR + Linear → UAT (`pk ship` does all three idempotently).
 
 ## 4. Plan reviewed but not executed
 
@@ -66,10 +66,10 @@ The foundation contract (see `method.md` § Foundation Contract) is the set of a
 
 ## 6. Issue Building, no plan yet
 
-**Match:** Branch is project-prefixed (`PROJ-XXX`) AND no `PLAN.md` exists for any phase referencing this issue AND Linear issue status (if checked) is "Building" AND inferred tier is Standard or Heavy.
+**Match:** Branch is project-prefixed (`PROJ-XXX`) AND no `PLAN.md` exists for any phase referencing this issue AND Linear issue status (if checked) is "In Progress" AND inferred tier is Standard or Heavy.
 
-**Recommend:** `/vbw:vibe --plan`
-**Why:** Issue is in Building but no plan has been generated yet. Start a fresh chat first (see method.md § Fresh-Chat Discipline).
+**Recommend:** `/work <issue>`
+**Why:** Issue is in worktree-and-branch state but no plan has been generated yet. `/work` does the verdict-gate planning then dispatches execution per `Backend:` config. Start a fresh chat first (see method.md § Fresh-Chat Discipline).
 
 ## 6b. Quick tier — direct to batch runner
 
@@ -96,22 +96,22 @@ The foundation contract (see `method.md` § Foundation Contract) is the set of a
 
 **Match:** Linear issue status is "Approved" AND no current branch matches the issue prefix.
 
-**Recommend:** `/launch PROJ-XXX`
-**Why:** Issue is human-approved and ready to enter Building.
+**Recommend:** `pk branch PROJ-XXX`
+**Why:** Issue is human-approved and ready to enter In Progress (`pk branch` creates the worktree + branch and transitions Linear). Then `cd` into the worktree and run `/work PROJ-XXX`.
 
 ## 10. Phase in flight, multiple candidates
 
 **Match:** Multiple Linear issues are in "Building" or "In Progress" simultaneously.
 
-**Recommend:** `/linear-status`
-**Why:** Multiple in-flight issues — pick the one to work on from the board view.
+**Recommend:** `pk status`
+**Why:** Multiple in-flight issues — `pk status` shows the full unscoped board so you can pick the one to work on.
 
 ## 11. Fallback
 
 **Match:** No prior rule matched.
 
-**Recommend:** `/linear-status`
-**Why:** State didn't match any known rule — start from the board view.
+**Recommend:** `pk status`
+**Why:** State didn't match any known rule — start from the full board view.
 
 ---
 

--- a/skills/pr-fix/skill.md
+++ b/skills/pr-fix/skill.md
@@ -390,4 +390,4 @@ If the PR has no linked Linear issue (no `<TEAM>-<N>` reference anywhere), skip 
 - `/code-review` — Lighter-weight review (no interactive discussion, no fixes)
 - `/security-review` — Comprehensive weekly security audit (full codebase, not PR-scoped)
 - `/commit` — For committing after manual fixes
-- `/g-promote-dev` — For promoting the branch after review passes
+- `pk ship` — Opens the feature → integration-branch PR; `pk promote` walks the chain to main

--- a/skills/release-changelog/skill.md
+++ b/skills/release-changelog/skill.md
@@ -186,7 +186,7 @@ $ /release-changelog --version v1.5.0 --from v1.4.1
 
 [TODO human: 1-2 sentence narrative lead summarizing the release theme]
 
-**`/spec-preflight` automates empirical pre-flight checks on specs** (closes #9). New skill verifies file paths, line refs, phase-detect baseline, Linear status, and dependency claims against reality. Read-only — never modifies the spec or transitions Linear. Slots between Spec Review Agent and `/launch`.
+**`/spec-preflight` automates empirical pre-flight checks on specs** (closes #9). New skill verifies file paths, line refs, phase-detect baseline, Linear status, and dependency claims against reality. Read-only — never modifies the spec or transitions Linear. Slots between Spec Review Agent and `pk branch`.
 
 **`/release-changelog` generates draft CHANGELOG entry from commits** (closes #10). New skill that parses `type(scope): subject` commits between two refs, buckets by section, and prints a draft entry to stdout. Human edits narrative + migration sections, then commits.
 
@@ -217,6 +217,6 @@ For consuming projects on v1.4.1:
 
 | Skill | Relationship |
 |-------|-------------|
-| `/end-session` | Writes session logs and updates `NEXT.md`. Independent of release work. |
+| `/pk-exit` | Writes the per-session narrative log to `Logs/Sessions/<date>_<HHMM>.md`. Independent of release work — this skill is per-release, `/pk-exit` is per-session. |
 | `/pipekit-update` | Pulls a tagged Pipekit version into a consumer project. The tag has to exist first — `/release-changelog` is part of the workflow that produces the tag. |
 | `/strategy-sync` | Closes the docs loop after a feature ships. Independent of Pipekit's own release flow, but conceptually similar (both convert "what shipped" into "what the doc says"). |

--- a/skills/review-plan/skill.md
+++ b/skills/review-plan/skill.md
@@ -81,8 +81,7 @@ or manually copy from your Pipekit checkout (templates/agents/plan-reviewer.md
 in older syncs, agents/plan-reviewer.md in current).
 
 Falling back to direct presentation: I'll show the PLAN.md structure
-and let you review manually. Note this is the same fallback /launch
-used to take when plan-reviewer was a phantom dependency.
+and let you review manually.
 ```
 
 ### Step 4 — Spawn the plan-reviewer agent
@@ -145,47 +144,19 @@ Based on the verdict:
 
 Always quote the agent's own Fast Path to Pass section verbatim — those are the concrete moves the user has to make.
 
-### Step 7 — NEXT.md update (with VBW active-plan deferral)
+### Step 7 — Next-step output
 
-Per the SOP `NEXT.md` schema in `sop/Skills_SOP.md`. Compose the intended file content with timestamp `{YYYY-MM-DD HH:MM local}` and writer `/review-plan`.
-
-Pointer logic:
+Emit an inline `➜ Next:` line in your terminal output. Pointer logic:
 
 - **Pass** → `/vbw:vibe --execute {phase-slug}`
 - **Revise** → `/vbw:vibe --execute {phase-slug}` (with note about non-blocking improvements)
 - **Block** → either `/vbw:vibe --plan {phase-slug}` (if Lead-revise scope) or `/02-light-spec-revise PROJ-XXX` (if spec/framing scope)
 
-Inline `➜ Next:` is **always emitted** to the terminal. The file write may be deferred — see below.
+Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
-#### Deferral check (v1.6.0+)
+### Step 8 — Pipeline state file
 
-Before writing `NEXT.md`, run the active-plan scope detection from `sop/Skills_SOP.md` § Deferral mechanism. `/review-plan` is the canonical case for deferral: it runs *inside* VBW's active-plan scope (the plan it just reviewed is the active plan), so VBW's file-guard hook will block a direct `NEXT.md` write unless the consuming project has adopted the `always_allow` allowlist (#12 Option B, upstream-coordinated).
-
-```bash
-ACTIVE_PLAN=""
-for plan in .vbw-planning/phases/*/[0-9]*-PLAN.md; do
-  [ -f "$plan" ] || continue
-  if grep -qE "^(files_modified:|## files_modified)" "$plan" 2>/dev/null; then
-    ACTIVE_PLAN="$plan"
-    break
-  fi
-done
-
-DEFER_NEXT_MD=0
-if [ -n "$ACTIVE_PLAN" ] && ! grep -q "NEXT\.md" "$ACTIVE_PLAN"; then
-  DEFER_NEXT_MD=1
-fi
-```
-
-If `DEFER_NEXT_MD=1`: resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR"`, write the queue file at `$STATE_DIR/pending-next-md.json` with the schema in the SOP. Mention briefly in your output: `"NEXT.md write deferred (VBW scope) — will apply on /end-session."`
-
-If `DEFER_NEXT_MD=0`: write `NEXT.md` directly at the project root.
-
-Inline `➜ Next:` and the eventual NEXT.md contents (whether written directly or via the queue) must match.
-
-#### Pipeline state file (v1.6.0+)
-
-After the verdict is delivered, resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR/pipeline-state"`, and write `$STATE_DIR/pipeline-state/<issue-id>.json` per the SOP schema (`stage: "review-plan"`, verdict, next_command, cwd, timestamp). Issue ID resolution mirrors Step 2's spec resolution; if no Linear ID, use the phase slug. The path is out-of-repo (v1.7.0+) so no hook block; write should always succeed.
+After the verdict is delivered, resolve `STATE_DIR=$(bash scripts/pipekit-state-dir.sh)`, `mkdir -p "$STATE_DIR/pipeline-state"`, and write `$STATE_DIR/pipeline-state/<issue-id>.json` per the SOP schema (`stage: "review-plan"`, verdict, cwd, timestamp). Issue ID resolution mirrors Step 2's spec resolution; if no Linear ID, use the phase slug. The path is out-of-repo so no hook block; write should always succeed.
 
 ---
 
@@ -216,7 +187,7 @@ Thoughts that mean "slow down on the review." Paired with `.claude/rules/pipekit
 
 | Skill | Relationship |
 |-------|-------------|
-| `/launch` | Validates Linear gates, then user runs `/vbw:vibe --plan`, then `/review-plan`. `/launch` no longer spawns plan-reviewer directly (Tier 1 / Option 3 split). |
+| `/work` (vbw backend) | Spawns `vbw-lead` to produce `PLAN.md`; the user then runs `/review-plan` between vbw-lead's output and vbw-dev's execution. `/work` does not spawn plan-reviewer directly. |
 | `/vbw:vibe --plan` | Produces the `PLAN.md` this skill reviews. |
 | `/vbw:vibe --execute` | Next step after Pass / Revise. |
 | `/02-light-spec-revise` | Route here when plan-reviewer's Block verdict points at spec-level issues (framing, missing AC, scope ambiguity). |
@@ -281,6 +252,4 @@ proceed to Dev with these two improvements applied during execution.
 ➜ Next: /vbw:vibe --execute rs-14-login-routes
    (apply the two non-blocking improvements during execution; verify-step
    sharpening can land in the same task commit)
-
-NEXT.md updated.
 ```

--- a/skills/roadmap-create/skill.md
+++ b/skills/roadmap-create/skill.md
@@ -293,9 +293,9 @@ When you encounter these situations, take the safer path:
 - **Untraceable requirements** → Every requirement should trace to a strategy doc section. If it doesn't, either the strategy docs need updating or the requirement is an orphan.
 - **Flat issue lists** → Create the full Linear hierarchy (Initiatives/Projects/Milestones). Issues without structure become unsortable quickly.
 
-## NEXT.md Output
+## Next-step output
 
-After roadmap creation completes, overwrite `NEXT.md` at the project root pointing to `/roadmap-review` (for validation) or `/phase-plan` (if validation already passed). See the NEXT.md convention in `sop/Skills_SOP.md`. Inline `➜ Next:` and `NEXT.md` content must match — emit them together.
+After roadmap creation completes, emit an inline `➜ Next:` line in your terminal output pointing to `/roadmap-review` (for validation) or `/phase-plan` (if validation already passed). Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
 ## Related
 

--- a/skills/spec-preflight/skill.md
+++ b/skills/spec-preflight/skill.md
@@ -5,7 +5,7 @@ description: Empirical pre-flight checks on a Linear issue's spec. Verifies file
 
 # Spec Preflight Skill
 
-You verify that the empirical claims in a Linear issue's spec match reality, *before* `/launch` consumes the spec. Spec Review Agent reviews narrative coherence; this skill reviews facts. The two are complementary — agent review catches "is the spec well-shaped?", `/spec-preflight` catches "is the spec still true?".
+You verify that the empirical claims in a Linear issue's spec match reality, *before* `pk branch <ID>` + `/work` consume the spec. Spec Review Agent reviews narrative coherence; this skill reviews facts. The two are complementary — agent review catches "is the spec well-shaped?", `/spec-preflight` catches "is the spec still true?".
 
 This skill is **read-only**: it never edits the spec, never transitions Linear status, never writes any project file. Output goes to stdout only. (A scratch file under `/tmp/` is acceptable for analysis state.)
 
@@ -18,13 +18,13 @@ Read `method.config.md` for project context (Linear team prefix, state IDs, proj
 
 ## When to use
 
-Between Spec Review Agent passing and `/launch`. The pipeline position:
+Between Spec Review Agent passing and `pk branch`. The pipeline position:
 
 ```
-/light-spec → Spec Review Agent → human approval → /spec-preflight → /launch
+/light-spec → Spec Review Agent → human approval → /spec-preflight → pk branch <ID> → /work
 ```
 
-For Quick-tier issues that skip agent review entirely, this skill is the only automated check before `/launch` — surface it in the Quick-tier template too.
+For Quick-tier issues that skip agent review entirely, this skill is the only automated check before `pk branch` — surface it in the Quick-tier template too.
 
 ## When NOT to use
 
@@ -91,7 +91,7 @@ A line range past EOF is a divergence — record `resolves: false`.
 
 #### 3c — phase-detect baseline
 
-Resolve `phase-detect.sh` using the same lookup chain as `/launch` Step 1.6 (since v1.4.1):
+Resolve `phase-detect.sh` using the same lookup chain as `/work` (which inherited it from the v1 `/launch` Step 1.6 logic):
 
 ```bash
 PHASE_DETECT=""
@@ -125,7 +125,7 @@ Re-fetch the issue (or reuse Step 1's payload if still in scope). Compare `state
 
 #### 3e — Dependencies
 
-For each `blocked_by` identifier (from `relations` and from any narrative claims in Step 2.5), call `mcp__linear-server__get_issue` and read `state.name`. Record `Done` / `<other>`. The pass criterion is "every blocker is Done"; anything else is a real gate failure that `/launch` Step 2 would also catch — surfacing it pre-launch saves a round trip.
+For each `blocked_by` identifier (from `relations` and from any narrative claims in Step 2.5), call `mcp__linear-server__get_issue` and read `state.name`. Record `Done` / `<other>`. The pass criterion is "every blocker is Done"; anything else is a real gate failure that `pk branch` / `/work` would also catch — surfacing it pre-flight saves a round trip.
 
 If the Linear MCP server times out or is unavailable on any individual fetch: record that specific dependency as `unverified — Linear API timeout` and continue. Do not fail the whole verdict on infrastructure flake. (See Graceful Degradation below.)
 
@@ -148,14 +148,14 @@ Verdict: {PASS | REVISE} — {one-line reason if REVISE}
 
 Verdict rules:
 
-- **PASS** — every category is `✓` or `n/a` (no claims of that type) or graceful-degradation `⚠ unverified` for phase-detect / Linear API. The user can proceed to `/launch` without manual gut-checking.
-- **REVISE** — at least one real divergence: missing file, unresolved line, phase-detect mismatch, status mismatch, or non-Done dependency. The user updates the spec (or resolves the blocker) before `/launch`.
+- **PASS** — every category is `✓` or `n/a` (no claims of that type) or graceful-degradation `⚠ unverified` for phase-detect / Linear API. The user can proceed to `pk branch <ID>` without manual gut-checking.
+- **REVISE** — at least one real divergence: missing file, unresolved line, phase-detect mismatch, status mismatch, or non-Done dependency. The user updates the spec (or resolves the blocker) before `pk branch`.
 
 When emitting REVISE, point at *where* in the spec the divergence sits — by AC number, by section heading, or by the claim text — so the human can edit surgically rather than re-reading the whole spec.
 
 ### Step 5 — Stop
 
-Print the verdict. Do nothing else. Do not call `/launch`. Do not transition Linear. Do not write `NEXT.md` (this skill doesn't move the pipeline forward; it gates the next move).
+Print the verdict. Do nothing else. Do not call `pk branch` or `/work`. Do not transition Linear. Do not write any project file (NEXT.md is retired in v2 anyway, but this skill writes nothing — it gates the next move).
 
 ## Graceful Degradation
 
@@ -185,7 +185,7 @@ Pre-flight checks for RS-87 (Standard tier):
   ✓ Linear status: Approved (matches spec)
   ✓ Dependencies: 2/2 Done
 
-Verdict: PASS — spec is empirically current. Proceed to /launch.
+Verdict: PASS — spec is empirically current. Proceed to pk branch RS-87.
 ```
 
 REVISE with a real divergence:
@@ -200,7 +200,7 @@ Pre-flight checks for RS-51 (Standard tier):
   ✓ Dependencies: 2/2 Done
 
 Verdict: REVISE — phase-detect baseline divergence at AC #1.
-Update the spec's "currently returns phase_count=0" line before /launch.
+Update the spec's "currently returns phase_count=0" line before pk branch.
 ```
 
 REVISE with infrastructure degradation plus a real divergence:
@@ -215,15 +215,15 @@ Pre-flight checks for RS-92 (Quick tier):
   ⚠ Dependencies: 1/2 verified — RS-89 Linear API timeout
 
 Verdict: REVISE — src/lib/old-auth.ts cited in §Technical Context no longer exists.
-Likely renamed during recent refactor; update the spec path before /launch.
+Likely renamed during recent refactor; update the spec path before pk branch.
 ```
 
 ## Rules of Engagement
 
-- **Read-only.** Never edit the spec. Never transition Linear. Never write `NEXT.md`. The only writes allowed are scratch files under `/tmp/` for parsing state.
+- **Read-only.** Never edit the spec. Never transition Linear. Never write any project file. The only writes allowed are scratch files under `/tmp/` for parsing state.
 - **No false confidence.** A graceful-degradation `⚠` is not a `✓`. The verdict surfaces what was unverified so the human can re-run later or accept the gap.
 - **Specific divergences.** When something fails, name *which* claim failed (AC #, section heading, file path, dependency identifier) — not just "phase-detect mismatch." The user shouldn't have to grep the spec to find what to fix.
-- **Don't recurse into `/launch`.** This skill ends at the verdict. The user invokes `/launch` themselves on PASS, or `/light-spec-revise` on REVISE.
+- **Don't recurse into the daily loop.** This skill ends at the verdict. The user invokes `pk branch <ID>` themselves on PASS (then `/work` from inside the worktree), or `/light-spec-revise` on REVISE.
 
 ## Relationship to Other Skills
 
@@ -232,4 +232,4 @@ Likely renamed during recent refactor; update the spec path before /launch.
 | `/light-spec` | Produces the spec this skill verifies. |
 | Spec Review Agent | Reviews narrative coherence. `/spec-preflight` reviews empirical claims — complementary, not redundant. |
 | `/light-spec-revise` | Where the user goes on REVISE if the spec body is the problem (most cases). |
-| `/launch` | Consumes specs that have passed `/spec-preflight`. `/launch` Step 1.6 also reads `phase-detect.sh`, but as a launch-time informational gate, not as a spec-vs-reality check. |
+| `pk branch` + `/work` | The v2 daily loop consumes specs that have passed `/spec-preflight`. `/work` also reads `phase-detect.sh` (inherited from v1's `/launch` Step 1.6 logic), but as a runtime informational gate, not as a spec-vs-reality check. |

--- a/skills/startup/skill.md
+++ b/skills/startup/skill.md
@@ -137,11 +137,11 @@ Foundation OK.
   Current phase: {phase name from PHASES.md}
   Issues in flight: {N from PHASES.md current phase}
 
-➜ Next: /start-session  (review past progress and capture intentions)
+➜ Next: pk next  (phase-aware: groups Linear by status with per-group hints)
    or:   /light-spec PROJ-XXX  (begin speccing an issue from the current phase)
 ```
 
-Read `.vbw-planning/PHASES.md` to extract the current phase name and issue list. If multiple issues are in flight (status In Progress / Building), recommend `/linear-status` instead so the user can pick.
+Read `.vbw-planning/PHASES.md` to extract the current phase name and issue list. If multiple issues are in flight (status In Progress / Building), recommend `pk status` instead so the user sees the full board.
 
 **If anything is missing:**
 
@@ -157,15 +157,15 @@ Run /pipekit-help for a state-aware next-step recommendation.
 
 List every missing artifact with its retrofit suggestion. Do **not** auto-run any retrofit skill — present options and let the user choose.
 
-### Emit `NEXT.md`
+### Emit inline `➜ Next:`
 
-Whether the check passes or fails, write `NEXT.md` at the project root with the recommended next command and a one-line reason (matching the on-screen `➜ Next:`). See `sop/Skills_SOP.md` § NEXT.md convention.
+Whether the check passes or fails, emit an inline `➜ Next:` line in your terminal output with the recommended next command and a one-line reason. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear once the foundation contract is satisfied.
 
 ---
 
 ## Mode Routing
 
-`/startup` accepts a `--mode={greenfield,brownfield,inherited}` flag. If absent, auto-detect by inspecting project state, then **always confirm with the user** before proceeding (same pattern as tier resolution in `/launch` Step 1.5 — never auto-pick).
+`/startup` accepts a `--mode={greenfield,brownfield,inherited}` flag. If absent, auto-detect by inspecting project state, then **always confirm with the user** before proceeding (same pattern as tier resolution in `/work` — never auto-pick).
 
 ### Auto-detection rules
 
@@ -180,7 +180,7 @@ Evaluate top-down; first match wins:
 
 ### Confirmation prompt
 
-Mirror the wording from `skills/launch/skill.md` Step 1.5:
+Mirror the wording from `skills/work/skill.md` Step 1.5:
 
 ```
 Auto-detected entry mode: {mode}
@@ -275,7 +275,7 @@ Walk through tech stack decisions from `STARTUP.md` Step 2:
 
 This decision determines:
 - Which environments to configure in Step 4
-- Which promotion skills to create in Step 9 (no `/g-promote-beta` needed for two-tier)
+- Which `Ship environments` value to set in `method.config.md` (`dev,main` for two-tier; `dev,beta,main` for three-tier — `pk promote` walks the chain)
 - How Linear status transitions work on merge (see `sop/Git_and_Deployment.md`)
 
 **Output:** Tech stack + git architecture decisions recorded in `method.config.md`
@@ -581,7 +581,7 @@ To tell skeleton vs. populated: check for Linear issue IDs or strategy doc refer
 **Critical reminder:** Do NOT run `/vbw:vibe` as an alternative to `/roadmap-create`. VBW's own output after `/vbw:init` suggests it as a path — but in Pipekit it's a dead end. The Pipekit flow is:
 
 ```
-/vbw:init (skeleton) → /roadmap-create (merges + populates Linear) → /phase-plan → /light-spec → /launch → VBW execution
+/vbw:init (skeleton) → /roadmap-create (merges + populates Linear) → /phase-plan → /light-spec → pk branch → /work (vbw or native backend)
 ```
 
 **Output:** ROADMAP.md populated (merged with VBW's phase structure), Linear board seeded with initiatives, projects, milestones, and issues
@@ -716,4 +716,4 @@ Next steps:
   This applies to `method.config.md`, `CLAUDE.md`, strategy docs, and any file where alternatives were presented. A document should never look like two conflicting decisions are both active.
 - **App code lives in `src/`.** All application code (framework, components, API routes, etc.) goes in a `src/` subdirectory. The project root is reserved for Pipekit files (`method.config.md`, `concept-brief.md`, `project-definition.md`, `Strategy/`, `.vbw-planning/`, `method/`, `.claude/`), config files (`.gitignore`, `.env`, `package.json`, `tsconfig.json`), and scripts. This keeps Pipekit's methodology layer cleanly separated from the application. When initializing a framework (Next.js, Remix, etc.), configure it to use `src/` as the source directory.
 - **Resumable.** The tracker + artifact checks make `/startup` fully resumable across sessions. A new session reads the tracker and picks up exactly where the last one stopped.
-- **Emit `NEXT.md` after every step.** When completing any step (including mid-`/startup` step transitions), overwrite `NEXT.md` at the project root with the next command the user should run and why. See the NEXT.md convention in `sop/Skills_SOP.md`. Inline `➜ Next:` and `NEXT.md` content must match — they're emitted together.
+- **Emit inline `➜ Next:` after every step.** When completing any step (including mid-`/startup` step transitions), emit an inline `➜ Next:` line in your terminal output with the next command the user should run and why. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear once the foundation contract is satisfied.

--- a/skills/task-processor/skill.md
+++ b/skills/task-processor/skill.md
@@ -48,7 +48,7 @@ Ask which task to work on.
 - Read full issue description for requirements
 - **Check for spec links:** Look for `**Spec:**` or `**Linked spec:**` lines in the description
   - If spec link exists → read the spec files before executing
-- Create a worktree for the work (use `/branch` skill or manually branch from `dev`)
+- Create a worktree for the work (`pk branch <ID>` for Linear-issue-based work, or `git worktree add` directly for non-Linear work)
 - Execute actions based on issue description + spec (if any)
 - Validate against success criteria
 - When done, ask user: move to **Done** or **UAT**?
@@ -74,6 +74,6 @@ Read all state IDs from your project's `method.config.md` under "Workflow State 
 
 - Linear issue workflow: `/linear PROJ-123` — full end-to-end issue workflow
 - Parallel batch execution: `/linear-todo-runner` — rolling queue with up to 4 concurrent agents
-- Branch skill: `/branch` — creates worktree + branch
-- Start/end session: `/start-session`, `/end-session`
+- Branch + worktree: `pk branch <ID>` — creates worktree + branch + Linear → In Progress
+- Session log: `/pk-exit` — narrative session log to `Logs/Sessions/<date>_<HHMM>.md` (last command of every Claude Code session)
 - Linear workspace: {Linear workspace URL from method.config.md}


### PR DESCRIPTION
## Summary

PR 6 of the pre-Piper-migration scrub series. **Stacked on PR #46** (set base accordingly). Final cleanup: skill files with stale cross-references to retired v1 skills in their prose, "Related" sections, and (for `/pipekit-help`) actual recommendation rules.

10 atomic commits, one per skill. Net diff: **+53 / -53** (mostly 1:1 token swaps, a handful of section restructures).

## Per-commit changes

1. **`skill:brainstorm-review`** — Heavy tier route: /launch → /work (Backend: vbw)
2. **`skill:strategy-sync`** — /end-session changelog cross-refs → v2 changelog ownership split (/release-changelog for releases, /pk-exit for sessions, manual for in-app Strategy/Changelog.md)
3. **`skill:brainstorm`** — 3× /launch tier mappings → /work (tier inference moved to /work)
4. **`skill:task-processor`** — /branch + /start-session + /end-session → pk branch <ID> + /pk-exit (no /start-session counterpart in v2)
5. **`skill:linear-todo-runner`** — /linear-status + /branch cross-refs → pk status / pk next + pk branch (pairs with PR #46's functional fix on this same skill)
6. **`skill:release-changelog`** — example output and Related table: /launch → pk branch; /end-session → /pk-exit
7. **`skill:linear`** — manual hands-on workflow updated: /branch → pk branch; /g-promote-* → pk ship + pk promote; /start-session, /end-session → /pk-exit. Added explicit pointer to v2 daily loop (this skill is the manual alternative).
8. **`skill:spec-preflight`** — biggest cross-ref fix. Spec-preflight is positioned as the gate before the spec consumer; in v1 the consumer was /launch, in v2 it's pk branch + /work. 11 references updated across the skill body, output examples, Rules of Engagement, and Related table. Two intentional v1 references kept where they explain provenance ("inherited from v1 /launch Step 1.6 logic").
9. **`skill:pr-fix`** — /g-promote-dev cross-ref → pk ship + pk promote
10. **`skill:pipekit-help`** ⚡ **functionally important** — this skill is the "what should I run next?" oracle. Its recommendation rules baked in v1 skill names, so every fallback path was telling users to run retired skills. Updated:
   - Rule 1c: /start-session → pk next (phase-aware entry point)
   - Rule 3 (verification done, ready to close): /launch <issue> --close → pk ship; matcher updated to "no PR opened" instead of "no Linear --close recorded"
   - Rule 6 (issue Building, no plan): matcher updated from "Building" to "In Progress" (v2 status); recommendation /vbw:vibe --plan → /work <issue>
   - Rule 9 (Approved issue): /launch PROJ-XXX → pk branch PROJ-XXX
   - Rule 10 + 11 (multi-issue + fallback): /linear-status → pk status
   - skill.md example outputs updated to match

## After PR 5 + PR 6 land

Every active `skills/*/skill.md` file speaks v2 vocabulary. The only v1 references remaining anywhere in the repo are:

- `archive/v1-skills/**` (intentionally preserved)
- `CHANGELOG.md` (historical)
- A few intentional historical-context callouts (e.g., `pk-exit/skill.md` explains v1 prior art; `spec-preflight` cites "inherited from v1 /launch Step 1.6 logic"; `work/skill.md` has a v1↔v2 comparison table)

## Known follow-up still tracked

- `scripts/pipekit-next-step-nudge.sh` — hardcoded v1 trigger regex. Stop-hook nudge currently won't fire on v2 commands. Separate script-change PR.

## Test plan

- [ ] `grep -rnE '/(branch|launch|...)\b' skills/` returns only intentional historical-context matches
- [ ] `/pipekit-help` recommendation rules all reference active v2 commands (manually verify each rule's "Recommend:" line points at a skill or pk subcommand that exists)
- [ ] No skill file recommends a retired skill in its example output

🤖 Generated with [Claude Code](https://claude.com/claude-code)