### PR TITLE
feat(pk+skills): pk spec-cycle + /01 cycle loop

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -15,6 +15,7 @@
 #   pk verify               — light verify (run test cmd from method.config.md)
 #   pk promote              — dev → main batch promote (multi-tier projects)
 #   pk delegate <ID> <txt>  — post @Linear-mentioned comment to delegate work
+#   pk spec-cycle <ID>      — trigger Spec Review Agent v5, poll, dispatch on verdict
 #
 # Linear access: GraphQL via $LINEAR_API_KEY (env var name configurable in
 # method.config.md → "Linear API key env var"). If absent, scripts that need
@@ -1057,6 +1058,156 @@ cmd_delegate() {
   pk_linear_comment "$id" "$body"
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# spec-cycle: trigger Linear Spec Review Agent v5, poll for verdict, dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Exit codes:
+#   0 — verdict parsed (Pass: state transitioned to "Approved" and printed
+#                       Revise: instruction printed for caller to invoke /02)
+#   1 — preflight failure (wrong state, stalemate cap hit, timeout, malformed)
+#   2 — infrastructure failure (Linear API error)
+#
+# stdout (machine-readable last line — callers may parse):
+#   VERDICT: Pass
+#   VERDICT: Revise
+#   VERDICT: Stalemate
+#   VERDICT: Timeout
+#   VERDICT: Malformed
+
+PK_LINEAR_AGENT_DISPLAY_NAME="linear"
+
+pk_linear_comments() {
+  local id="$1"
+  local q='query($id: String!) { issue(id: $id) { comments(orderBy: createdAt) { nodes { id body createdAt user { displayName } } } } }'
+  pk_linear_gql "$q" "$(jq -n --arg id "$id" '{id:$id}')" \
+    | jq -r '.data.issue.comments.nodes // []'
+}
+
+pk_spec_cycle_agent_count() {
+  local id="$1"
+  pk_linear_comments "$id" \
+    | jq --arg name "$PK_LINEAR_AGENT_DISPLAY_NAME" \
+        '[.[] | select(.user.displayName == $name)] | length'
+}
+
+pk_spec_cycle_latest_agent_body_since() {
+  local id="$1" since="$2"
+  pk_linear_comments "$id" \
+    | jq -r --arg name "$PK_LINEAR_AGENT_DISPLAY_NAME" --arg since "$since" '
+        [.[] | select(.user.displayName == $name and .createdAt > $since)]
+        | sort_by(.createdAt) | last // empty | .body // empty
+      '
+}
+
+pk_spec_cycle_trigger_body() {
+  cat <<'EOF'
+@linear review this spec using Spec Review Agent (v5).
+
+Assess whether it is safe and ready for VBW planning. Focus on planning readiness, scope clarity, authority/source of truth, edge cases, financial correctness if relevant, and decomposition readiness.
+
+Return:
+
+Verdict: Pass or Revise
+Recommended Flag: Blocked, Quick Win, Spec: Needed, Spec: Pass, or Spec: Revise
+Readiness Score out of 10
+Blocking Issues
+Non-Blocking Improvements
+Fast Path to Pass
+Decomposition Readiness: Yes or No
+Final Recommendation
+
+Then update the issue description by replacing the existing ## Agent Review section with the new review.
+EOF
+}
+
+cmd_spec_cycle() {
+  local id="${1:-}"
+  if [ -z "$id" ]; then
+    echo "Usage: pk spec-cycle <ISSUE-ID>" >&2
+    echo "  Trigger Spec Review Agent v5, poll for verdict, dispatch." >&2
+    return 1
+  fi
+
+  local ready_state approved_state
+  ready_state=$(pk_config "Spec ready state" "Specced")
+  approved_state=$(pk_config "Spec approved state" "Approved")
+
+  # 1. Validate state.
+  local state_q='query($id: String!) { issue(id: $id) { id state { name } } }'
+  local resp current_state
+  resp=$(pk_linear_gql "$state_q" "$(jq -n --arg id "$id" '{id:$id}')") || return 2
+  current_state=$(echo "$resp" | jq -r '.data.issue.state.name // empty')
+  if [ -z "$current_state" ]; then
+    echo "ERROR: issue $id not found" >&2
+    return 1
+  fi
+  if [ "$current_state" != "$ready_state" ]; then
+    echo "ERROR: $id is in '$current_state', not '$ready_state'." >&2
+    echo "  Run /01-light-spec $id first to publish a spec." >&2
+    return 1
+  fi
+
+  # 2. Stalemate guard.
+  local prior_count
+  prior_count=$(pk_spec_cycle_agent_count "$id")
+  if [ "$prior_count" -ge 3 ]; then
+    echo "STALEMATE: $id has $prior_count prior agent reviews." >&2
+    echo "  Run /02-light-spec-revise $id and use the override path." >&2
+    echo "VERDICT: Stalemate"
+    return 1
+  fi
+
+  # 3. Capture cutoff timestamp and post trigger.
+  local since
+  since=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+  echo "→ posting Spec Review Agent v5 trigger on $id (review #$((prior_count + 1)) of 3)"
+  pk_linear_comment "$id" "$(pk_spec_cycle_trigger_body)" || return 2
+
+  # 4. Poll: 30s × 10 = 5 min cap.
+  local attempts=10 sleep_s=30 i=0 body=""
+  echo "→ polling for verdict (cap 5 min, every ${sleep_s}s)"
+  while [ $i -lt $attempts ]; do
+    sleep $sleep_s
+    body=$(pk_spec_cycle_latest_agent_body_since "$id" "$since")
+    if [ -n "$body" ]; then break; fi
+    i=$((i + 1))
+    printf "."
+  done
+  echo
+  if [ -z "$body" ]; then
+    echo "TIMEOUT: no agent response after 5 min. Check Linear UI." >&2
+    echo "VERDICT: Timeout"
+    return 1
+  fi
+
+  # 5. Parse Verdict line.
+  local verdict
+  verdict=$(echo "$body" | grep -iE '^Verdict:' | head -1 \
+    | sed -E 's/^Verdict:[[:space:]]*//I; s/[[:space:]]+$//')
+  case "$verdict" in
+    Pass|pass|PASS)
+      echo "✓ verdict: Pass"
+      pk_linear_set_state "$id" "$approved_state" || return 2
+      echo
+      echo "  ➜ next: pk branch $id"
+      echo "VERDICT: Pass"
+      ;;
+    Revise|revise|REVISE)
+      echo "✗ verdict: Revise"
+      echo
+      echo "  ➜ next: /02-light-spec-revise $id"
+      echo "VERDICT: Revise"
+      ;;
+    *)
+      echo "WARN: could not parse verdict from agent comment." >&2
+      echo "  Inspect the comment manually on Linear." >&2
+      echo "VERDICT: Malformed"
+      return 1
+      ;;
+  esac
+}
+
 cmd_install() {
   local force=false
   while [ $# -gt 0 ]; do
@@ -1143,6 +1294,7 @@ Subcommands:
   pk verify                       Run the project's pre-deploy gate
   pk promote [--stash|--take-remote]  dev → main batch promote (flags resolve local-edit conflicts with incoming dev)
   pk delegate <ID> <prompt>       Post an @Linear-mentioned comment to invoke Linear Agent
+  pk spec-cycle <ID>              Trigger Spec Review Agent v5, poll, dispatch on verdict
   pk doctor                       Diagnose v2 setup (config, env, deps)
   pk init                         Walkthrough config check + setup hints
   pk install [--force]            Symlink pk onto \$PATH (so 'pk' replaces './bin/pk')
@@ -1288,6 +1440,7 @@ main() {
     verify)   cmd_verify "$@" ;;
     promote)  cmd_promote "$@" ;;
     delegate) cmd_delegate "$@" ;;
