### PR TITLE
feat(work): session labels, RUNBOOK step, auto-backend routing

### DIFF
--- a/method.config.template.md
+++ b/method.config.template.md
@@ -143,7 +143,7 @@ Keys consumed by `bin/pk` and the `/work` + `/verify` skills. All have sensible 
 
 | Key | Value | Default | Used by |
 |-----|-------|---------|---------|
-| **Backend** | `vbw` \| `native` | `vbw` | `/work` — chooses agent dispatch path |
+| **Backend** | `vbw` \| `native` \| `auto` | `vbw` | `/work` — chooses agent dispatch path. `auto` routes per plan complexity: ≤3 files + no migration → native, otherwise → vbw |
 | **Integration branch** | `dev` \| `main` | derived from § Git Architecture | `pk ship` (PR base) |
 | **Promote to main** | `true` \| `false` | `true` if integration is `dev` | `pk promote` (skips if `false`) |
 | **Require QA review** | `true` \| `false` | `false` | `/verify` (auto-spawns QA subagent if `true`) |
@@ -168,7 +168,7 @@ Ship environments: main
 ### Example (Piper)
 
 ```
-Backend: vbw
+Backend: auto
 Integration branch: dev
 Promote to main: true
 Require QA review: true

--- a/resources/spec-work-auto-backend.md
+++ b/resources/spec-work-auto-backend.md
@@ -1,0 +1,87 @@
+## Light Spec
+
+**Status:** Draft
+**Complexity:** Low (~2-4h)
+**Linear Project:** Pipekit
+
+### Problem
+
+`/work` reads `Backend` from `method.config.md` as a fixed project-level value (`vbw` or `native`). Two problems:
+
+1. The config parser is unreliable — the skill tells Claude to grep for `Backend`, but the table uses bold markdown (`**Backend**`), causing Claude to miss the value and silently fall back to the `vbw` default. rs-vault (configured `native`) observed this firsthand: `/work` printed `Backend: vbw` and dispatched VBW agents.
+2. There is no complexity-aware routing. Projects like Piper need simple issues executed inline (native) and complex issues escalated to VBW — but the config today forces a single choice for the whole project.
+
+### Goal
+
+`/work` selects the execution backend correctly: fixed (`native` or `vbw`) when configured, or automatically from the plan when `auto` is configured. The routing decision is always visible to the user before execution begins.
+
+### Proposed Solution
+
+- Fix config parsing: replace the grep/LLM-parse approach with an explicit `bin/pk pk_config "Backend" "vbw"` bash call in Step 1.
+- Add `Backend: auto` as a valid third config value in `method.config.template.md`.
+- When `auto` is active, evaluate the written plan at Step 3b against a routing heuristic and resolve to `native` or `vbw`.
+- Print the resolved backend + routing reason one line before dispatch, regardless of mode.
+
+### Scope
+
+**In scope:**
+- Fix Step 1 to use `bin/pk pk_config` for reliable backend value extraction
+- Add `auto` to the valid backend values (Triggers, Step 1, Failure model)
+- New Step 3c: routing logic that runs after plan is written, only when `auto` is active
+- Print `Routing: <reason> → <backend>` before Step 5 dispatch (all modes)
+- Update `method.config.template.md` to document `auto` as a valid value
+
+**Out of scope:**
+- Auto-routing to `06-linear-todo-runner` (that remains a manual, explicit invocation)
+- Changes to `vbw` or `native` execution paths (Step 5 is unchanged)
+- Any changes to the `--backend=` CLI override (already overrides everything)
+
+### Decisions
+
+- **Routing heuristic signals:** File count in plan, presence of migration file paths, presence of packages not already imported in the spec's referenced files. All three are readable from the written plan without additional file I/O.
+- **Routing threshold:** ≤3 files AND no migration AND no unfamiliar package → `native`. Any other combination → `vbw`.
+- **Routing timing:** After Step 3b (plan written), before Step 4 (verdict gate). User approves the plan; the routing line prints immediately after `proceed`, before dispatch. No second approval step.
+- **`--backend=` override still wins:** If the user passed `--backend=native` or `--backend=vbw` explicitly, `auto` routing is skipped entirely. Print `Backend: native (explicit override)` in Step 1 as today.
+- **Config parse fix is non-breaking:** `bin/pk pk_config "Backend" "vbw"` returns the same values as before for `vbw` and `native` projects. The fix is invisible to those projects.
+
+### Requirements
+
+- [ ] Step 1 uses `bin/pk pk_config "Backend" "vbw"` via Bash, not LLM grep
+- [ ] `auto` is accepted as a valid backend value; any other value (including blank) triggers the existing unknown-backend refusal
+- [ ] When `Backend: auto`, Step 1 prints `Backend: auto` (not resolved yet)
+- [ ] Step 3c exists and runs only when effective backend is `auto`
+- [ ] Step 3c evaluates: (a) count of "Files to touch" entries, (b) whether any path matches `*/migrations/*` or `*.sql`, (c) whether any package listed is not resolvable in `package.json`
+- [ ] Step 3c resolves to `native` if: file count ≤3, no migration path, no unfamiliar package
+- [ ] Step 3c resolves to `vbw` otherwise
+- [ ] After `proceed` at Step 4, print one line: `Routing: <signal summary> → <native|vbw>` (auto mode) or `Backend: <native|vbw>` (fixed mode)
+- [ ] Step 5 dispatch uses the resolved backend, not the raw config value
+- [ ] `method.config.template.md` documents `auto` as a valid Backend value with a one-line description
+
+### Acceptance Criteria
+
+- [ ] Given `method.config.md` has `Backend: native` (bold markdown), when `/work` runs Step 1, then it prints `Backend: native` (not `vbw`) — verifiable by running `/work` on rs-vault
+- [ ] Given `Backend: auto` and a plan with 2 files and no migration, when user says `proceed`, then the routing line reads `Routing: 2 files, no migration → native` and a native execution path is used
+- [ ] Given `Backend: auto` and a plan with 5 files, when user says `proceed`, then the routing line reads `Routing: 5 files → vbw` and `vbw:vbw-dev` is dispatched
+- [ ] Given `Backend: auto` and a plan containing a `supabase/migrations/` path, when user says `proceed`, then routing resolves to `vbw` regardless of file count
+- [ ] Given `/work RS-XX --backend=native` with `Backend: auto` in config, then Step 1 prints `Backend: native (explicit override)` and Step 3c is skipped
+- [ ] Given `/work RS-XX --backend=invalid`, then skill refuses: `Unknown backend 'invalid'. Valid: vbw, native, auto.`
+
+### Technical Context
+
+- **Existing code:** `skills/work/skill.md` — all changes are to this file's prose instructions
+- **Config binary:** `bin/pk pk_config "<Key>" "<default>"` — already ships in consuming projects via sync; handles bold markdown table format
+- **Template:** `method.config.template.md` — add `auto` to the Backend row comment
+- **Patterns to follow:** All other Step N additions in the skill follow the existing header + code-block format
+- **Authority:** `bin/pk pk_config` is authoritative for config value extraction; LLM grep is not
+
+### Risks & Open Questions
+
+- `bin/pk pk_config` availability: the binary is synced into consuming projects but must exist at `bin/pk`. If absent, the skill should fall back to grep with a warning — or refuse and tell the user to run `/pipekit-update`. Planner to decide fallback behavior.
+- Unfamiliar-package detection in Step 3c is the weakest signal — it requires Claude to cross-reference package names against `package.json`. This could be slow or inaccurate. Planner may choose to drop this signal and rely only on file count + migration presence, which are unambiguous.
+
+### Notes
+
+- This bundles two separate bugs (config parse) + one feature (auto routing) into one skill edit. They are coupled because fixing the parse bug changes Step 1, and the auto-routing adds Step 3c — easier to review as one change than two.
+- rs-vault stays on `Backend: native` (no change needed).
+- Piper would move to `Backend: auto` after this ships.
+- The RUNBOOK.md and `method.config.template.md` commentary should note that `auto` is the recommended default for multi-complexity projects.

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -13,7 +13,7 @@ You are a focused work driver. Given a Linear issue ID, you read its spec, plan 
 
 - `/work <ISSUE-ID>` — primary
 - `/work <ISSUE-ID> --deep` — adds spec-validator + plan-review subagent + security-review on completion
-- `/work <ISSUE-ID> --backend=vbw|native` — override the project's default backend for this invocation only
+- `/work <ISSUE-ID> --backend=vbw|native|auto` — override the project's default backend for this invocation only
 - "work on RS-30" / "let's do PIP-123"
 
 ## Required preconditions
@@ -42,29 +42,35 @@ ISSUE=$(echo "$CURRENT" | grep -oE '[A-Z]+-[0-9]+' | head -1)
 
 ## Step 1 — Read configuration
 
-Read these values from `method.config.md` (use `bin/pk pk_config "<Key>" "<default>"` semantics, or grep the rows directly):
+Read these values from `method.config.md` using the `bin/pk pk_config` binary — do not grep the file directly, as the markdown table format (bold keys, backtick values) is unreliable to parse inline:
 
-| Key | Default |
-|---|---|
-| Backend | `vbw` |
-| Default deep flag | `false` |
-| Require QA review | `false` |
-| Strategy docs path | `Strategy/` |
+```bash
+BACKEND=$(bin/pk pk_config "Backend" "vbw")
+DEEP_FLAG=$(bin/pk pk_config "Default deep flag" "false")
+QA_REVIEW=$(bin/pk pk_config "Require QA review" "false")
+STRATEGY_PATH=$(bin/pk pk_config "Strategy docs path" "Strategy/")
+```
 
 Resolve the effective `--deep` (CLI flag OR `Default deep flag: true`).
 
 Resolve the effective backend in this order (first match wins):
 
-1. `--backend=vbw` or `--backend=native` passed on the invocation
-2. `Backend` row in `method.config.md`
+1. `--backend=vbw`, `--backend=native`, or `--backend=auto` passed on the invocation
+2. `Backend` row in `method.config.md` (read via `bin/pk pk_config` above)
 3. Default: `vbw`
 
-If `--backend=` is passed with any value other than `vbw` or `native`, refuse: `Unknown backend '<value>'. Valid: vbw, native.`
+If `--backend=` is passed with any value other than `vbw`, `native`, or `auto`, refuse: `Unknown backend '<value>'. Valid: vbw, native, auto.`
 
-Print one line for the user:
+When the resolved backend is `vbw` or `native`, print one line:
 
 ```
 Work: <ISSUE-ID>  ·  Backend: <vbw|native>  ·  Deep: <yes|no>
+```
+
+When the resolved backend is `auto`, print:
+
+```
+Work: <ISSUE-ID>  ·  Backend: auto (routing after plan)  ·  Deep: <yes|no>
 ```
 
 ## Step 2 — Fetch the spec from Linear
@@ -182,6 +188,36 @@ Format (single screen — keep tight):
 **Risks / open questions:**
 - <empty list — if non-empty, the spec is not ready, go back to step 2>
 ```
+
+## Step 3c — Auto-backend routing (only when `Backend: auto`)
+
+Skip this step entirely if the effective backend is `vbw` or `native`.
+
+After the plan is written, evaluate these three signals from the **Files to touch** section:
+
+| Signal | Check |
+|---|---|
+| File count | Count entries in "Files to touch" |
+| Migration present | Any path matches `*/migrations/*` or ends in `.sql` |
+| Unfamiliar package | Any package referenced in the plan is absent from `package.json` (run `node -e "require('./package.json')"` to confirm) |
+
+**Routing decision:**
+
+- If file count ≤ 3 AND no migration AND no unfamiliar package → resolve to `native`
+- Any other combination → resolve to `vbw`
+
+Store the resolved backend as the effective backend for Step 5.
+
+Print one line immediately after the plan (before the verdict prompt):
+
+```
+Routing: <signal summary> → <native|vbw>
+```
+
+Examples:
+- `Routing: 2 files, no migration → native`
+- `Routing: 7 files → vbw`
+- `Routing: migration present → vbw`
 
 ## Step 4 — Verdict gate
 
@@ -361,6 +397,8 @@ Resume:
 | Spec missing required sections, no `--deep` | Warn, ask y/N. |
 | Spec missing required sections, with `--deep` | Refuse. Recommend `/light-spec` or `pk delegate`. |
 | Plan revised >3 times | Refuse. Recommend `pk delegate`. |
+| `--backend=` with unknown value | Refuse: `Unknown backend '<value>'. Valid: vbw, native, auto.` |
+| `bin/pk pk_config` binary absent | Warn: `bin/pk not found — cannot read Backend from config. Defaulting to vbw. Run /pipekit-update to fix.` |
 | Subagent returns permission denial | Stop. Print the denial. Do not retry. |
 | Subagent returns ambiguous failure | Print full output. Ask user how to proceed. |
 | Tests fail post-execute | Surface. Don't auto-fix — that's `/verify`. |

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -81,17 +81,25 @@ Validate the description contains either `## Light Spec` or `## Acceptance Crite
 - **Without `--deep`:** print a warning, print the description's first 30 lines, ask: `Continue planning with this vague spec? (y/N)`. Default N.
 - **With `--deep`:** refuse: `Spec missing required sections. Run /light-spec <ID> first, OR pk delegate <ID> "draft a Light Spec for this issue against {project} conventions" to invoke Linear Agent.`
 
-## Step 2.5 — Label the session
+## Step 2.5 — Label the session and terminal
 
-Now that you have `<ISSUE-ID>` and the issue `title`, set the Claude session topic so the human can find this session at a glance:
+Now that you have `<ISSUE-ID>` and the issue `title`, label the work in two places so the human can find this session at a glance.
 
-```bash
-if [ -x "$HOME/.claude/scripts/set-topic.sh" ]; then
-  "$HOME/.claude/scripts/set-topic.sh" "<ISSUE-ID> — <title>"
-fi
-```
+1. **Claude session topic** — set if the helper script exists:
 
-Best-effort — skip silently if it fails. Never block planning on a labeling failure.
+   ```bash
+   if [ -x "$HOME/.claude/scripts/set-topic.sh" ]; then
+     "$HOME/.claude/scripts/set-topic.sh" "<ISSUE-ID> — <title>"
+   fi
+   ```
+
+2. **Terminal / multiplexer tab title** — emit the OSC 0 escape (honored by most terminals, tmux, screen, and CMUX):
+
+   ```bash
+   printf '\033]0;%s\007' "<ISSUE-ID>"
+   ```
+
+Both are best-effort. Skip silently if either fails — never block planning on a labeling failure.
 
 ## Step 3 — Plan
 


### PR DESCRIPTION
## Summary

- **Session labeling** (`Step 2.5`): `/work` now sets the Claude session topic and terminal tab title (OSC 0) as soon as the issue is fetched — best-effort, never blocks planning
- **RUNBOOK cleanup**: session-close block (`/pk-exit + /exit + cd`) is now an explicit numbered step instead of floating prose
- **Auto-backend routing** (`Step 3c`): adds `Backend: auto` as a valid config value; routes to `native` for small plans (≤3 files, no migration) and `vbw` otherwise — routing reason printed before dispatch
- **Config parse fix** (`Step 1`): replaces unreliable LLM grep with explicit `bin/pk pk_config` bash calls — fixes silent fallback to `vbw` default on projects configured `native`

## Test plan

- [ ] On an rs-vault worktree, run `/work RS-XX` and confirm it prints `Backend: native` (not `vbw`)
- [ ] On a project with `Backend: auto`, confirm `Routing: N files → native|vbw` line appears after plan
- [ ] Confirm session topic and terminal tab title set on `/work` invocation
- [ ] Confirm RUNBOOK step 7 is the session-close block

🤖 Generated with [Claude Code](https://claude.com/claude-code)