### PR TITLE
feat(pk init): scour-and-scaffold method.config.md

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -944,24 +944,16 @@ cmd_log() {
 }
 
 cmd_init_bootstrap() {
-  # Stub: scaffold method.config.md by scouring the repo.
-  # Phases: detect → resolve → prompt → render → diff → write.
-  # Wired in step 2+. For now, just announce intent and exit.
+  # Scaffold method.config.md by scouring the repo.
+  # Phases (filled in across steps 2-6): detect → resolve → render → diff → prompt → write.
   local root="$1"
-  echo "── pk init (bootstrap) ──"
-  echo ""
-  echo "method.config.md not found. Bootstrap mode would:"
-  echo "  1. Detect repo, stack, scripts, tiers, strategy docs, vbw, linear"
-  echo "  2. Resolve detections into a proposed config"
-  echo "  3. Prompt only for ambiguous fields"
-  echo "  4. Render proposal from method.config.template.md"
-  echo "  5. Show unified diff and confirm"
-  echo "  6. Write method.config.md"
-  echo ""
-  echo "(detection not implemented yet — manual fallback below)"
-  echo "  cp $root/method.config.template.md $root/method.config.md"
-  echo "  \$EDITOR $root/method.config.md"
-  return 1
+  local main_sh
+  main_sh="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")/pk-init/main.sh"
+  if [ ! -x "$main_sh" ]; then
+    echo "ERROR: pk-init/main.sh not found at $main_sh" >&2
+    return 1
+  fi
+  exec "$main_sh" "$root"
 }
 
 cmd_init() {

--- a/bin/pk
+++ b/bin/pk
@@ -944,22 +944,37 @@ cmd_log() {
 }
 
 cmd_init_bootstrap() {
-  # Scaffold method.config.md by scouring the repo.
-  # Phases (filled in across steps 2-6): detect → resolve → render → diff → prompt → write.
+  # Scaffold or update method.config.md via the pk-init pipeline:
+  # detect → prompt → render → review → confirm → write.
   local root="$1"
+  shift
   local main_sh
   main_sh="$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")/pk-init/main.sh"
   if [ ! -x "$main_sh" ]; then
     echo "ERROR: pk-init/main.sh not found at $main_sh" >&2
     return 1
   fi
-  exec "$main_sh" "$root"
+  exec "$main_sh" "$root" "$@"
 }
 
 cmd_init() {
   local root
   root=$(pk_repo_root) || { echo "ERROR: not in a git repo" >&2; return 1; }
   local cfg="$root/method.config.md"
+
+  # --update: re-run detection against existing config.
+  for arg in "$@"; do
+    if [ "$arg" = "--update" ]; then
+      if [ ! -f "$cfg" ]; then
+        echo "ERROR: --update requires existing method.config.md (none found)." >&2
+        echo "       Run 'pk init' (no flag) to bootstrap first." >&2
+        return 1
+      fi
+      cmd_init_bootstrap "$root" --update
+      return $?
+    fi
+  done
+
   if [ ! -f "$cfg" ]; then
     cmd_init_bootstrap "$root"
     return $?

--- a/bin/pk
+++ b/bin/pk
@@ -943,14 +943,34 @@ cmd_log() {
   cat "$logs_dir/$latest"
 }
 
+cmd_init_bootstrap() {
+  # Stub: scaffold method.config.md by scouring the repo.
+  # Phases: detect → resolve → prompt → render → diff → write.
+  # Wired in step 2+. For now, just announce intent and exit.
+  local root="$1"
+  echo "── pk init (bootstrap) ──"
+  echo ""
+  echo "method.config.md not found. Bootstrap mode would:"
+  echo "  1. Detect repo, stack, scripts, tiers, strategy docs, vbw, linear"
+  echo "  2. Resolve detections into a proposed config"
+  echo "  3. Prompt only for ambiguous fields"
+  echo "  4. Render proposal from method.config.template.md"
+  echo "  5. Show unified diff and confirm"
+  echo "  6. Write method.config.md"
+  echo ""
+  echo "(detection not implemented yet — manual fallback below)"
+  echo "  cp $root/method.config.template.md $root/method.config.md"
+  echo "  \$EDITOR $root/method.config.md"
+  return 1
+}
+
 cmd_init() {
   local root
   root=$(pk_repo_root) || { echo "ERROR: not in a git repo" >&2; return 1; }
   local cfg="$root/method.config.md"
   if [ ! -f "$cfg" ]; then
-    echo "ERROR: method.config.md missing." >&2
-    echo "  Run sync-method.sh first, or copy method.config.template.md to method.config.md." >&2
-    return 1
+    cmd_init_bootstrap "$root"
+    return $?
   fi
   echo "── pk init ──"
   echo ""

--- a/bin/pk-init/detect_linear.sh
+++ b/bin/pk-init/detect_linear.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Emit: linear_team_key, linear_team_id
+# If LINEAR_API_KEY (or configured var) is set, query teams via GraphQL.
+# Otherwise mark needs_input — user can fill manually or set the key and rerun.
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+key_var="${LINEAR_API_KEY_VAR:-LINEAR_API_KEY}"
+key="${!key_var:-}"
+
+if [ -z "$key" ]; then
+  out=$(jq -s 'add' \
+    <(emit_needs_input linear_team_key '[]' "\$$key_var not set; export it and rerun, or fill manually") \
+    <(emit_needs_input linear_team_id  '[]' "\$$key_var not set; export it and rerun, or fill manually"))
+  echo "$out"; exit 0
+fi
+
+resp=$(curl -sS -X POST https://api.linear.app/graphql \
+  -H "Authorization: $key" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ teams { nodes { id key name } } }"}' 2>/dev/null || echo '{}')
+
+teams=$(echo "$resp" | jq -c '.data.teams.nodes // []' 2>/dev/null || echo '[]')
+count=$(echo "$teams" | jq 'length')
+
+if [ "$count" = "0" ]; then
+  out=$(jq -s 'add' \
+    <(emit_missing linear_team_key "Linear API returned no teams") \
+    <(emit_missing linear_team_id  "Linear API returned no teams"))
+elif [ "$count" = "1" ]; then
+  k=$(echo "$teams" | jq -r '.[0].key')
+  i=$(echo "$teams" | jq -r '.[0].id')
+  out=$(jq -s 'add' \
+    <(emit_detected linear_team_key "$k" "Linear API (sole team)") \
+    <(emit_detected linear_team_id  "$i" "Linear API (sole team)"))
+else
+  keys=$(echo "$teams" | jq '[.[].key]')
+  ids=$(echo "$teams" | jq '[.[].id]')
+  out=$(jq -s 'add' \
+    <(emit_needs_input linear_team_key "$keys" "$count teams accessible; pick one") \
+    <(emit_needs_input linear_team_id  "$ids"  "$count teams accessible; pick one (must match team_key choice)"))
+fi
+echo "$out"

--- a/bin/pk-init/detect_repo.sh
+++ b/bin/pk-init/detect_repo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Emit: repo_org, repo_name, default_branch
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+cd "$ROOT"
+
+remote=$(git remote get-url origin 2>/dev/null || echo "")
+org="" name=""
+if [ -n "$remote" ]; then
+  # Handles git@github.com:org/repo.git and https://github.com/org/repo(.git)
+  stripped="${remote%.git}"
+  case "$stripped" in
+    *github.com:*|*github.com/*)
+      tail="${stripped#*github.com[:/]}"
+      org="${tail%%/*}"
+      name="${tail#*/}"
+      ;;
+  esac
+fi
+
+default_branch=""
+if git symbolic-ref refs/remotes/origin/HEAD >/dev/null 2>&1; then
+  default_branch=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')
+fi
+
+out="{}"
+if [ -n "$org" ]; then
+  out=$(jq -s 'add' <(echo "$out") <(emit_detected repo_org "$org" "git remote origin"))
+else
+  out=$(jq -s 'add' <(echo "$out") <(emit_missing repo_org "no origin remote"))
+fi
+if [ -n "$name" ]; then
+  out=$(jq -s 'add' <(echo "$out") <(emit_detected repo_name "$name" "git remote origin"))
+else
+  out=$(jq -s 'add' <(echo "$out") <(emit_missing repo_name "no origin remote"))
+fi
+if [ -n "$default_branch" ]; then
+  out=$(jq -s 'add' <(echo "$out") <(emit_detected default_branch "$default_branch" "origin/HEAD"))
+else
+  out=$(jq -s 'add' <(echo "$out") <(emit_needs_input default_branch '["main","master"]' "origin/HEAD not set; pick default"))
+fi
+
+echo "$out"

--- a/bin/pk-init/detect_scripts.sh
+++ b/bin/pk-init/detect_scripts.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Emit: script_typecheck, script_lint, script_test, script_build
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+pkg="$ROOT/package.json"
+
+pick() {
+  # $@ candidate script names; print first match in package.json scripts
+  [ -f "$pkg" ] || return 0
+  for name in "$@"; do
+    if jq -e --arg n "$name" '.scripts[$n] // empty' "$pkg" >/dev/null 2>&1; then
+      echo "$name"; return 0
+    fi
+  done
+}
+
+emit_or_missing() {
+  local field="$1"; shift
+  local picked
+  picked=$(pick "$@")
+  if [ -n "${picked:-}" ]; then
+    emit_detected "$field" "$picked" "package.json scripts.$picked"
+  else
+    emit_missing "$field" "no matching script in package.json"
+  fi
+}
+
+if [ ! -f "$pkg" ]; then
+  out=$(jq -s 'add' \
+    <(emit_missing script_typecheck "no package.json") \
+    <(emit_missing script_lint      "no package.json") \
+    <(emit_missing script_test      "no package.json") \
+    <(emit_missing script_build     "no package.json"))
+else
+  out=$(jq -s 'add' \
+    <(emit_or_missing script_typecheck typecheck check-types tsc) \
+    <(emit_or_missing script_lint      lint check) \
+    <(emit_or_missing script_test      test) \
+    <(emit_or_missing script_build     build))
+fi
+
+echo "$out"

--- a/bin/pk-init/detect_stack.sh
+++ b/bin/pk-init/detect_stack.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Emit: package_manager, runtime
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+pm="" pm_src=""
+if   [ -f "$ROOT/pnpm-lock.yaml" ];   then pm="pnpm";  pm_src="pnpm-lock.yaml"
+elif [ -f "$ROOT/yarn.lock" ];        then pm="yarn";  pm_src="yarn.lock"
+elif [ -f "$ROOT/package-lock.json" ];then pm="npm";   pm_src="package-lock.json"
+elif [ -f "$ROOT/bun.lockb" ];        then pm="bun";   pm_src="bun.lockb"
+fi
+
+runtime="" runtime_src=""
+if [ -f "$ROOT/package.json" ]; then
+  runtime="node"; runtime_src="package.json"
+elif [ -f "$ROOT/pyproject.toml" ] || [ -f "$ROOT/requirements.txt" ]; then
+  runtime="python"; runtime_src="$( [ -f "$ROOT/pyproject.toml" ] && echo pyproject.toml || echo requirements.txt )"
+elif [ -f "$ROOT/go.mod" ]; then
+  runtime="go"; runtime_src="go.mod"
+elif [ -f "$ROOT/Cargo.toml" ]; then
+  runtime="rust"; runtime_src="Cargo.toml"
+fi
+
+out="{}"
+if [ -n "$pm" ]; then
+  out=$(jq -s 'add' <(echo "$out") <(emit_detected package_manager "$pm" "$pm_src"))
+else
+  out=$(jq -s 'add' <(echo "$out") <(emit_missing package_manager "no lockfile found"))
+fi
+if [ -n "$runtime" ]; then
+  out=$(jq -s 'add' <(echo "$out") <(emit_detected runtime "$runtime" "$runtime_src"))
+else
+  out=$(jq -s 'add' <(echo "$out") <(emit_missing runtime "no recognized manifest"))
+fi
+echo "$out"

--- a/bin/pk-init/detect_strategy.sh
+++ b/bin/pk-init/detect_strategy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Emit: strategy_docs (array of paths)
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+found=()
+for d in "docs/strategy" "Strategy" "strategy" "docs/Strategy"; do
+  full="$ROOT/$d"
+  [ -d "$full" ] || continue
+  while IFS= read -r f; do
+    rel="${f#$ROOT/}"
+    found+=("$rel")
+  done < <(find "$full" -maxdepth 2 -type f -name '*.md' 2>/dev/null)
+done
+
+if [ ${#found[@]} -gt 0 ]; then
+  arr=$(printf '%s\n' "${found[@]}" | jq -R . | jq -s .)
+  emit_detected_array strategy_docs "$arr" "filesystem glob"
+else
+  emit_missing strategy_docs "no strategy docs found (expected docs/strategy/*.md or Strategy/*.md)"
+fi

--- a/bin/pk-init/detect_strategy.sh
+++ b/bin/pk-init/detect_strategy.sh
@@ -15,7 +15,7 @@ for d in "docs/strategy" "Strategy" "strategy" "docs/Strategy"; do
 done
 
 if [ ${#found[@]} -gt 0 ]; then
-  arr=$(printf '%s\n' "${found[@]}" | jq -R . | jq -s .)
+  arr=$(printf '%s\n' "${found[@]}" | sort -u | jq -R . | jq -s .)
   emit_detected_array strategy_docs "$arr" "filesystem glob"
 else
   emit_missing strategy_docs "no strategy docs found (expected docs/strategy/*.md or Strategy/*.md)"

--- a/bin/pk-init/detect_tiers.sh
+++ b/bin/pk-init/detect_tiers.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Emit: tiers (array of branches that look like environment tiers)
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+cd "$ROOT"
+
+# Look at remote and local branches; common tier names.
+all=$( (git branch --format='%(refname:short)'; git branch -r --format='%(refname:short)') 2>/dev/null \
+  | sed 's@^origin/@@' \
+  | sort -u )
+
+tiers=()
+for t in main master dev develop staging uat preview production; do
+  if echo "$all" | grep -qx "$t"; then
+    tiers+=("$t")
+  fi
+done
+
+if [ ${#tiers[@]} -gt 0 ]; then
+  arr=$(printf '%s\n' "${tiers[@]}" | jq -R . | jq -s .)
+  emit_detected_array tiers "$arr" "git branches"
+else
+  emit_missing tiers "no recognized tier branches"
+fi

--- a/bin/pk-init/detect_vbw.sh
+++ b/bin/pk-init/detect_vbw.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Emit: backend (vbw if .vbw-planning/ exists, else needs_input)
+set -euo pipefail
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+. "$(dirname "$0")/lib.sh"
+
+if [ -d "$ROOT/.vbw-planning" ]; then
+  emit_detected backend "vbw" ".vbw-planning/ present"
+else
+  emit_needs_input backend '["vbw","native"]' ".vbw-planning/ not present; pick backend (vbw=full agent pipeline, native=in-context)"
+fi

--- a/bin/pk-init/diff.sh
+++ b/bin/pk-init/diff.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# diff.sh — show unified diff of draft against a baseline (template or existing config).
+#
+# Usage: diff.sh <baseline> <draft>
+#   baseline: original file we're comparing against (template, or existing method.config.md for --update)
+#   draft:    rendered candidate
+#
+# Prints colorized diff if stdout is a tty; plain otherwise. Exits 0 even
+# when the files differ — caller decides what to do with the diff.
+set -euo pipefail
+
+BASELINE="${1:?usage: diff.sh <baseline> <draft>}"
+DRAFT="${2:?usage: diff.sh <baseline> <draft>}"
+
+[ -f "$BASELINE" ] || { echo "ERROR: baseline missing: $BASELINE" >&2; exit 1; }
+[ -f "$DRAFT" ]    || { echo "ERROR: draft missing: $DRAFT" >&2; exit 1; }
+
+if [ -t 1 ] && command -v diff >/dev/null 2>&1; then
+  # Try `git diff --no-index --color` first — best output, handles binary safely.
+  if command -v git >/dev/null 2>&1; then
+    git --no-pager diff --no-index --color=always -- "$BASELINE" "$DRAFT" || true
+    exit 0
+  fi
+fi
+
+diff -u "$BASELINE" "$DRAFT" || true

--- a/bin/pk-init/lib.sh
+++ b/bin/pk-init/lib.sh
@@ -1,0 +1,33 @@
+# pk-init shared helpers — sourced by detect_*.sh and main.sh.
+#
+# Field shape:
+#   detected:    {"status":"detected","value":<x>,"source":"<where>"}
+#   needs_input: {"status":"needs_input","candidates":[...],"reason":"<why>"}
+#   missing:     {"status":"missing","reason":"<why>"}
+#
+# Each detect_*.sh prints ONE JSON object: { field: <Field>, ... }.
+# main.sh merges them with `jq -s add`.
+
+emit_detected() {
+  # $1 field, $2 value (string), $3 source
+  jq -n --arg f "$1" --arg v "$2" --arg s "$3" \
+    '{($f): {status:"detected", value:$v, source:$s}}'
+}
+
+emit_detected_array() {
+  # $1 field, $2 JSON array string, $3 source
+  jq -n --arg f "$1" --argjson v "$2" --arg s "$3" \
+    '{($f): {status:"detected", value:$v, source:$s}}'
+}
+
+emit_needs_input() {
+  # $1 field, $2 JSON array of candidates, $3 reason
+  jq -n --arg f "$1" --argjson c "$2" --arg r "$3" \
+    '{($f): {status:"needs_input", candidates:$c, reason:$r}}'
+}
+
+emit_missing() {
+  # $1 field, $2 reason
+  jq -n --arg f "$1" --arg r "$2" \
+    '{($f): {status:"missing", reason:$r}}'
+}

--- a/bin/pk-init/main.sh
+++ b/bin/pk-init/main.sh
@@ -83,8 +83,40 @@ DRAFT="$STATE_DIR/method.config.md.draft"
 bash "$HERE/render.sh" "$TEMPLATE" "$STATE" > "$DRAFT"
 echo "Draft:      $DRAFT"
 echo ""
-echo "── render preview (first 40 lines of draft) ──"
-head -40 "$DRAFT"
-echo "..."
+
+# Step 4: diff + confirm.
+echo "── diff (template → draft) ──"
+bash "$HERE/diff.sh" "$TEMPLATE" "$DRAFT"
 echo ""
-echo "(steps 4-6 not implemented — diff, prompt, write come next)"
+
+TARGET="$ROOT/method.config.md"
+echo "Target:     $TARGET"
+echo ""
+
+while true; do
+  printf "Write? [y]es  [e]dit draft in \$EDITOR  [n]o, abort: "
+  read -r choice
+  case "$choice" in
+    y|Y)
+      echo "(step 6 not implemented — would write $DRAFT → $TARGET)"
+      break
+      ;;
+    e|E)
+      "${EDITOR:-vi}" "$DRAFT"
+      echo ""
+      echo "── diff (template → draft, post-edit) ──"
+      bash "$HERE/diff.sh" "$TEMPLATE" "$DRAFT"
+      echo ""
+      ;;
+    n|N|"")
+      echo "Aborted. Draft kept at: $DRAFT"
+      exit 1
+      ;;
+    *)
+      echo "  unknown choice: $choice"
+      ;;
+  esac
+done
+
+echo ""
+echo "(step 5 not implemented — prompts for needs_input fields will run before diff)"

--- a/bin/pk-init/main.sh
+++ b/bin/pk-init/main.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# pk-init/main.sh — bootstrap orchestrator (step 2: detect-only).
+#
+# Phases (this file grows over steps 2-6):
+#   2. Detect → state.json + dump      ← we are here
+#   3. Resolve + render
+#   4. Diff + confirm
+#   5. Prompt for needs_input
+#   6. Write
+set -euo pipefail
+
+ROOT="${1:?usage: main.sh <repo_root>}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+. "$HERE/lib.sh"
+
+# Per-run state dir; survives the run for inspection if --keep-state.
+STATE_DIR="${TMPDIR:-/tmp}/pk-init-$$"
+mkdir -p "$STATE_DIR"
+STATE="$STATE_DIR/state.json"
+
+DETECTORS=(
+  detect_repo.sh
+  detect_stack.sh
+  detect_scripts.sh
+  detect_tiers.sh
+  detect_strategy.sh
+  detect_vbw.sh
+  detect_linear.sh
+)
+
+echo "── pk init: detect ──"
+echo "(state dir: $STATE_DIR)"
+echo ""
+
+# Run each detector; collect fragments.
+fragments=()
+for d in "${DETECTORS[@]}"; do
+  frag="$STATE_DIR/${d%.sh}.json"
+  if bash "$HERE/$d" "$ROOT" > "$frag" 2>"$STATE_DIR/${d%.sh}.err"; then
+    fragments+=("$frag")
+  else
+    echo "  ✗ $d failed (see $STATE_DIR/${d%.sh}.err)" >&2
+    fragments+=("$frag")  # may be partial/empty; tolerated
+  fi
+done
+
+# Merge.
+jq -s 'add // {}' "${fragments[@]}" > "$STATE"
+
+# Pretty-print summary.
+echo "Detected fields:"
+jq -r '
+  to_entries
+  | sort_by(.key)
+  | .[]
+  | "  " + (.key | . + ":" + (" " * (20 - length)))
+    + (
+        if   .value.status == "detected"    then "✓ " + (.value.value | tostring) + "  (" + .value.source + ")"
+        elif .value.status == "needs_input" then "? candidates=" + (.value.candidates | tostring) + "  — " + .value.reason
+        elif .value.status == "missing"     then "✗ " + .value.reason
+        else "? unknown" end
+      )
+' "$STATE"
+
+echo ""
+echo "State file: $STATE"
+echo ""
+echo "(steps 3-6 not implemented — render, diff, prompt, write come next)"

--- a/bin/pk-init/main.sh
+++ b/bin/pk-init/main.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
-# pk-init/main.sh — bootstrap orchestrator (step 2: detect-only).
+# pk-init/main.sh — bootstrap orchestrator.
 #
-# Phases (this file grows over steps 2-6):
-#   2. Detect → state.json + dump      ← we are here
-#   3. Resolve + render
-#   4. Diff + confirm
-#   5. Prompt for needs_input
-#   6. Write
+# Flow: detect → prompt → render → review → confirm → write.
+#
+# Modes:
+#   bootstrap (default): when method.config.md is missing. Renders draft from
+#                        method.config.template.md.
+#   --update:            when method.config.md exists. Re-runs detection,
+#                        renders against the existing config as baseline, and
+#                        lets the user merge in detection improvements.
 set -euo pipefail
 
-ROOT="${1:?usage: main.sh <repo_root>}"
+ROOT=""
+MODE="bootstrap"
+for arg in "$@"; do
+  case "$arg" in
+    --update) MODE="update" ;;
+    --*) echo "unknown flag: $arg" >&2; exit 2 ;;
+    *) [ -z "$ROOT" ] && ROOT="$arg" ;;
+  esac
+done
+[ -n "$ROOT" ] || { echo "usage: main.sh <repo_root> [--update]" >&2; exit 2; }
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 . "$HERE/lib.sh"
 
