### PR TITLE
chore(docs): paperwork for pk spec-cycle + RUNBOOK + /work session labels

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -174,10 +174,14 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
   └──────────────────────────────────────────────────────────┘
        │
        ▼
-       /pk-exit                   (writes Logs/Sessions/<date>_<HHMM>.md narrative)
-       /exit                      (close Claude in worktree)
-       cd ~/Projects/<repo>       (back to parent repo)
-       claude --dangerously-skip-permissions
+  ┌──────────────────────────────────────────────────────────┐
+  │ [7] Session close + return to parent repo                │
+  │     /pk-exit       writes Logs/Sessions/<date>_<HHMM>.md │
+  │                    narrative for the worktree session    │
+  │     /exit          close Claude in the worktree          │
+  │     cd ~/Projects/<repo>                                 │
+  │     claude --dangerously-skip-permissions                │
+  └──────────────────────────────────────────────────────────┘
        │
 ┌──────┴──────────────────────────────────────────────────────────┐
 │  PARENT REPO       cwd: ~/Projects/<repo>     branch: dev       │
@@ -185,7 +189,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        │
        ▼
   ┌──────────────────────────────────────────────────────────┐
-  │ [7] Cleanup                                              │
+  │ [8] Cleanup                                              │
   │     pk done <ID>                                         │
   │     • verifies PR merged                                 │
   │     • posts journal highlights to Linear                 │
@@ -202,7 +206,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        │
        ▼
   ┌──────────────────────────────────────────────────────────┐
-  │ [8] Promote dev → main      (separate, batched)          │
+  │ [9] Promote dev → main      (separate, batched)          │
   │     pk promote                                           │
   │     • only runs if Promote to main: true in config       │
   │     • git pull dev, run pre-deploy gate                  │

--- a/method.md
+++ b/method.md
@@ -171,9 +171,11 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 **Steps:** 1–3 (Light Spec → Agent Review → Human Review)
 **Pre-condition:** Roadmap Review (Step 0) must pass
 
-**Tools:** `/light-spec`, Spec Review Agent, Human
+**Tools:** `/light-spec`, `pk spec-cycle`, `/light-spec-revise`, Spec Review Agent, Human
 
 - `/light-spec` explores the codebase, reads reference material and Strategy docs, and generates a structured spec as an AI→AI contract