+    spec-cycle) cmd_spec_cycle "$@" ;;
     doctor)   cmd_doctor "$@" ;;
     init)     cmd_init "$@" ;;
     install)  cmd_install "$@" ;;

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -151,6 +151,8 @@ Keys consumed by `bin/pk` and the `/work` + `/verify` skills. All have sensible 
 | **Ship environments** | comma-separated list, ordered | `dev,main` | `pk ship --env=<name>` (multi-env projects only) |
 | **Linear API key env var** | name, e.g. `LINEAR_API_KEY` | `LINEAR_API_KEY` | `pk *` (Linear API access) |
 | **Migration dir** | e.g. `supabase/migrations/` | (none) | `/pr-security-review` (locate migrations to audit) |
+| **Spec ready state** | Linear state name | `Specced` | `pk spec-cycle` (refuses to trigger if issue is in any other state) |
+| **Spec approved state** | Linear state name | `Approved` | `pk spec-cycle` (transitions issue to this state on a Pass verdict) |
 
 ### Example (rs-vault)
 

--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -149,30 +149,63 @@ Before presenting to the user, audit every section:
    - `labels`: add `spec` label
 2. Store the issue ID for reference.
 
-### Phase 6 — Optional: Linear Agent Review
+### Phase 6 — Spec Review Cycle (automated)
 
