### PR TITLE
fix(skills): trigger Linear Spec Review Agent via MCP

### DIFF
--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -153,40 +153,26 @@ Before presenting to the user, audit every section:
 
 Ask the user: _"Want Linear's Spec Review Agent to review this before planning?"_
 
-**Do NOT post the trigger comment via `mcp__linear-server__save_comment`.** The MCP tool only accepts a markdown string body; it cannot create Linear's structured mention node. A plaintext `@linear` renders as visible text but carries no mention metadata, so the Spec Review Agent never receives the event and never runs.
+If yes, post the trigger comment directly via `mcp__linear-server__save_comment`. The body **must start with the literal text `@linear`** — Linear's server resolves that token into a real mention of the Linear app user (displayName: `linear`, ID `1793645b-7fa5-4c31-8f9b-0c3685a9e185`), which fires the agent. Verified 2026-05-03 on RS-32.
 
-Verified twice:
-- 2026-04-19: MCP-posted `@linear` comments on RS-5 and RS-6 produced no agent response; manual UI re-triggers worked within minutes.
-- 2026-04-21: URL-mention auto-conversion (posting `https://linear.app/<workspace>/profiles/<handle>` in the body, with or without markdown link wrapping) also fails via the MCP — URLs render as plain links, not mention pills. Auto-conversion is a UI-editor feature that does not apply to API-posted content.
+Tool call:
 
-Instead, give the user a ready-to-paste trigger and ask them to run it in Linear's UI, where `@` opens the mention picker and inserts a real mention node.
+```
+mcp__linear-server__save_comment({
+  issueId: "PROJ-XXX",
+  body: "@linear review this spec using Spec Review Agent (v5).\n\nAssess whether it is safe and ready for VBW planning. Focus on planning readiness, scope clarity, authority/source of truth, edge cases, financial correctness if relevant, and decomposition readiness.\n\nReturn:\n\nVerdict: Pass or Revise\nRecommended Flag: Blocked, Quick Win, Spec: Needed, Spec: Pass, or Spec: Revise\nReadiness Score out of 10\nBlocking Issues\nNon-Blocking Improvements\nFast Path to Pass\nDecomposition Readiness: Yes or No\nFinal Recommendation\n\nThen update the issue description by replacing the existing ## Agent Review section with the new review."
+})
+```
 
-Output to the user:
+Tell the user: _"Trigger posted. The agent usually responds within a minute. Run `/light-spec-revise PROJ-XXX` to apply feedback surgically, or go straight to planning if the verdict is Pass."_
 