-# Per-run state dir; survives the run for inspection if --keep-state.
 STATE_DIR="${TMPDIR:-/tmp}/pk-init-$$"
 mkdir -p "$STATE_DIR"
 STATE="$STATE_DIR/state.json"
@@ -29,10 +40,9 @@ DETECTORS=(
 )
 
 echo "── pk init: detect ──"
-echo "(state dir: $STATE_DIR)"
+echo "(state dir: $STATE_DIR  mode: $MODE)"
 echo ""
 
-# Run each detector; collect fragments.
 fragments=()
 for d in "${DETECTORS[@]}"; do
   frag="$STATE_DIR/${d%.sh}.json"
@@ -40,14 +50,13 @@ for d in "${DETECTORS[@]}"; do
     fragments+=("$frag")
   else
     echo "  ✗ $d failed (see $STATE_DIR/${d%.sh}.err)" >&2
-    fragments+=("$frag")  # may be partial/empty; tolerated
+    fragments+=("$frag")
   fi
 done
 
-# Merge.
 jq -s 'add // {}' "${fragments[@]}" > "$STATE"
 
-# Pretty-print summary.
+# Initial scan summary (compact one-liner per field).
 echo "Detected fields:"
 jq -r '
   to_entries
@@ -65,50 +74,72 @@ jq -r '
 echo ""
 echo "State file: $STATE"
 
