### PR TITLE
fix(01-light-spec): remove pre-cycle opt-in prompt

### DIFF
--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -151,9 +151,9 @@ Before presenting to the user, audit every section:
 
 ### Phase 6 — Spec Review Cycle (automated)
 
-Ask the user: _"Run Linear's Spec Review Agent now? (Y/n)"_ — default yes.
+Enter the cycle automatically once Phase 5 publishes. Do **not** prompt the user before pass 1 — the cycle is the whole point of `/01-light-spec`. The cycle calls `pk spec-cycle`, which owns the agent trigger, the polling, and the state transition on Pass — so this skill never posts the `@linear` comment directly.
 
-If they decline, skip to Phase 7. If yes, run the cycle below. The cycle calls `pk spec-cycle`, which owns the agent trigger, the polling, and the state transition on Pass — so this skill never posts the `@linear` comment directly.
+The user can opt out only by interrupting (Ctrl-C). Confirmation prompts appear on passes 2 and 3 inside the loop below — that is the designed bail-out point.
 
 **Cycle (max 3 passes):**
 


### PR DESCRIPTION
## Summary
Phase 6 of `/01-light-spec` opened with a redundant `Run Linear's Spec Review Agent now? (Y/n)` prompt that contradicted the auto-cycle design documented in PR #54's method.md update. Surfaced 2026-05-04 on RS-36: user expected the cycle to enter automatically after publish, but the prompt fired anyway.

The bail-out points are still in place:
- `[Y/n/o]` confirmation on passes 2 and 3 (designed pause for stalemate awareness)
- Ctrl-C to abort the cycle entirely

Pass 1 now just runs.

## Test plan
- [ ] Sync into rs-vault
- [ ] Run `/01-light-spec` against a fresh test issue; confirm Phase 6 enters `pk spec-cycle` immediately after publishing, no prompt
- [ ] Confirm pass 2 still shows `[Y/n/o]` if first pass returns Revise

🤖 Generated with [Claude Code](https://claude.com/claude-code)