### PR TITLE
fix(work+verify): use --auto-ship arg, not env var, for rollover signal

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -27,7 +27,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.1.2"
+PK_VERSION="2.1.3"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/skills/verify/skill.md
+++ b/skills/verify/skill.md
@@ -165,15 +165,15 @@ Based on verdict, print the next-action:
 
 | Verdict | Next |
 |---|---|
-| Pass (gate only) | `pk ship` (auto-shipped if `PIPEKIT_AUTO_SHIP=1`; otherwise hint only) |
-| Pass (gate + QA) | `pk ship` (auto-shipped if `PIPEKIT_AUTO_SHIP=1`; otherwise hint only) |
+| Pass (gate only) | `pk ship` (auto-shipped if invoked with `--auto-ship`; otherwise hint only) |
+| Pass (gate + QA) | `pk ship` (auto-shipped if invoked with `--auto-ship`; otherwise hint only) |
 | Partial | Read the per-AC table. Decide: amend with `/work` (if gap is real), or ship anyway with `git commit --amend` documenting the gap. Then `pk ship`. |
 | Fail (gate) | Fix the failing command, then re-run `/verify` (idempotent). |
 | Fail (QA) | Stop. Either: expand `/work <ID>` to address Unmet ACs; OR `pk delegate <ID> "the spec needs <X>"` to refine spec; OR override consciously with documented decision. |
 
-### Auto-ship rollover (Pass only, only when invoked by /work)
+### Auto-ship rollover (Pass only, only when invoked with --auto-ship)
 