-# Step 5: prompt for needs_input fields. Mutates state.json in place.
+# Prompt for needs_input fields. Mutates state.json in place.
 bash "$HERE/prompt.sh" "$STATE"
 
-# Step 3: render draft.
-TEMPLATE="$ROOT/method.config.template.md"
-if [ ! -f "$TEMPLATE" ]; then
-  PIPEKIT_TEMPLATE="$(dirname "$HERE")/../method.config.template.md"
-  if [ -f "$PIPEKIT_TEMPLATE" ]; then
-    TEMPLATE="$PIPEKIT_TEMPLATE"
-  else
-    echo ""
-    echo "ERROR: method.config.template.md not found in $ROOT or pipekit source." >&2
-    echo "       Run scripts/sync-method.sh from pipekit first, or copy the template manually." >&2
+# Locate template (bootstrap) or existing config (update) as baseline.
+TARGET="$ROOT/method.config.md"
+if [ "$MODE" = "update" ]; then
+  if [ ! -f "$TARGET" ]; then
+    echo "ERROR: --update requires existing method.config.md at $TARGET" >&2
     exit 1
+  fi
+  BASELINE="$TARGET"
+else
+  BASELINE="$ROOT/method.config.template.md"
+  if [ ! -f "$BASELINE" ]; then
+    PIPEKIT_TEMPLATE="$(dirname "$HERE")/../method.config.template.md"
+    if [ -f "$PIPEKIT_TEMPLATE" ]; then
+      BASELINE="$PIPEKIT_TEMPLATE"
+    else
+      echo ""
+      echo "ERROR: method.config.template.md not found in $ROOT or pipekit source." >&2
+      echo "       Run scripts/sync-method.sh from pipekit first, or copy the template manually." >&2
+      exit 1
+    fi
   fi
 fi
 
 DRAFT="$STATE_DIR/method.config.md.draft"
