### PR TITLE
fix(work): make rollover mandatory — remove all judgment-based skip conditions

### DIFF
--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -387,36 +387,47 @@ Do **not** generate plausible-sounding rationale that fits the visible artifact.
 
 When in doubt, default to: *"Let me check the spec and the integration site before I answer."*
 
-## Step 7 — Auto-rollover to /verify
+## Step 7 — Auto-rollover to /verify (mandatory)
 
-Once execution exits successfully — all tasks committed, no aborts, no deviation pending user input — auto-invoke `/verify` immediately. Do not prompt; verification is the deterministic next step in the v2 loop, and `/verify` is idempotent and read-only.
+**Rollover is mandatory.** When Step 6 finishes — last commit lands, last shell command exits 0 — invoke `/verify` immediately. Do not deliberate. Do not weigh whether the user "might want" to inspect first. Do not interpret implementation notes, Step 6.5 advisory output, or surfaced deviations as a pause signal. The user opted into the chain by typing `/work`; they will type Ctrl-C, `stop`, or pass `--no-rollover` if they want to pause.
 
-**Skip the rollover** if any of the following holds:
+This rule exists because three prior versions of this skill listed soft skip conditions ("explicit stop", "deviation pending user input", "behavioral gap surfaced") and the model paraphrased past every one of them — turning the v2 loop into a manual chain. Rollover is the loop. If you skip it on agent judgment, you broke the loop.
 
-- `/work` was interrupted or aborted mid-execution (Ctrl-C, abort verdict, agent failure)
-- A deviation was raised that the user has not yet resolved
-- The user's last intent was an explicit stop — a stop signal **the user typed**, not one the agent self-issued. Examples: "stop", "let me check this manually first", "hold on", "wait", "pause", or any `--no-rollover` flag on the original `/work` invocation.
+### Mechanical skip conditions (the only ones)
 
-**Do NOT skip** just because Step 6.5 surfaced behavioral or visual gaps. `/verify` is idempotent and read-only — running it does not prevent later human/browser checks. The Step 6.5 gap list is *advisory output*, not a pause signal. Pre-emptively skipping `/verify` because the agent feels cautious adds a manual step against the user's expectation of the v2 loop. If the user wants to pause, they will tell you; the rule is "user-driven stop, not agent-driven stop."
+Skip rollover only when **a deterministic, non-judgmental signal** holds. There are exactly two:
 
-Otherwise:
+1. **Execution failed.** The last shell command in Step 6 exited non-zero, or a Bash tool call returned an error you could not auto-recover. This is checkable: `if (last_exit_code != 0)`. No interpretation.
+2. **`--no-rollover` flag.** Passed on the original `/work <ISSUE-ID> --no-rollover` invocation. The user said "build but don't auto-verify." This is checkable: scan the invocation args.
+
+Nothing else skips. Not "the user might want to inspect." Not "implementation deviated from spec wording." Not "Step 6.5 listed gaps." Not "I'm uncertain." Those produce *advisory output in the hand-off summary*, not skips.
+
+### Procedure
 
 1. Print: `✓ /work complete for <ISSUE-ID> — auto-running /verify`
 2. Invoke `/verify` by calling the Skill tool with `skill="verify"` and `args="--auto-ship"`. The `--auto-ship` arg signals `/verify` that this invocation is part of the auto-flow and authorises `pk ship` on Pass. **Do not** try to set environment variables before invoking — env vars don't propagate across separate Bash subshells, so the only reliable signal is the Skill tool's `args` parameter.
 3. Surface `/verify`'s verdict block to the user verbatim.
 4. After `/verify` returns:
-   - If `/verify` Pass: `pk ship` will already have run inside `/verify`'s rollover (Step 4 below). Print the final hand-off line: _"Run `/pk-exit` at the end of the session to write `Logs/Sessions/<date>_<HHMM>.md`."_
-   - If `/verify` Partial / Fail: STOP. The verdict block already showed the per-AC table; do not invoke `pk ship`. Tell the user: _"Address the failures and re-run `/verify` when ready (or `/work --resume` if execution gaps remain)."_
+   - **Pass:** `pk ship` will already have run inside `/verify`'s rollover. Print: _"Run `/pk-exit` at the end of the session to write `Logs/Sessions/<date>_<HHMM>.md`."_
+   - **Partial / Fail:** STOP. The verdict block already showed the per-AC table; do not invoke `pk ship`. Tell the user: _"Address the failures and re-run `/verify` when ready (or `/work --resume` if execution gaps remain)."_
 