-If the verdict is **Pass** AND the environment variable `PIPEKIT_AUTO_SHIP=1` is set (which `/work`'s Step 7 rollover sets before calling this skill), auto-invoke `pk ship`:
+If the verdict is **Pass** AND this skill was invoked with the `--auto-ship` argument (which `/work`'s Step 7 rollover passes via the Skill tool's `args` parameter), auto-invoke `pk ship`:
 
 1. Print: `✓ /verify Pass — auto-running pk ship`
 2. Run `pk ship` via bash. Use no flags — `pk ship` reads `Integration branch` from `method.config.md` to pick the destination, which gives `dev` for Piper-style multi-env projects and `main` for single-env projects (correct in both cases).
@@ -182,9 +182,11 @@ If the verdict is **Pass** AND the environment variable `PIPEKIT_AUTO_SHIP=1` is
 
 `--review` (antagonistic review) stays opt-in; the user runs `pk ship --review` separately if they want it.
 
-If `PIPEKIT_AUTO_SHIP` is unset (standalone `/verify` invocation), do NOT auto-ship on Pass. Print the hint and let the user pace.
+If `--auto-ship` is **not** in this skill's args (standalone `/verify` invocation), do NOT auto-ship on Pass. Print the hint and let the user pace.
 
-**Partial / Fail with `PIPEKIT_AUTO_SHIP=1`:** still no auto-ship. Auto-ship is gated on Pass, not on the rollover signal alone. The signal only authorizes the *Pass branch* to ship; failures always pause for human attention.
+**Why an arg, not an env var:** env vars set in one Bash tool call don't propagate to subsequent Bash calls — each invocation is a fresh subshell. The only reliable cross-skill signal is the Skill tool's `args` parameter.
+
+**Partial / Fail with `--auto-ship`:** still no auto-ship. Auto-ship is gated on Pass, not on the arg alone. The arg only authorizes the *Pass branch* to ship; failures always pause for human attention.
 
 ## Failure model
 

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -360,30 +360,35 @@ Do **not** generate plausible-sounding rationale that fits the visible artifact.
 
 When in doubt, default to: *"Let me check the spec and the integration site before I answer."*
 
-## Step 7 — Hand off
+## Step 7 — Auto-rollover to /verify
 
-Print:
+Once execution exits successfully — all tasks committed, no aborts, no deviation pending user input — auto-invoke `/verify` immediately. Do not prompt; verification is the deterministic next step in the v2 loop, and `/verify` is idempotent and read-only.
+
+**Skip the rollover** if any of the following holds:
+
+- `/work` was interrupted or aborted mid-execution (Ctrl-C, abort verdict, agent failure)
+- A deviation was raised that the user has not yet resolved
+- The user's last intent was an explicit stop (e.g., responding "stop" to a prompt)
+- A Step 6.5 behavioral gap was surfaced that the user clearly wants to resolve before verification (e.g. "let me check this manually first")
+
+Otherwise:
+
+1. Print: `✓ /work complete for <ISSUE-ID> — auto-running /verify`
+2. Invoke `/verify` by calling the Skill tool with `skill="verify"` and `args="--auto-ship"`. The `--auto-ship` arg signals `/verify` that this invocation is part of the auto-flow and authorises `pk ship` on Pass. **Do not** try to set environment variables before invoking — env vars don't propagate across separate Bash subshells, so the only reliable signal is the Skill tool's `args` parameter.
+3. Surface `/verify`'s verdict block to the user verbatim.
+4. After `/verify` returns:
+   - If `/verify` Pass: `pk ship` will already have run inside `/verify`'s rollover (Step 4 below). Print the final hand-off line: _"Run `/pk-exit` at the end of the session to write `Logs/Sessions/<date>_<HHMM>.md`."_
+   - If `/verify` Partial / Fail: STOP. The verdict block already showed the per-AC table; do not invoke `pk ship`. Tell the user: _"Address the failures and re-run `/verify` when ready (or `/work --resume` if execution gaps remain)."_
+
+If the rollover is skipped (per the conditions above), fall back to the legacy hand-off:
 
 ```
-✓ /work complete for <ISSUE-ID>
+✓ /work paused for <ISSUE-ID>
 
-Required next:
-  /verify        — pre-deploy gate (required before pk ship)
-
-Then:
-  pk ship        — push, open PR, transition Linear
-
-Run /pk-exit at the end of the session to write Logs/Sessions/<date>_<HHMM>.md.
+Resume:
+  /work <ISSUE-ID>          — continue execution
+  /verify                   — run gate manually if you want to inspect first
 ```
-
-**`/verify` is required, not optional.** The only valid reasons to skip it:
-
-- Execution was interrupted or aborted (agent failure, abort verdict, Ctrl-C) — in which case fix the gap first, then run `/verify`
-- The gate explicitly failed during execution and the user is addressing the failure before re-running
-
-Step 6.5 behavioral gaps (e.g. Docker not running, browser not available) are **not** a skip reason — they are surfaced in the hand-off summary for the user to decide whether to resolve before shipping, but they do not block `/verify`.
-
-**Do not** invoke `/verify` or `pk ship` automatically. The user paces.
 
 ## Failure model
 


### PR DESCRIPTION
## Summary
The PIPEKIT_AUTO_SHIP env var mechanism from PR #56 was structurally broken: env vars set in one Bash tool call don't survive into subsequent Bash calls (each is a fresh subshell). `/verify` always read it as unset and stood down. PR #58 had since reverted `/work`'s auto-invoke prose, leaving `/verify`'s auto-ship logic in place but never signalled — effectively dead code.

This restores the auto-flow with a working signal: the Skill tool's `args` parameter.

## Changes
- **`/work` Step 7**: restores auto-invoke of `/verify` on clean exit; passes `args="--auto-ship"` via the Skill tool. Drops the broken `export PIPEKIT_AUTO_SHIP=1` instruction. Skip-the-rollover conditions (abort, deviation, explicit stop, behavioral gap) preserved.
- **`/verify` Step 4**: detects `--auto-ship` in its own args instead of reading `$PIPEKIT_AUTO_SHIP`. Adds a "Why an arg, not an env var" footnote so future sessions understand the constraint.
- **`bin/pk`**: PK_VERSION 2.1.2 → 2.1.3.

## How discovered
RS-76 dev session: `/verify` Pass'd, user echoed `$PIPEKIT_AUTO_SHIP` and saw `unset`, manually stood down. Diagnostic was correct — the var genuinely never gets set across Skill→Bash boundaries.

## Test plan
- [ ] Sync into rs-vault
- [ ] Run `/work <ID>` end-to-end on a clean issue; confirm `/verify` auto-runs and `pk ship` auto-runs on Pass
- [ ] Run `/verify` standalone (no `--auto-ship`); confirm hint-only behavior, no auto-ship
- [ ] Force a `/verify` Fail; confirm rollover stops, no `pk ship`, even with `--auto-ship` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)