-bash "$HERE/render.sh" "$TEMPLATE" "$STATE" > "$DRAFT"
-echo "Draft:      $DRAFT"
+bash "$HERE/render.sh" "$BASELINE" "$STATE" > "$DRAFT"
 echo ""
+echo "Draft:    $DRAFT"
+echo "Target:   $TARGET"
 
-# Step 4: diff + confirm.
-echo "── diff (template → draft) ──"
-bash "$HERE/diff.sh" "$TEMPLATE" "$DRAFT"
-echo ""
-
-TARGET="$ROOT/method.config.md"
-echo "Target:     $TARGET"
+# Review table (high-level summary).
+bash "$HERE/summary.sh" "$STATE"
 echo ""
 
 while true; do
-  printf "Write? [y]es  [e]dit draft in \$EDITOR  [n]o, abort: "
+  printf "Write? [y]es  [d]iff (full)  [e]dit draft in \$EDITOR  [n]o, abort: "
   read -r choice
   case "$choice" in
     y|Y)
-      echo "(step 6 not implemented — would write $DRAFT → $TARGET)"
+      if [ -e "$TARGET" ] && [ "$MODE" != "update" ]; then
+        echo "ERROR: $TARGET already exists. Use 'pk init --update' to merge." >&2
+        exit 1
+      fi
+      cp "$DRAFT" "$TARGET"
+      bytes=$(wc -c < "$TARGET" | tr -d ' ')
+      echo ""
+      echo "✓ Wrote $bytes bytes → $TARGET"
+      if [ "$MODE" = "bootstrap" ]; then
+        echo ""
+        echo "Next: pk init   (post-config health check)"
+      fi
       break