+- `/light-spec` Phase 6 then runs the **review cycle** automatically: invokes `pk spec-cycle` (which posts the agent trigger, polls Linear for the verdict, and transitions the issue to **Approved** on Pass), and on Revise auto-invokes `/light-spec-revise` for surgical patches before the next cycle pass
+- The cycle is hard-capped at 3 passes. On passes 2 and 3 the user is prompted `[Y/n/o]` (continue / bail / drop into `/light-spec-revise`'s override path) so a stalemating agent can't drive infinite revision
 - Spec Review Agent enforces planning readiness (Pass/Revise with blocking issues identified)
 - Human validates product decisions, scope, and priority
 - Iteration continues until Agent passes AND Human approves
@@ -418,8 +420,9 @@ VBW resolves the path relative to the project root. The hook is fail-open — if
 |-----------------|---------|
 | `/roadmap-review` | Stage 0 gate + health check: completeness, dependencies, spec coverage |
 | `/brainstorm` | Feature-level feasibility exploration (within an existing project) |
-| `/light-spec` | Structured spec generation with agent review |
-| `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detects stalemate loops |
+| `/light-spec` | Structured spec generation with auto-cycled agent review (invokes `pk spec-cycle` and `/light-spec-revise` internally, max 3 passes) |
+| `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detects stalemate loops. Usually invoked by `/light-spec` Phase 6, but can be run standalone. |
+| `pk spec-cycle <ID>` | Post the Spec Review Agent v5 trigger, poll Linear for the verdict, transition state to Approved on Pass. Owns the `@linear` trigger format and polling — Claude doesn't wait. |
 | `/spec-preflight {ISSUE}` | Empirical pre-flight on a specced issue — verifies file paths, line refs, phase-detect baseline, Linear status against reality. Read-only. Run between Spec Review Agent and `pk branch`. |
 | `pk next` | Phase-aware: groups Linear results by status with per-group hints |
 | `pk branch <ID>` | Worktree + branch + Linear → In Progress (idempotent) |

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -81,6 +81,26 @@ Validate the description contains either `## Light Spec` or `## Acceptance Crite
 - **Without `--deep`:** print a warning, print the description's first 30 lines, ask: `Continue planning with this vague spec? (y/N)`. Default N.
 - **With `--deep`:** refuse: `Spec missing required sections. Run /light-spec <ID> first, OR pk delegate <ID> "draft a Light Spec for this issue against {project} conventions" to invoke Linear Agent.`
 
+## Step 2.5 — Label the session and terminal
+
+Now that you have `<ISSUE-ID>` and the issue `title`, label the work in two places so the human can find this session at a glance.
+
+1. **Claude session topic** — set if the helper script exists:
+
+   ```bash
+   if [ -x "$HOME/.claude/scripts/set-topic.sh" ]; then
+     "$HOME/.claude/scripts/set-topic.sh" "<ISSUE-ID> — <title>"
+   fi
+   ```
+
+2. **Terminal / multiplexer tab title** — emit the OSC 0 escape (honored by most terminals, tmux, screen, and CMUX):
+
+   ```bash
+   printf '\033]0;%s\007' "<ISSUE-ID>"
+   ```
+
+Both are best-effort. Skip silently if either fails — never block planning on a labeling failure.
+
 ## Step 3 — Plan
 
 ### `--deep` path: parallel grounding

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -37,8 +37,9 @@ These skills work across any project that follows the method. They read `method.
 | `/roadmap-review` | Pre-pipeline health check (Stage 0 gate) | Stage 0 → Stage 1 gate |
 | `/brainstorm` | Feature-level feasibility exploration | Stage 1: Spec |
 | `/brainstorm-review` | Triage untriaged Linear issues | Stage 1: Spec |
-| `/light-spec` | Structured spec generation with agent review | Stage 1: Spec |
-| `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detect stalemate loops | Stage 1: Spec |
+| `/light-spec` | Structured spec generation with auto-cycled agent review (Phase 6 invokes `pk spec-cycle` + `/light-spec-revise` internally, max 3 passes) | Stage 1: Spec |
+| `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detect stalemate loops. Usually invoked by `/light-spec` Phase 6, can also run standalone. | Stage 1: Spec |
+| `pk spec-cycle <ID>` | Trigger Spec Review Agent v5, poll Linear for verdict, transition to Approved on Pass. Bash-side helper used by `/light-spec`'s cycle — keeps polling out of Claude's context. | Stage 1: Spec |
 | `/spec-preflight` | Empirical pre-flight checks on a specced Linear issue (file paths, line refs, phase-detect baseline, Linear status). Read-only. | Stage 1 → Stage 2 gate |
 | `pk next` | Phase-aware: groups Linear results by status (In Progress / Approved / Needs Spec) | Stage 2: Plan + Build |
 | `pk branch <ID>` | Worktree + branch + Linear → In Progress (idempotent) | Stage 2: Plan + Build |


### PR DESCRIPTION
## Summary
- **RUNBOOK.md**: wrap the `/pk-exit` + return-to-parent step in a numbered box matching the rest of the v2 daily-loop flowchart; renumber downstream cleanup + promote steps to 8/9.
- **skills/work**: add Step 2.5 — label the Claude session topic (via `~/.claude/scripts/set-topic.sh` if present) and the terminal tab title (OSC 0 escape) using `<ISSUE-ID>` + title. Best-effort, never blocks planning.
- **method.md** Stage 1 + skill index, **sop/Skills_SOP.md** table: document the new auto-cycle in `/01-light-spec` Phase 6 and add a row for `pk spec-cycle <ID>`. Brings the methodology paperwork in line with PR #53.

## Test plan
- [ ] Re-run `scripts/sync-method.sh` in rs-vault and confirm method.md + sop/Skills_SOP.md updates land in `method/`
- [ ] Visual check of RUNBOOK.md flowchart — boxes align, numbering is consecutive 1-9
- [ ] Run `/work` against a test issue and confirm the terminal tab title and Claude session topic both update

🤖 Generated with [Claude Code](https://claude.com/claude-code)