-Ask the user: _"Want Linear's Spec Review Agent to review this before planning?"_
+Ask the user: _"Run Linear's Spec Review Agent now? (Y/n)"_ — default yes.
 
-If yes, post the trigger comment directly via `mcp__linear-server__save_comment`. The body **must start with the literal text `@linear`** — Linear's server resolves that token into a real mention of the Linear app user (displayName: `linear`, ID `1793645b-7fa5-4c31-8f9b-0c3685a9e185`), which fires the agent. Verified 2026-05-03 on RS-32.
+If they decline, skip to Phase 7. If yes, run the cycle below. The cycle calls `pk spec-cycle`, which owns the agent trigger, the polling, and the state transition on Pass — so this skill never posts the `@linear` comment directly.
 
-Tool call:
+**Cycle (max 3 passes):**
 
 ```
-mcp__linear-server__save_comment({
-  issueId: "PROJ-XXX",
-  body: "@linear review this spec using Spec Review Agent (v5).\n\nAssess whether it is safe and ready for VBW planning. Focus on planning readiness, scope clarity, authority/source of truth, edge cases, financial correctness if relevant, and decomposition readiness.\n\nReturn:\n\nVerdict: Pass or Revise\nRecommended Flag: Blocked, Quick Win, Spec: Needed, Spec: Pass, or Spec: Revise\nReadiness Score out of 10\nBlocking Issues\nNon-Blocking Improvements\nFast Path to Pass\nDecomposition Readiness: Yes or No\nFinal Recommendation\n\nThen update the issue description by replacing the existing ## Agent Review section with the new review."
-})
+pass = 1
+loop:
+  bash: pk spec-cycle PROJ-XXX
+  read pk's last "VERDICT: <X>" line and exit code
+
+  case VERDICT:
+    Pass       → done. pk has set the issue state to the configured
+                 "Spec approved state" (default: Approved). Tell the user:
+                   "✓ Spec approved on pass {pass}. ➜ next: pk branch PROJ-XXX"
+                 EXIT.
+
+    Revise     → invoke /02-light-spec-revise PROJ-XXX.
+
+                 Pass-aware confirmation:
+                   - pass == 1: auto-invoke. No prompt.
+                   - pass >= 2: show the agent's blocker count and readiness
+                     score, then prompt: "Continue to /02? [Y/n/o]"
+                       Y → invoke /02
+                       n → exit, leave issue in Specced
+                       o → invoke /02 with override directive (the user wants
+                           to override the agent verdict, not patch the spec)
+
+                 After /02 returns, increment pass and loop.
+
+    Stalemate  → pk's 3-comment guard fired before triggering. Tell the user:
+                   "Agent already reviewed 3x — likely stalemate. Run
+                    /02-light-spec-revise PROJ-XXX with the override path."
+                 EXIT.
+
+    Timeout    → no agent response in 5 min. Tell the user:
+                   "Agent didn't respond. Inspect Linear UI; rerun
+                    /01-light-spec PROJ-XXX when ready."
+                 EXIT.
+
+    Malformed  → tell the user the agent comment couldn't be parsed and
+                 point them at Linear UI. EXIT.
+
+  if pass == 3 and verdict was Revise:
+    Tell the user: "3 passes complete. /02 has the override path if the
+    agent is stuck — rerun /02-light-spec-revise PROJ-XXX."
+    EXIT.
+
+  pass += 1
 ```
 
-Tell the user: _"Trigger posted. The agent usually responds within a minute. Run `/light-spec-revise PROJ-XXX` to apply feedback surgically, or go straight to planning if the verdict is Pass."_
+**Why `pk spec-cycle` and not an inline MCP comment:** centralizes the Linear-agent trigger format in one place (so a Linear product change is one fix, not many), keeps the polling out of Claude's context window, and matches the rest of the `pk` CLI surface.
 