+      ;;
+    d|D)
+      echo ""
+      echo "── diff (baseline → draft) ──"
+      bash "$HERE/diff.sh" "$BASELINE" "$DRAFT"
+      echo ""
       ;;
     e|E)
       "${EDITOR:-vi}" "$DRAFT"
       echo ""
-      echo "── diff (template → draft, post-edit) ──"
-      bash "$HERE/diff.sh" "$TEMPLATE" "$DRAFT"
+      echo "── diff (baseline → draft, post-edit) ──"
+      bash "$HERE/diff.sh" "$BASELINE" "$DRAFT"
       echo ""
       ;;
     n|N|"")

--- a/bin/pk-init/main.sh
+++ b/bin/pk-init/main.sh
@@ -65,6 +65,9 @@ jq -r '
 echo ""
 echo "State file: $STATE"
 
+# Step 5: prompt for needs_input fields. Mutates state.json in place.
+bash "$HERE/prompt.sh" "$STATE"
+
 # Step 3: render draft.
 TEMPLATE="$ROOT/method.config.template.md"
 if [ ! -f "$TEMPLATE" ]; then

--- a/bin/pk-init/main.sh
+++ b/bin/pk-init/main.sh
@@ -120,6 +120,3 @@ while true; do
       ;;
   esac
 done
