### PR TITLE
chore(merge-strategy): forbid squash on feature → dev

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -174,8 +174,10 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        ▼
   ┌──────────────────────────────────────────────────────────┐
   │ [6] Merge PR (manual, GitHub UI)                         │
-  │     • feature → dev: merge-commit (history visibility)   │
-  │     • feature → main: squash (single commit per release) │
+  │     • feature → dev: merge-commit or rebase (NOT squash) │
+  │     • dev/beta → main: squash (single release commit)    │
+  │     Squash on feature → dev causes phantom conflicts on  │
+  │     the next promote. Emergency override only.           │
   └──────────────────────────────────────────────────────────┘
        │
        ▼

--- a/bin/pk
+++ b/bin/pk
@@ -682,6 +682,21 @@ cmd_ship() {
     echo "PR: $pr_url"
   fi
 
+  # Merge-strategy reminder. Squashing feature → dev collapses dev's commit
+  # identity and causes phantom conflicts on every subsequent dev → main
+  # promote. See sop/Git_and_Deployment.md § Merge Strategy by Hop.
+  case "$target" in
+    dev|beta)
+      echo ""
+      echo "⚑ Merge with: 'Create a merge commit' or 'Rebase and merge'."
+      echo "  Do NOT squash feature → dev (causes phantom-conflict tax on promotes)."
+      ;;
+    main)
+      echo ""
+      echo "⚑ Merge with: 'Squash and merge' (one release commit per promotion)."
+      ;;
+  esac
+
   # Linear: → In Review / UAT (state name varies; try common ones)
   local target_state
   case "$target" in

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -75,7 +75,7 @@ Different hops want different strategies. The phantom-conflict trap (observed du
 
 | Hop | Recommended | Also OK | Rationale |
 |---|---|---|---|
-| `feature/*` → `dev` | **Rebase** | Merge-commit | Rebase = linear atomic commits; merge-commit = bubble preserving feature scope. Either works on dev (no phantom-conflict risk; bubbles get absorbed when dev → main squashes). |
+| `feature/*` → `dev` | **Rebase** | Merge-commit | Rebase = linear atomic commits; merge-commit = bubble preserving feature scope. **Do not squash here.** Squashing feature → dev collapses dev's commit identity, and every subsequent `dev → main` promote then sees phantom conflicts (same content, different SHAs and boundaries). Emergency override only when dev tip is broken. |
 | `dev` → `beta` (three-tier) | Rebase or merge-commit | — | Same as feature → dev. |
 | **`dev` → `main`** (two-tier) or `beta` → `main` (three-tier) | **Squash (enforced)** | — | One release commit per promotion. Merge-commits here cause phantom conflicts on subsequent promotes. **Enforced by ruleset, not user discipline.** |
 


### PR DESCRIPTION
## Summary

Closes the gap that caused PRs #99, #109, and #127 to all need manual conflict resolution. PRs into `dev` were getting squash-merged, which collapses dev's commit identity and causes phantom conflicts on every subsequent `dev → main` promote.

## Changes

- **RUNBOOK step [6]** — rewrite to explicitly forbid squash on feature → dev, name the phantom-conflict cost, reserve emergency override.
- **sop/Git_and_Deployment.md** — sharpen the merge-by-hop table: **Do not squash here** is now bold with the rationale inline.
- **bin/pk cmd_ship** — append a branch-aware merge-strategy reminder right after the PR opens:
  - dev/beta target: "Merge with 'Create a merge commit' or 'Rebase and merge'. Do NOT squash."
  - main target: "Merge with 'Squash and merge'."

## Out of scope

Repo-level enforcement (GitHub branch protection / Rulesets). Project-specific, not the methodology repo's job. The `cmd_ship` reminder + sharpened docs are the methodology layer; consuming projects can layer Rulesets on top per `sop/Git_and_Deployment.md` § Enforcement model.

## Test plan

- [ ] `pk ship` against a `dev` target prints the merge-commit/rebase reminder.
- [ ] `pk ship --env=main` (multi-tier) prints the squash reminder.
- [ ] `bash -n bin/pk` is clean.
- [ ] RUNBOOK and Git SOP read consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)