### PR TITLE
fix(pk spec-cycle): enforce Verdict: line as first line of agent response

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -1133,16 +1133,18 @@ pk_spec_cycle_trigger_body() {
 
 Assess whether it is safe and ready for VBW planning. Focus on planning readiness, scope clarity, authority/source of truth, edge cases, financial correctness if relevant, and decomposition readiness.
 
-Return:
+**REQUIRED: Your response must begin with exactly one of these two lines — nothing before it, no extra words:**
+Verdict: Pass
+Verdict: Revise
 
-Verdict: Pass or Revise
+Then continue with:
 Recommended Flag: Blocked, Quick Win, Spec: Needed, Spec: Pass, or Spec: Revise
-Readiness Score out of 10
-Blocking Issues
-Non-Blocking Improvements
-Fast Path to Pass
+Readiness Score: <N>/10
+Blocking Issues: <list or "None">
+Non-Blocking Improvements: <list or "None">
+Fast Path to Pass: <1-2 sentences or "N/A">
 Decomposition Readiness: Yes or No
-Final Recommendation
+Final Recommendation: <1-2 sentences>
 
 Then update the issue description by replacing the existing ## Agent Review section with the new review.
 EOF


### PR DESCRIPTION
## Summary

- The Linear Spec Review Agent was returning `Spec Review: Pass ✓` instead of `Verdict: Pass`, causing `pk spec-cycle` to parse the verdict as Malformed and leave the issue in Specced rather than transitioning to Approved
- Fix: rewrite the trigger prompt to make `Verdict: Pass` / `Verdict: Revise` an explicit first-line requirement with no room for interpretation

## Test plan

- [ ] Run `pk spec-cycle` on a spec-ready issue and confirm the agent response starts with `Verdict: Pass` or `Verdict: Revise`
- [ ] Confirm a Pass verdict auto-transitions the issue to Approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)