-
-echo ""
-echo "(step 5 not implemented — prompts for needs_input fields will run before diff)"

--- a/bin/pk-init/main.sh
+++ b/bin/pk-init/main.sh
@@ -64,5 +64,27 @@ jq -r '
 
 echo ""
 echo "State file: $STATE"
+
+# Step 3: render draft.
+TEMPLATE="$ROOT/method.config.template.md"
+if [ ! -f "$TEMPLATE" ]; then
+  PIPEKIT_TEMPLATE="$(dirname "$HERE")/../method.config.template.md"
+  if [ -f "$PIPEKIT_TEMPLATE" ]; then
+    TEMPLATE="$PIPEKIT_TEMPLATE"
+  else
+    echo ""
+    echo "ERROR: method.config.template.md not found in $ROOT or pipekit source." >&2
+    echo "       Run scripts/sync-method.sh from pipekit first, or copy the template manually." >&2
+    exit 1
+  fi
+fi
+
+DRAFT="$STATE_DIR/method.config.md.draft"
+bash "$HERE/render.sh" "$TEMPLATE" "$STATE" > "$DRAFT"
+echo "Draft:      $DRAFT"
 echo ""
-echo "(steps 3-6 not implemented — render, diff, prompt, write come next)"
+echo "── render preview (first 40 lines of draft) ──"
+head -40 "$DRAFT"
+echo "..."
+echo ""
+echo "(steps 4-6 not implemented — diff, prompt, write come next)"

