### PR TITLE
feat(work+verify): auto-rollover /work → /verify → pk ship on Pass

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -74,8 +74,9 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
   │     • atomic commits, gate-aware                         │
   │     • --deep adds spec-validator + plan-review +         │
   │       security-review subagents                          │
+  │     • on clean exit → auto-invokes [4] /verify           │
   └──────────────────────────────────────────────────────────┘
-       │
+       │ (auto on /work success; aborts skip the rollover)
        ▼
   ┌──────────────────────────────────────────────────────────┐
   │ [4] Verify                                               │
@@ -83,8 +84,11 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
   │     • runs § Pre-Deploy Gate from method.config.md       │
   │     • if Require QA review=true: spawns QA subagent      │
   │     • returns Pass / Partial / Fail with per-AC table    │
+  │     • on Pass + auto-flow → auto-invokes [5] pk ship     │
+  │     • on Partial/Fail → STOP (user fixes and reruns)     │
   └──────────────────────────────────────────────────────────┘
-       │
+       │ (auto on Pass when invoked by /work; standalone
+       │  /verify just prints the hint)
        ▼
   ┌──────────────────────────────────────────────────────────┐
   │ [5] Ship   (still in worktree, still on feature branch)  │
@@ -92,6 +96,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
   │     • push (idempotent)                                  │
   │     • gh pr create against integration branch            │
   │     • Linear: Building → UAT (or → In Review)            │
+  │     • on push/gh failure → STOP, surface error, no retry │
   └──────────────────────────────────────────────────────────┘
        │
        ▼

--- a/method.md
+++ b/method.md
@@ -211,6 +211,7 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 **Tools:** `/verify`, `pk ship`, optional `/pr-fix` and `/pr-security-review`, Human
 
 - **`/verify`** runs the pre-deploy gate from `method.config.md` (types + lint + test). Returns Pass / Partial / Fail with a per-AC table. If `Require QA review: true`, also spawns the QA subagent for goal-backward verification.
+- **Auto-rollover**: `/work` auto-invokes `/verify` on successful completion (no prompt). On Pass, `/verify` auto-invokes `pk ship` (gated by the `PIPEKIT_AUTO_SHIP=1` env var that `/work` sets — standalone `/verify` calls do not auto-ship). On Partial / Fail, the rollover stops with the per-AC table; the user fixes and re-runs. Aborts inside `/work` skip the rollover entirely.
 - **`pk ship`** pushes the feature branch, opens the PR against the integration branch from config, and transitions Linear → UAT.
 - **`pk ship --review`** posts a Linear comment flagging review-in-flight and prints the antagonistic reviewer invocation. The reviewer plays devil's advocate vs `/work` + `/verify` (which validate spec adherence) — surfaces cross-cutting concerns the spec didn't think to mention.
 - **`/pr-security-review`** is the right tool for migrations / RLS / SECURITY DEFINER / auth surface (use instead of, or alongside, the generic reviewer).

--- a/skills/verify/skill.md
+++ b/skills/verify/skill.md
@@ -159,19 +159,32 @@ Use Task tool with:
 
 Wait for the subagent to return. Print its verdict block verbatim — no editorializing.
 
-## Step 4 — Hand off
+## Step 4 — Hand off (with auto-ship for the /work rollover path)
 
 Based on verdict, print the next-action:
 
 | Verdict | Next |
 |---|---|
-| Pass (gate only) | `pk ship` |
-| Pass (gate + QA) | `pk ship` |
+| Pass (gate only) | `pk ship` (auto-shipped if `PIPEKIT_AUTO_SHIP=1`; otherwise hint only) |
+| Pass (gate + QA) | `pk ship` (auto-shipped if `PIPEKIT_AUTO_SHIP=1`; otherwise hint only) |
 | Partial | Read the per-AC table. Decide: amend with `/work` (if gap is real), or ship anyway with `git commit --amend` documenting the gap. Then `pk ship`. |
 | Fail (gate) | Fix the failing command, then re-run `/verify` (idempotent). |
 | Fail (QA) | Stop. Either: expand `/work <ID>` to address Unmet ACs; OR `pk delegate <ID> "the spec needs <X>"` to refine spec; OR override consciously with documented decision. |
 