-**What does NOT work** (don't fall back to these):
-
-- URL-form mention (`https://linear.app/<workspace>/profiles/linear`) — renders as a plain hyperlink, no mention chip, agent does not fire.
-- `mcp__linear-server__save_issue` with `delegate: "Linear"` — errors: _"Delegating to Linear requires the Coding Agent to be enabled."_ (Coding Agent ≠ workspace AI skills.)
-- Editing the issue description — the agent does not auto-watch description changes.
-
-**Caveat:** if `@linear` text stops firing the agent in the future, suspect a Linear product change. Re-test both the URL-form and `@linear`-text paths before assuming either is permanently broken, and update this phase + the reference memory accordingly.
+**State preconditions:** `pk spec-cycle` refuses to run if the issue is not in the configured "Spec ready state" (default: `Specced`). Phase 5 of this skill sets that state, so the precondition holds on entry.
 
 ### Phase 7 — VBW Ingestion Pointer
 

--- a/skills/02-light-spec-revise/skill.md
+++ b/skills/02-light-spec-revise/skill.md
@@ -181,7 +181,7 @@ Do not proceed to Phase 6/7 until the user chooses.
 
 ### Phase 6 — Act on stalemate / override / manual choices
 
-- **Post nudge (option 2)**: draft a short comment (under 50 words) pointing at the specific line in the description that addresses the stalemate blocker. Post it via `mcp__linear-server__save_comment` — the body MUST start with the literal text `@linear` (see `/light-spec` Phase 6 for why). Format:
+- **Post nudge (option 2)**: draft a short comment (under 50 words) pointing at the specific line in the description that addresses the stalemate blocker. Post it via `mcp__linear-server__save_comment` — the body MUST start with the literal text `@linear`. Format:
 
   ```
   mcp__linear-server__save_comment({
@@ -189,6 +189,8 @@ Do not proceed to Phase 6/7 until the user chooses.
     body: "@linear this blocker has been addressed in the description — see the [section name] section where [specific line or text]. Please re-review."
   })
   ```
+
+  Note: this is a targeted nudge, not a full re-review. For a full re-review, exit this skill and run `pk spec-cycle PROJ-XXX` — that's the canonical re-trigger path.
 
 - **Override (option 3)**: append a note to the `## Agent Review` section of the description documenting that the latest verdict is stale. Include:
   - Date of the stale review being overridden.
@@ -246,7 +248,7 @@ Do **not** apply Non-Blocking Improvements silently or in bulk.
 
    Omit sub-sections that had zero entries.
 
-3. Offer to re-trigger the Spec Review Agent. If the user agrees, post via `mcp__linear-server__save_comment` with body starting `@linear` (see `/light-spec` Phase 6 for the full pattern).
+3. Do NOT re-trigger the Spec Review Agent from this skill. Re-triggering is owned by `pk spec-cycle`, which the caller (`/01-light-spec` Phase 6 cycle) invokes after this skill returns. If this skill was run standalone (not via the cycle), tell the user: _"➜ next: pk spec-cycle PROJ-XXX"_.
 
 ### Phase 10 — Next-step output
 


### PR DESCRIPTION
## Summary
- New `pk spec-cycle <ID>` owns the Spec Review Agent v5 trigger, polling (30s × 10 = 5min cap), and verdict dispatch (Pass → state=Approved; Revise → emits next-step hint; Stalemate/Timeout/Malformed → exits cleanly).
- `/01-light-spec` Phase 6 rewritten as a 3-pass cycle: auto-invokes `/02-light-spec-revise` on pass 1 Revise verdicts; pause-prompts with `[Y/n/o]` on pass 2-3 (override path baked in).
- `/02-light-spec-revise` no longer posts re-triggers — Phase 9.3 hands control back to `pk spec-cycle`. Phase 6 nudge (option 2) clarified as a targeted nudge, not a full re-review.
- Two new `method.config.md` keys (with defaults): `Spec ready state` (`Specced`), `Spec approved state` (`Approved`).

## Why
Yesterday's "switch from manual paste to MCP" change put the `@linear` trigger format in two skill files. Centralizing it in `pk` means a future Linear product change is one fix, not many. Polling in bash (not in a Claude turn) keeps context tokens spent on reasoning, not waiting.

## Test plan
- [ ] Sync into rs-vault via `scripts/sync-method.sh`
- [ ] Run `/01-light-spec` end-to-end on a new test issue; confirm trigger fires, agent responds, verdict parsed, state transitions on Pass
- [ ] Force a Revise verdict; confirm /02 auto-invokes on pass 1, prompts on pass 2
- [ ] Manually post 3 prior agent comments on a test issue; confirm `pk spec-cycle` refuses with Stalemate

🤖 Generated with [Claude Code](https://claude.com/claude-code)