-> Open [PROJ-XXX] in Linear and paste this as a new comment. Type `@` and pick **Linear** from the picker (don't just type the characters `@linear` — the mention has to be a structured node for the agent to fire).
->
-> ```
-> @linear review this spec using Spec Review Agent (v5).
->
-> Assess whether it is safe and ready for VBW planning. Focus on planning readiness, scope clarity, authority/source of truth, edge cases, financial correctness if relevant, and decomposition readiness.
->
-> Return:
->
-> Verdict: Pass or Revise
-> Recommended Flag: Blocked, Quick Win, Spec: Needed, Spec: Pass, or Spec: Revise
-> Readiness Score out of 10
-> Blocking Issues
-> Non-Blocking Improvements
-> Fast Path to Pass
-> Decomposition Readiness: Yes or No
-> Final Recommendation
->
-> Then update the issue description by replacing the existing ## Agent Review section with the new review.
-> ```
->
-> Once the agent posts its review (usually within a minute), run `/light-spec-revise PROJ-XXX` to apply its feedback surgically (handles stalemate loops), or go straight to planning mode if the verdict is Pass.
+**What does NOT work** (don't fall back to these):
 
-**Future alternative (unverified):** Linear shipped `agentSessionCreateOnComment` and `agentSessionCreateOnIssue` GraphQL mutations in March 2026 for programmatic agent-session invocation. These would bypass the mention-node requirement entirely but require a direct GraphQL call with `LINEAR_API_KEY` — no MCP tool exposes them yet. Not wired up here; manual paste remains primary until this is tested against Linear's built-in Spec Review Agent.
+- URL-form mention (`https://linear.app/<workspace>/profiles/linear`) — renders as a plain hyperlink, no mention chip, agent does not fire.
+- `mcp__linear-server__save_issue` with `delegate: "Linear"` — errors: _"Delegating to Linear requires the Coding Agent to be enabled."_ (Coding Agent ≠ workspace AI skills.)
+- Editing the issue description — the agent does not auto-watch description changes.
+
+**Caveat:** if `@linear` text stops firing the agent in the future, suspect a Linear product change. Re-test both the URL-form and `@linear`-text paths before assuming either is permanently broken, and update this phase + the reference memory accordingly.
 
 ### Phase 7 — VBW Ingestion Pointer
 

--- a/skills/02-light-spec-revise/skill.md
+++ b/skills/02-light-spec-revise/skill.md
@@ -20,7 +20,7 @@ Apply **only** the fixes the agent asked for, preserving everything else. Detect
 ## When to Use
 
 - The spec has already been published (via `/light-spec` Phase 5).
-- The Spec Review Agent has posted at least one review comment (via the manual-paste trigger from `/light-spec` Phase 6).
+- The Spec Review Agent has posted at least one review comment (via the MCP trigger from `/light-spec` Phase 6).
 - You want to incorporate that feedback without rewriting the spec from scratch.
 
 ## When NOT to Use
@@ -181,13 +181,14 @@ Do not proceed to Phase 6/7 until the user chooses.
 
 ### Phase 6 — Act on stalemate / override / manual choices
 
-- **Post nudge (option 2)**: draft a short comment (under 50 words) pointing at the specific line in the description that addresses the stalemate blocker. Output it for the user to **paste manually in Linear's UI** — do NOT post via `mcp__linear-server__save_comment` (plaintext `@linear` doesn't trigger the agent; see `/light-spec` Phase 6 for the full rationale). Format:
+- **Post nudge (option 2)**: draft a short comment (under 50 words) pointing at the specific line in the description that addresses the stalemate blocker. Post it via `mcp__linear-server__save_comment` — the body MUST start with the literal text `@linear` (see `/light-spec` Phase 6 for why). Format:
 
-  > Open the Linear issue and paste this as a new comment. Type `@` and pick **Linear** from the picker.
-  >
-  > ```
-  > @linear this blocker has been addressed in the description — see the [section name] section where [specific line or text]. Please re-review.
-  > ```
+  ```
+  mcp__linear-server__save_comment({
+    issueId: "PROJ-XXX",
+    body: "@linear this blocker has been addressed in the description — see the [section name] section where [specific line or text]. Please re-review."
+  })
+  ```
 
 - **Override (option 3)**: append a note to the `## Agent Review` section of the description documenting that the latest verdict is stale. Include:
   - Date of the stale review being overridden.
@@ -245,7 +246,7 @@ Do **not** apply Non-Blocking Improvements silently or in bulk.
 
    Omit sub-sections that had zero entries.
 
-3. Offer to re-trigger the Spec Review Agent using the same manual-paste pattern as `/light-spec` Phase 6. Output the ready-to-paste trigger comment and remind the user: _"Paste in Linear's UI, not via MCP — the mention has to be a structured node for the agent to fire."_
+3. Offer to re-trigger the Spec Review Agent. If the user agrees, post via `mcp__linear-server__save_comment` with body starting `@linear` (see `/light-spec` Phase 6 for the full pattern).
 
 ### Phase 10 — Next-step output
 
@@ -276,7 +277,6 @@ The skill MUST NEVER:
 - Rewrite sections the agent did not flag.
 - Delete user commentary from the `## Agent Review` section.
 - Apply Non-Blocking Improvements without explicit per-item user approval.
-- Post `@linear` trigger comments via `mcp__linear-server__save_comment` (the MCP cannot create structured mention nodes; see `/light-spec` Phase 6).
 - Proceed past Phase 5 without user choice.
 
 ## Related Skills


### PR DESCRIPTION
## Summary
- Verified 2026-05-03 (RS-32): a comment posted via `mcp__linear-server__save_comment` whose body starts with literal `@linear` resolves into a real mention of the Linear app user and fires the Spec Review Agent. Prior memory that the trigger was UI-only was wrong.
- `/01-light-spec` Phase 6 and `/02-light-spec-revise` (Phase 5 prereq, Phase 6 option 2, Phase 9.3, Output Contract) all switched from "ready-to-paste body for the user" to direct MCP posting.
- Documents the paths that do NOT work (URL-form mention, `save_issue delegate: "Linear"`, description edits) so we don't re-try them, plus a re-test caveat if Linear changes behavior.

## Test plan
- [ ] Sync into rs-vault via `scripts/sync-method.sh` and run `/light-spec` against a fresh test issue end-to-end
- [ ] Confirm the agent fires from the MCP-posted trigger (verify in Linear UI within ~1 min)
- [ ] Run `/light-spec-revise` Phase 9.3 re-trigger path and confirm same fire behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)