-If the rollover is skipped (per the conditions above), fall back to the legacy hand-off:
+### When the rollover IS skipped (one of the two mechanical conditions)
+
+Print the legacy hand-off:
 
 ```
 ✓ /work paused for <ISSUE-ID>
+
+Reason: <execution-failure | --no-rollover>
 
 Resume:
   /work <ISSUE-ID>          — continue execution
   /verify                   — run gate manually if you want to inspect first
 ```
+
+### Self-check before declaring complete
+
+Before printing the hand-off, ask yourself: "Did the last shell command exit 0?" If yes, **the rollover MUST run.** If you find yourself drafting a hand-off with `Required next: /verify` (the legacy form) when execution succeeded, **stop and invoke the Skill tool instead.** That hand-off line is reserved for the mechanical-skip case. Printing it after a green run means you skipped on judgment, which is forbidden.
 
 ## Failure model
 


### PR DESCRIPTION
## Summary

Third pass-through of the same failure mode in 24 hours (RS-79, RS-29, RS-80 in rs-vault — three different `/work` runs, three different rationalizations, same skipped `/verify` on a successful run). The trilogy of prose fixes (#65, #66, #67) reduced the surface area but did not eliminate the model's tendency to interpret soft signals as a skip rationale.

**Verdict:** prose cannot reliably constrain model judgment when the model has any latitude to read \"I'm uncertain\" as a pause signal. Stop enumerating \"good reasons to skip\" — the model will always find one.

**Fix:** remove all judgment-based skip conditions. Rollover becomes mandatory unless one of two **mechanical** signals fires.

## Diff in one line

\`\`\`diff
- Skip if user "explicitly stopped" / surfaced a gap / raised a deviation
+ Skip ONLY if last shell exited non-zero OR --no-rollover flag passed
\`\`\`

## Mechanical skip conditions (the only ones)

1. **Execution failed.** Last shell command in Step 6 exited non-zero. Checkable: `if (last_exit_code != 0)`. No interpretation.
2. **`--no-rollover` flag.** Passed on the original `/work` invocation. The user opted out at invocation time. Checkable: scan args.

Nothing else skips. Not \"the user might want to inspect.\" Not \"implementation deviated from spec wording.\" Not \"Step 6.5 listed gaps.\" Not \"I'm uncertain.\" Those produce **advisory output in the hand-off summary**, not skips.

## What changed in skill.md

- Step 7 preamble: \"Rollover is the loop. If you skip on judgment, you broke the loop.\"
- Skip-condition list reduced to the two mechanical signals (with explicit \"checkable\" annotations).
- Added a **self-check** at the end: if you find yourself drafting a `Required next: /verify` hand-off after a green run, **you skipped on judgment** — stop and invoke the Skill tool instead.

## Trilogy → Quadrilogy

| PR | What | Why it wasn't enough |
|---|---|---|
| #65 | tighten condition #4 to require user-typed stop | model still inferred user intent from its own Step 6.5 |
| #66 | literal grep commands in Step 6.5 | doesn't fix rollover-skip; only fixes integration check |
| #67 | automated gate (`check-no-self-references.sh`) | catches integration misses post-hoc, not rollover skips |
| **#68 (this)** | **mandatory rollover, mechanical-only skip** | — |

## Behavior change

Slightly more aggressive defaults. Users who want to pause now:

- Ctrl-C during execution, or
- Pass `--no-rollover` on the original `/work` invocation.

Matches the v2 loop design: the user paces by what they invoke, not by what the agent infers from advisory output.

## Test plan

- [ ] `/work` on a clean issue → green execution → `/verify` auto-fires, no judgment-based hesitation.
- [ ] `/work --no-rollover RS-NN` → `/verify` skipped, legacy hand-off prints with `Reason: --no-rollover`.
- [ ] `/work` where Step 6 fails → `/verify` skipped, legacy hand-off prints with `Reason: execution-failure`.
- [ ] `/work` with surfaced deviations in hand-off summary → rollover still fires (deviations are output, not skip signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)