--- a/bin/pk-init/prompt.sh
+++ b/bin/pk-init/prompt.sh
@@ -104,7 +104,7 @@ while IFS= read -r line; do
 done < <(jq -r '
   to_entries
   | map(select(.value.status == "needs_input"))
-  | map(select(.key != "linear_team_id"))
+  | map(select(.key != "linear_team_id" and .key != "linear_team_key"))
   | .[].key
 ' "$STATE")
 

--- a/bin/pk-init/prompt.sh
+++ b/bin/pk-init/prompt.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# prompt.sh — interactive dialogue for state fields with status=needs_input.
+#
+# Reads state.json, iterates needs_input fields, prompts the user, and rewrites
+# state.json with their choices applied (status flips to detected, source set
+# to "user prompt"). Skipped fields stay needs_input — the diff/edit step lets
+# the user fill them manually.
+#
+# If stdin is not a tty (piped/test mode), skip all prompts and exit 0.
+#
+# Special-case: linear_team_key + linear_team_id are paired. We prompt once
+# on team_key and apply the matching team_id at the same array index.
+set -euo pipefail
+
+STATE="${1:?usage: prompt.sh <state.json>}"
+[ -f "$STATE" ] || { echo "ERROR: state missing: $STATE" >&2; exit 1; }
+
+if [ ! -t 0 ]; then
+  # Non-interactive: nothing to do.
+  exit 0
+fi
+
+# Helper: rewrite a single field in state.json to status=detected.
+set_detected() {
+  local field="$1" value="$2" source="$3"
+  local tmp
+  tmp=$(mktemp)
+  jq --arg f "$field" --arg v "$value" --arg s "$source" \
+    '.[$f] = {status:"detected", value:$v, source:$s}' "$STATE" > "$tmp"
+  mv "$tmp" "$STATE"
+}
+
+# Helper: present a numbered choice list and return the picked value via stdout.
+# Args: $1=field name, $2=JSON candidates array, $3=reason
+# Returns: chosen value on stdout, or empty if skipped.
+ask_choice() {
+  # All UI goes to stderr; only the chosen value (or empty) goes to stdout
+  # so callers can use `picked=$(ask_choice ...)` cleanly.
+  local field="$1" cands_json="$2" reason="$3"
+  local count
+  count=$(echo "$cands_json" | jq 'length')
+  {
+    echo ""
+    echo "┌─ $field ─────────────────────────────────────"
+    echo "│ Reason: $reason"
+    if [ "$count" -gt 0 ]; then
+      echo "│ Candidates:"
+      local i=1
+      while IFS= read -r c; do
+        echo "│   $i. $c"
+        i=$((i+1))
+      done < <(echo "$cands_json" | jq -r '.[]')
+      echo "│ [1-$count] pick  [s] skip  [q] abort"
+    else
+      echo "│ No candidates auto-detected."
+      echo "│ Type a value, [s] skip, [q] abort"
+    fi
+    printf "└─ "
+  } >&2
+  local choice
+  read -r choice
+  case "$choice" in
+    q|Q) echo "Aborted." >&2; exit 1 ;;
+    s|S|"") echo "" ;;
+    *)
+      if [ "$count" -gt 0 ] && [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
+        echo "$cands_json" | jq -r ".[$((choice-1))]"
+      else
+        echo "$choice"
+      fi
+      ;;
+  esac
+}
+
+echo ""
+echo "── pk init: prompts ──"
+
+# Special-case: Linear team pair. Handle before the generic loop so we can
+# pop both fields together.
+team_key_status=$(jq -r '.linear_team_key.status // ""' "$STATE")
+if [ "$team_key_status" = "needs_input" ]; then
+  cands=$(jq -c '.linear_team_key.candidates // []' "$STATE")
+  reason=$(jq -r '.linear_team_key.reason // ""' "$STATE")
+  picked=$(ask_choice "linear_team_key" "$cands" "$reason")
+  if [ -n "$picked" ]; then
+    set_detected linear_team_key "$picked" "user prompt"
+    # Find matching team_id at the same index (only valid when both came from
+    # the same Linear API response and arrays are aligned).
+    idx=$(echo "$cands" | jq --arg p "$picked" 'to_entries | map(select(.value == $p)) | .[0].key // -1')
+    id_cands=$(jq -c '.linear_team_id.candidates // []' "$STATE")
+    if [ "$idx" != "-1" ] && [ "$(echo "$id_cands" | jq 'length')" -gt "$idx" ]; then
+      matched_id=$(echo "$id_cands" | jq -r ".[$idx]")
+      set_detected linear_team_id "$matched_id" "paired with linear_team_key"
+      echo "  → linear_team_id auto-paired: $matched_id"
+    fi
+  fi
+fi
+
+# Generic loop for remaining needs_input fields.
+# (Bash 3.2-compatible — no `mapfile`.)
+fields=()
+while IFS= read -r line; do
+  [ -n "$line" ] && fields+=("$line")
+done < <(jq -r '
+  to_entries
+  | map(select(.value.status == "needs_input"))
+  | map(select(.key != "linear_team_id"))
+  | .[].key
+' "$STATE")
+
+if [ ${#fields[@]} -eq 0 ]; then
+  echo "No fields needing input."
+  exit 0
+fi
+
+for field in "${fields[@]}"; do
+  cands=$(jq -c --arg f "$field" '.[$f].candidates // []' "$STATE")
+  reason=$(jq -r --arg f "$field" '.[$f].reason // ""' "$STATE")
+  picked=$(ask_choice "$field" "$cands" "$reason")
+  if [ -n "$picked" ]; then
+    set_detected "$field" "$picked" "user prompt"
+  fi
+done

--- a/bin/pk-init/render.sh
+++ b/bin/pk-init/render.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# render.sh — substitute detected values into method.config.template.md.
+#
+# Inputs:  $1=template path, $2=state.json path
+# Output:  rendered markdown on stdout
+#
+# Substitutions are conservative: only fields whose state is "detected" get
+# applied. Ambiguous (needs_input) and missing fields keep template defaults
+# so prompt phase (step 5) can fill them.
+set -euo pipefail
+
+TEMPLATE="${1:?usage: render.sh <template> <state.json>}"
+STATE="${2:?usage: render.sh <template> <state.json>}"
+
+[ -f "$TEMPLATE" ] || { echo "ERROR: template not found: $TEMPLATE" >&2; exit 1; }
+[ -f "$STATE" ]    || { echo "ERROR: state not found: $STATE" >&2; exit 1; }
+
+# jq helper: get .field.value if status==detected, else empty.
+val() {
+  jq -r --arg f "$1" '
+    .[$f] // {} | select(.status == "detected") | .value // empty
+  ' "$STATE"
+}
+
+# jq helper: get .field.value as JSON (for arrays) if detected.
+valj() {
+  jq -c --arg f "$1" '
+    .[$f] // {} | select(.status == "detected") | .value // empty
+  ' "$STATE"
+}
+
+repo_name=$(val repo_name)
+repo_org=$(val repo_org)
+default_branch=$(val default_branch)
+pm=$(val package_manager)
+backend=$(val backend)
+team_key=$(val linear_team_key)
+team_id=$(val linear_team_id)
+tiers_json=$(valj tiers)
+
+s_typecheck=$(val script_typecheck)
+s_lint=$(val script_lint)
+s_test=$(val script_test)
+s_build=$(val script_build)
+
+# Title-case repo_name for display name (foo-bar → Foo Bar).
+display_name=""
+if [ -n "$repo_name" ]; then
+  display_name=$(echo "$repo_name" \
+    | tr '_-' '  ' \
+    | awk '{ for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2)) }1')
+fi
+
+# Decide integration branch: prefer dev if present in tiers, else default_branch, else main.
+integration_branch="main"
+if [ -n "$tiers_json" ] && echo "$tiers_json" | jq -e 'index("dev")' >/dev/null 2>&1; then
+  integration_branch="dev"
+elif [ -n "$default_branch" ]; then
+  integration_branch="$default_branch"
+fi
+
+# Build pre-deploy gate block from detected scripts.
+gate_lines=""
+if [ -n "$pm" ] && { [ -n "$s_typecheck" ] || [ -n "$s_lint" ] || [ -n "$s_test" ]; }; then
+  [ -n "$s_typecheck" ] && gate_lines+="$pm run $s_typecheck"$'\n'
+  [ -n "$s_lint" ]      && gate_lines+="$pm run $s_lint"$'\n'
+  [ -n "$s_test" ]      && gate_lines+="$pm run $s_test"$'\n'
+fi
+
+# Read template, apply substitutions.
+content=$(cat "$TEMPLATE")
+
+# Project name + display
+if [ -n "$repo_name" ]; then
+  content=${content//your-project/$repo_name}
+  content=${content//Your Project/$display_name}
+fi
+
+# Linear team
+if [ -n "$team_key" ]; then
+  content=${content//YourTeam/$team_key}
+fi
+if [ -n "$team_id" ]; then
+  content=${content//00000000-0000-0000-0000-000000000000/$team_id}
+fi
+
+# Backend (V2 keys row)
+if [ -n "$backend" ]; then
+  content=$(echo "$content" | awk -v val="$backend" '
+    /^\| \*\*Backend\*\*/ { sub(/`vbw` \\\| `native`/, "`" val "`") } 1
+  ')
+fi
+
+# Integration branch (V2 keys row)
+content=$(echo "$content" | awk -v val="$integration_branch" '
+  /^\| \*\*Integration branch\*\*/ { sub(/`dev` \\\| `main`/, "`" val "`") } 1
+')
+
+# Pre-Deploy Gate block — replace the example pnpm turbo lines if we have detections.
+if [ -n "$gate_lines" ]; then
+  gate_file=$(mktemp)
+  printf '%s' "$gate_lines" > "$gate_file"
+  content=$(echo "$content" | awk -v gate_file="$gate_file" '
+    BEGIN {
+      in_block=0; replaced=0
+      while ((getline line < gate_file) > 0) gate = gate line "\n"
+      close(gate_file)
+    }
+    /^## Pre-Deploy Gate/ { in_block=1; print; next }
+    in_block && /^```bash/ && !replaced {
+      print; printf "%s", gate; replaced=1; skipping=1; next
+    }
+    skipping && /^```/ { skipping=0; print; in_block=0; next }
+    skipping { next }
+    { print }
+  ')
+  rm -f "$gate_file"
+fi
+
+echo "$content"

--- a/bin/pk-init/summary.sh
+++ b/bin/pk-init/summary.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# summary.sh — render state.json as a human-readable review table.
+# Grouped: detected → needs_input → missing. Truncates long values to fit width.
+set -euo pipefail
+
+STATE="${1:?usage: summary.sh <state.json>}"
+[ -f "$STATE" ] || { echo "ERROR: state missing: $STATE" >&2; exit 1; }
+
+# Column widths: field=20, value=28, source/reason=remainder
+print_row() {
+  local symbol="$1" field="$2" value="$3" extra="$4"
+  # Truncate long values
+  if [ ${#value} -gt 28 ]; then
+    value="${value:0:25}..."
+  fi
+  printf "  %s  %-20s  %-28s  %s\n" "$symbol" "$field" "$value" "$extra"
+}
+
+print_group() {
+  local title="$1" filter="$2"
+  local rows
+  # Use unit separator (\x1f) so empty fields aren't collapsed by read.
+  rows=$(jq -r --arg filter "$filter" '
+    to_entries
+    | sort_by(.key)
+    | map(select(.value.status == $filter))
+    | .[]
+    | [.key, (.value.value // "" | tostring), (.value.source // .value.reason // "")]
+    | join("")
+  ' "$STATE")
+  if [ -z "$rows" ]; then
+    return 0
+  fi
+  echo ""
+  echo "$title"
+  while IFS=$'\x1f' read -r field value extra; do
+    case "$filter" in
+      detected)    sym="✓" ;;
+      needs_input) sym="?" ;;
+      missing)     sym="✗" ;;
+    esac
+    # For arrays, jq emits JSON array as the value — shorten for display.
+    if [[ "$value" == \[* ]]; then
+      value=$(echo "$value" | jq -r 'join(", ")' 2>/dev/null || echo "$value")
+    fi
+    print_row "$sym" "$field" "$value" "$extra"
+  done <<< "$rows"
+}
+
+echo "── pk init: review ──"
+print_group "Detected:"    detected
+print_group "Needs input:" needs_input
+print_group "Missing:"     missing


### PR DESCRIPTION
## Summary

Extends `pk init` to bootstrap `method.config.md` from scratch instead of erroring when it's missing. Pipeline: **detect → prompt → render → review → confirm → write**. Never writes silently — a review table + confirm gate sits between detection and disk.

When `method.config.md` already exists, `pk init` runs the existing health check unchanged. New `--update` flag re-runs detection against the existing config so you can merge in improvements without losing manual edits.

## What it detects

7 detector modules under `bin/pk-init/` write JSON fragments merged into one state file:

- **repo** — org / name / default_branch (from `git remote` + `origin/HEAD`)
- **stack** — package manager (lockfile) + runtime (manifest)
- **scripts** — typecheck / lint / test / build (from `package.json`)
- **tiers** — branches matching `main|dev|staging|beta|uat|preview|production`
- **strategy** — globs `docs/strategy/**`, `Strategy/**`
- **vbw** — `.vbw-planning/` presence → backend default
- **linear** — GraphQL teams query if `LINEAR_API_KEY` is exported

Each field is `detected` / `needs_input` / `missing`. Only `detected` fields are substituted into the rendered draft; everything else keeps the template default for the user to fill via `[e]dit`.

## UX

```
── pk init: detect ──    14 fields scanned, one-line each
── pk init: prompts ──   interactive picks for needs_input only
── pk init: review ──    grouped table: Detected / Needs input / Missing
Write? [y]es  [d]iff (full)  [e]dit draft in $EDITOR  [n]o, abort
```

`[d]iff` shows the unified diff against the template (or against the existing config in `--update` mode). `[e]dit` opens the draft in `\$EDITOR` and re-renders the diff. `[n]` aborts and keeps the draft in `/tmp` for inspection.

## Build steps

Each step landed as its own commit for reviewability:

1. `af8a3e0` branch dispatch in `cmd_init` (existing health check unchanged when config present)
2. `1340df2` 7 detect modules + state.json + shared lib
3. `107f26a` `render.sh` — substitute detected fields into template
4. `c7a8736` `diff.sh` + confirm gate
5. `3a8e660` `prompt.sh` — interactive picks (Bash 3.2 compatible; non-tty stdin skips silently)
6. `8f635a1` fix double-prompt of `linear_team_key`
7. `d383975` actual write + `--update` + review table + `[d]iff` option

## Test plan

- [ ] In a fresh repo with no `method.config.md`: `pk init` walks detect → prompts → review → confirm. `[n]` aborts cleanly, no file written.
- [ ] In the same repo: `pk init` again with `[y]` writes the file. Output: `✓ Wrote N bytes → ...` and a hint to rerun for health check.
- [ ] Rerun `pk init`: hits the existing-config health-check path (unchanged).
- [ ] `pk init --update` re-runs against the existing config; aborts cleanly with `[n]`.
- [ ] `pk init --update` with no existing config errors with a clear "bootstrap first" message.
- [ ] Detection accuracy on a real Next.js project (verified against \`~/Projects/distill\`): npm, scripts, repo org/name, tiers all correct.

## Out of scope (explicit punts)

- Doc updates (RUNBOOK / method.md / Skills_SOP) — small, follow-up.
- State-dir cleanup on success (currently always kept for inspection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)