### PR TITLE
fix(work): tighten auto-rollover skip — user signal only

### DIFF
--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -368,8 +368,9 @@ Once execution exits successfully — all tasks committed, no aborts, no deviati
 
 - `/work` was interrupted or aborted mid-execution (Ctrl-C, abort verdict, agent failure)
 - A deviation was raised that the user has not yet resolved
-- The user's last intent was an explicit stop (e.g., responding "stop" to a prompt)
-- A Step 6.5 behavioral gap was surfaced that the user clearly wants to resolve before verification (e.g. "let me check this manually first")
+- The user's last intent was an explicit stop — a stop signal **the user typed**, not one the agent self-issued. Examples: "stop", "let me check this manually first", "hold on", "wait", "pause", or any `--no-rollover` flag on the original `/work` invocation.
+
+**Do NOT skip** just because Step 6.5 surfaced behavioral or visual gaps. `/verify` is idempotent and read-only — running it does not prevent later human/browser checks. The Step 6.5 gap list is *advisory output*, not a pause signal. Pre-emptively skipping `/verify` because the agent feels cautious adds a manual step against the user's expectation of the v2 loop. If the user wants to pause, they will tell you; the rule is "user-driven stop, not agent-driven stop."
 
 Otherwise:
 


### PR DESCRIPTION
## Summary

`/work`'s Step 7 auto-rollover skip condition #4 ("Step 6.5 behavioral gap was surfaced that the user clearly wants to resolve before verification") was ambiguous and got applied agent-side: `/work` would self-pause when its own Step 6.5 listed visual/UX gaps, even though the user hadn't asked to stop.

Surfaced today (2026-05-05) on RS-79 — a UI change where `/work` listed 5 \"needs human eyes\" items, then refused to auto-rollover into `/verify` despite the user expecting the v2 daily-loop to flow through.

## Why it's wrong

- `/verify` is idempotent and read-only. Running it does not prevent later browser/visual checks.
- Step 6.5's gap list is **advisory output**, not a pause signal.
- The example trigger phrases in the original prose (\"stop\", \"let me check this manually first\") are things the **user types** — not things the **agent** infers from its own self-survey.
- Pre-emptively skipping `/verify` adds a manual step against the v2 loop's design.

## Fix

Rewrite skip condition #4 to make the user-signal-only intent explicit, and add a \"Do NOT skip\" clause naming the failure mode (agent self-pause on Step 6.5 gaps).

```diff
- - The user's last intent was an explicit stop (e.g., responding "stop" to a prompt)
- - A Step 6.5 behavioral gap was surfaced that the user clearly wants to resolve...
+ - The user's last intent was an explicit stop — a stop signal **the user typed**,
+   not one the agent self-issued. Examples: "stop", "let me check this manually
+   first", "hold on", "wait", "pause", or any \`--no-rollover\` flag on the
+   original \`/work\` invocation.
+
+ **Do NOT skip** just because Step 6.5 surfaced behavioral or visual gaps.
+ \`/verify\` is idempotent and read-only — running it does not prevent later
+ human/browser checks. The Step 6.5 gap list is *advisory output*, not a pause
+ signal. ...
```

## Test plan

- [ ] `/work` on a UI issue with Step 6.5 gaps → auto-rollover fires.
- [ ] User typing \"stop\" or \"let me check first\" → rollover skips with legacy hand-off.
- [ ] Skill prose reads consistently with \"the user is the chain\" principle elsewhere in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)