-Do **not** auto-ship on Pass. The user runs `pk ship` when ready.
+### Auto-ship rollover (Pass only, only when invoked by /work)
+
+If the verdict is **Pass** AND the environment variable `PIPEKIT_AUTO_SHIP=1` is set (which `/work`'s Step 7 rollover sets before calling this skill), auto-invoke `pk ship`:
+
+1. Print: `✓ /verify Pass — auto-running pk ship`
+2. Run `pk ship` via bash. Use no flags — `pk ship` reads `Integration branch` from `method.config.md` to pick the destination, which gives `dev` for Piper-style multi-env projects and `main` for single-env projects (correct in both cases).
+3. If `pk ship` succeeds: print its output (PR URL + Linear transition) and exit.
+4. If `pk ship` fails (push rejected, gh CLI error, branch protection): surface the error verbatim and STOP. Do NOT auto-retry — push failures usually mean branch protection, lockfile drift, or remote conflicts that need human eyes.
+
+`--review` (antagonistic review) stays opt-in; the user runs `pk ship --review` separately if they want it.
+
+If `PIPEKIT_AUTO_SHIP` is unset (standalone `/verify` invocation), do NOT auto-ship on Pass. Print the hint and let the user pace.
+
+**Partial / Fail with `PIPEKIT_AUTO_SHIP=1`:** still no auto-ship. Auto-ship is gated on Pass, not on the rollover signal alone. The signal only authorizes the *Pass branch* to ship; failures always pause for human attention.
 
 ## Failure model
 

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -324,24 +324,34 @@ Do **not** generate plausible-sounding rationale that fits the visible artifact.
 
 When in doubt, default to: *"Let me check the spec and the integration site before I answer."*
 
-## Step 7 — Hand off, don't auto-ship
+## Step 7 — Auto-rollover to /verify
 
-Print:
+Once execution exits successfully — all tasks committed, no aborts, no deviation pending user input — auto-invoke `/verify` immediately. Do not prompt; verification is the deterministic next step in the v2 loop, and `/verify` is idempotent and read-only.
+
+**Skip the rollover** if any of the following holds:
+
+- `/work` was interrupted or aborted mid-execution (Ctrl-C, abort verdict, agent failure)
+- A deviation was raised that the user has not yet resolved
+- The user's last intent was an explicit stop (e.g., responding "stop" to a prompt)
+
+Otherwise:
+
+1. Print: `✓ /work complete for <ISSUE-ID> — auto-running /verify`
+2. Set the environment variable `PIPEKIT_AUTO_SHIP=1` for the `/verify` invocation. This signals `/verify` that it was called as part of the auto-flow and should auto-ship on Pass. (Standalone `/verify` calls do not set this var, and so do not auto-ship.)
+3. Invoke `/verify` by calling the Skill tool with `skill="verify"`. Surface its verdict block to the user verbatim.
+4. After `/verify` returns:
+   - If `/verify` Pass: `pk ship` will already have run inside `/verify`'s rollover (Step 4 below). Print the final hand-off line: _"Run `/pk-exit` at the end of the session to write `Logs/Sessions/<date>_<HHMM>.md`."_
+   - If `/verify` Partial / Fail: STOP. The verdict block already showed the per-AC table; do not invoke `pk ship`. Tell the user: _"Address the failures and re-run `/verify` when ready (or `/work --resume` if execution gaps remain)."_
+
+If the rollover is skipped (per the conditions above), fall back to the legacy hand-off:
 
 ```
-✓ /work complete for <ISSUE-ID>
+✓ /work paused for <ISSUE-ID>
 
-Next:
-  /verify        — run pre-deploy gate + QA review (if configured)
-  pk verify      — same, from shell
-
-Then:
-  pk ship        — push, open PR, transition Linear
-
-Run /pk-exit at the end of the session to write Logs/Sessions/<date>_<HHMM>.md.
+Resume:
+  /work <ISSUE-ID>          — continue execution
+  /verify                   — run gate manually if you want to inspect first
 ```
-
-**Do not** invoke `pk ship` or `/verify` automatically. The user paces.
 
 ## Failure model
 


### PR DESCRIPTION
## Summary
Same auto-flow pattern as `/01-light-spec` → `pk spec-cycle` (PR #53/#55). The middle of the v2 daily loop (`/work` → `/verify` → `pk ship`) is deterministic when things go right; codifying that saves keystrokes without losing the bail-out points.

## Behavior
- **`/work` Step 7**: on clean exit (all tasks committed, no aborts, no unresolved deviation), set `PIPEKIT_AUTO_SHIP=1` and invoke `/verify` via the Skill tool. Aborts/interrupts skip the rollover and fall back to a "paused" hand-off.
- **`/verify` Step 4**: on `Pass` AND `PIPEKIT_AUTO_SHIP=1`, auto-run `pk ship` (no flags). Standalone `/verify` (no env var) keeps current hint-only behavior. `Partial`/`Fail` always stop — auto-ship is gated on Pass, not on the rollover signal alone.
- **`pk ship` failure**: surface error verbatim and STOP. No retry — push failures usually mean branch protection / lockfile / conflicts that need human eyes.
- **`pk ship` runs without `--env`**: existing config (`Integration branch` in `method.config.md`) drives the destination — `dev` for Piper, `main` for rs-vault. Verified against both projects.
- **`--review`** (antagonistic) stays opt-in, out of scope.

## Paperwork
- `method.md` Stage 3: documents the rollover and its gates.
- `RUNBOOK.md` flowchart: arrows between [3]→[4]→[5] now annotate the auto-flow conditions.

## Test plan
- [ ] Sync into rs-vault, run `/work` against a test issue end-to-end; confirm clean Pass auto-ships
- [ ] Force a `/verify` Fail; confirm rollover stops with per-AC table, no `pk ship`
- [ ] Run `/verify` standalone; confirm it does NOT auto-ship (env var unset)
- [ ] Force a `pk ship` push rejection; confirm error surfaces and rollover stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)