### PR TITLE
feat(pk verify): self-reference check — automated gate for RS-29-style misses

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -878,7 +878,26 @@ cmd_verify() {
     return 1
   fi
   echo "Running pre-deploy gate..."
-  echo "$cmd" | bash
+  echo "$cmd" | bash || return $?
+
+  # Optional: self-reference check (catches RS-29-style integration misses
+  # where the gate is green but a predecessor's placeholder still references
+  # the current ticket in an un-touched file). Opt-in via:
+  #   | **Self-reference check** | `enabled` |
+  # in method.config.md. The script lives in pipekit and gets synced.
+  local sr_flag root sr_script
+  sr_flag=$(pk_config "Self-reference check" "disabled")
+  if [ "$sr_flag" = "enabled" ]; then
+    root=$(pk_repo_root)
+    sr_script="$root/scripts/check-no-self-references.sh"
+    if [ -x "$sr_script" ]; then
+      echo ""
+      bash "$sr_script" || return $?
+    else
+      echo "  ⓘ Self-reference check enabled but script not found at $sr_script" >&2
+      echo "    Run scripts/sync-method.sh from pipekit to install it." >&2
+    fi
+  fi
 }
 
 cmd_promote() {

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -153,6 +153,8 @@ Keys consumed by `bin/pk` and the `/work` + `/verify` skills. All have sensible 
 | **Migration dir** | e.g. `supabase/migrations/` | (none) | `/pr-security-review` (locate migrations to audit) |
 | **Spec ready state** | Linear state name | `Specced` | `pk spec-cycle` (refuses to trigger if issue is in any other state) |
 | **Spec approved state** | Linear state name | `Approved` | `pk spec-cycle` (transitions issue to this state on a Pass verdict) |
+| **Self-reference check** | `enabled` \| `disabled` | `disabled` | `pk verify` — runs `scripts/check-no-self-references.sh`; fails if current branch's source still references its own ticket ID (e.g. `RS-29`) in any file the branch did not edit. Catches predecessor-placeholder integration misses (RS-29 rs-vault, 2026-05-05). Bypass on a per-run basis with `AGREED_PLACEHOLDER=1 pk verify` after surfacing matches in the hand-off summary. |
+| **Source root** | path | `src/` | `scripts/check-no-self-references.sh` (where to grep) |
 
 ### Example (rs-vault)
 

--- a/scripts/check-no-self-references.sh
+++ b/scripts/check-no-self-references.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# check-no-self-references.sh — fail if the current branch's source still
+# contains references to its own ticket ID outside the files it edited.
+#
+# Catches the RS-29 failure mode: a ticket ships, all tests pass, gate is
+# green, but a predecessor's placeholder branch in an un-touched file still
+# references the current ticket ("until RS-29 ships"). The integration is
+# incomplete.
+#
+# Usage:
+#   scripts/check-no-self-references.sh             # auto-detect issue ID + source root
+#   scripts/check-no-self-references.sh RS-29       # explicit issue ID
+#   scripts/check-no-self-references.sh RS-29 src/  # explicit ID + source root
+#
+# Exit codes:
+#   0 — no matches outside edited files (or no issue ID detected → skip)
+#   1 — matches found in non-edited, non-allowlisted source files
+#   2 — usage / configuration error
+#
+# Configuration (read from method.config.md if present):
+#   Source root        — defaults to `src/`
+#   Allowlist          — globs always excluded (defaults: *.md, *.test.*,
+#                        Logs/Sessions/**, .vbw-planning/**, CHANGELOG*)
+
+set -euo pipefail
+
+# --- Locate repo + config --------------------------------------------------
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "ERROR: not in a git repo" >&2
+  exit 2
+}
+cd "$REPO_ROOT"
+
+CONFIG="$REPO_ROOT/method.config.md"
+
+# Prefer pk_config (read structured value from method.config.md). Falls back
+# to defaults when pk isn't on PATH or method.config.md is missing.
+read_config() {
+  local key="$1" default="$2"
+  if command -v pk >/dev/null 2>&1 && [ -f "$CONFIG" ]; then
+    pk pk_config "$key" "$default" 2>/dev/null || echo "$default"
+  else
+    echo "$default"
+  fi
+}
+
+# --- Resolve issue ID ------------------------------------------------------
+
+ISSUE="${1:-}"
+if [ -z "$ISSUE" ]; then
+  CURRENT=$(git branch --show-current 2>/dev/null || echo "")
+  ISSUE=$(echo "$CURRENT" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+fi
+if [ -z "$ISSUE" ]; then
+  echo "  ⓘ check-no-self-references: no issue ID detected (branch: ${CURRENT:-<none>}); skipping"
+  exit 0
+fi
+
+# --- Resolve source root ---------------------------------------------------
+
+SOURCE_ROOT="${2:-}"
+if [ -z "$SOURCE_ROOT" ]; then
+  SOURCE_ROOT=$(read_config "Source root" "src/")
+fi
+if [ ! -d "$REPO_ROOT/$SOURCE_ROOT" ]; then
+  # Fallback: try common roots
+  for cand in src/ app/ packages/; do
+    if [ -d "$REPO_ROOT/$cand" ]; then
+      SOURCE_ROOT="$cand"
+      break
+    fi
+  done
+fi
+if [ ! -d "$REPO_ROOT/$SOURCE_ROOT" ]; then
+  echo "  ⓘ check-no-self-references: source root '$SOURCE_ROOT' not found; skipping" >&2
+  exit 0
+fi
+
+# --- Determine merge-base + edited files -----------------------------------
+
+# Default base branch: try origin/dev → origin/main → main → empty.
+BASE=""
+for cand in origin/dev origin/main main dev; do
+  if git rev-parse --verify "$cand" >/dev/null 2>&1; then
+    BASE="$cand"
+    break
+  fi
+done
+
+EDITED_FILES=""
+if [ -n "$BASE" ]; then
+  EDITED_FILES=$(git diff --name-only "$BASE"...HEAD 2>/dev/null | sort -u)
+fi
+
+# --- Run the grep ----------------------------------------------------------
+
+# Pathspec exclusions for the allowlist. Globs use git's pathspec syntax.
+ALLOWLIST=(
+  ":(exclude)*.md"
+  ":(exclude)*.test.*"
+  ":(exclude)*.spec.*"
+  ":(exclude)**/__tests__/**"
+  ":(exclude)Logs/Sessions/**"
+  ":(exclude).vbw-planning/**"
+  ":(exclude)CHANGELOG*"
+)
+
+# Run grep in source root + allowlist exclusions.
+matches=$(git grep -nE "$ISSUE" -- "$SOURCE_ROOT" "${ALLOWLIST[@]}" 2>/dev/null || true)
+
+if [ -z "$matches" ]; then
+  echo "✓ check-no-self-references: no '$ISSUE' references in $SOURCE_ROOT (excluding tests/docs)"
+  exit 0
+fi
+
+# --- Filter out edited files ----------------------------------------------
+
+unexpected=""
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file="${line%%:*}"
+  if [ -n "$EDITED_FILES" ] && echo "$EDITED_FILES" | grep -qx "$file"; then
+    continue  # legitimate — this file was edited by the current branch
+  fi
+  unexpected+="$line"$'\n'
+done <<< "$matches"
+
+if [ -z "$unexpected" ]; then
+  edited_count=$(echo "$matches" | wc -l | tr -d ' ')
+  echo "✓ check-no-self-references: $edited_count match(es) for '$ISSUE', all in edited files"
+  exit 0
+fi
+
+# --- Report failures -------------------------------------------------------
+
+echo ""
+echo "✗ check-no-self-references: '$ISSUE' is referenced in non-edited source files:"
+echo ""
+printf '%s' "$unexpected" | sed 's/^/  /'
+echo ""
+echo "These are likely placeholder branches a predecessor scaffolded for this ticket"
+echo "to replace. Either (a) make the edit to remove them, or (b) re-run with"
+echo "AGREED_PLACEHOLDER=1 to bypass after surfacing them in the hand-off summary."
+echo ""
+
+if [ "${AGREED_PLACEHOLDER:-0}" = "1" ]; then
+  echo "  AGREED_PLACEHOLDER=1 — bypassing (matches above must be in hand-off summary)"
+  exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary

Catches the failure mode where a feature branch passes types, lint, tests, and the full pre-deploy gate — but a predecessor's placeholder in an un-touched file still references the current ticket (\"until RS-29 ships\"). Integration incomplete, gate green, PR ships broken-on-completion.

Surfaced 2026-05-05 by RS-29 in rs-vault. PR #66 was the prose half of the fix; this is the automated half.

## What it does

`scripts/check-no-self-references.sh` runs as part of `pk verify` (opt-in). For the current branch:

1. Detects issue ID from `[A-Z]+-[0-9]+` in the branch name (or accepts an explicit arg).
2. `git grep` for that ID in the source root, excluding `*.md`, `*.test.*`, `*.spec.*`, `__tests__/`, `Logs/Sessions/`, `.vbw-planning/`, `CHANGELOG*`.
3. Filters out matches in files the current branch edited (legitimate work).
4. Exits 1 with unexpected matches printed; exits 0 if clean.

Bypass for intentional cases: `AGREED_PLACEHOLDER=1 pk verify` (surface the matches in the hand-off summary).

## Wire-up

`pk verify` runs the script after the standard gate, gated on a new config flag:

\`\`\`
| **Self-reference check** | \`enabled\` \| \`disabled\` | \`disabled\` | pk verify |
| **Source root**          | path                      | \`src/\`      | check script grep target |
\`\`\`

Default is **disabled** so existing projects don't break on first sync. Consuming projects opt in by flipping the flag in `method.config.md`.

## Test scenarios (passed)

Synthetic RS-29-pattern repo:

| Scenario | Expected | Got |
|---|---|---|
| Placeholder in un-touched file | exit 1 + matches printed | ✓ |
| `AGREED_PLACEHOLDER=1` bypass | exit 0 + bypass note | ✓ |
| Placeholder removed in edited file | exit 0 | ✓ |
| No issue ID in branch name | skip, exit 0 | ✓ |
| Source root missing | skip, exit 0 | ✓ |

## Trilogy

- PR #65 — tighten what triggers a skip (user-typed only)
- PR #66 — tighten what triggers a \"complete\" (literal grep + matches)
- **PR #67 (this) — automated gate when the model still skips**

## Test plan

- [ ] Sync into rs-vault (`scripts/sync-method.sh`); enable `Self-reference check: enabled` in `method.config.md`; run `pk verify` on a feature branch with a known-clean integration → passes.
- [ ] Synthetic test against the RS-29 pattern (a placeholder in `src/builder.tsx` referencing the current ticket) → fails with the placeholder line surfaced.
- [ ] `pk verify` without the flag enabled → unchanged behavior (gate runs, no extra check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)