### PR TITLE
fix(pk done): SIGPIPE-immune git log read — silent exit 141

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -793,7 +793,11 @@ cmd_done() {
   local merge_base commits diffstat pr_url_done
   merge_base=$(git merge-base "$current" "$(pk_integration_branch)" 2>/dev/null || echo "")
   if [ -n "$merge_base" ]; then
-    commits=$(git log "${merge_base}..${current}" --pretty=format:'- %h %s' 2>/dev/null | head -20)
+    # Use awk instead of `head -20` — awk reads the full stream so git log
+    # never gets SIGPIPE. Under `set -o pipefail`, head's early-exit kills
+    # git log mid-stream and the pipeline returns 141, silently aborting
+    # cmd_done with no output (RS-80 in rs-vault, 2026-05-05).
+    commits=$(git log "${merge_base}..${current}" --pretty=format:'- %h %s' 2>/dev/null | awk 'NR<=20')
     diffstat=$(git diff --shortstat "${merge_base}..${current}" 2>/dev/null | sed 's/^[[:space:]]*//')
   fi
   pr_url_done=$(pk_gh_pr_view "$current" | jq -r '.url // empty')


### PR DESCRIPTION
## Summary

`pk done` was silently exiting with code 141 (SIGPIPE) when the merge included more than 20 commits — Linear stays UAT, worktree remains, branch lingers, no output. Surfaced 2026-05-05 on RS-80 (rs-vault, 22 commits in the merge range).

## Root cause

\`\`\`bash
commits=\$(git log \"\${merge_base}..\${current}\" --pretty=format:'- %h %s' 2>/dev/null | head -20)
\`\`\`

With `set -euo pipefail` (set at the top of `bin/pk`), this pipeline:

1. `git log` produces N>20 lines
2. `head -20` exits after reading 20 lines
3. `git log` gets SIGPIPE on its next write
4. Pipeline exit code = 141
5. `pipefail` propagates the 141 as the substitution's exit code
6. `cmd_done` aborts before the first \`echo\`, before \`pk_linear_*\`, before worktree cleanup

Net effect: a no-op that looks like success at the prompt level (no error) but actually changes nothing.

## Fix

Replace `head -20` with `awk 'NR<=20'`. awk reads the full stream to EOF, silently dropping lines past 20 — git log never gets SIGPIPE. Output is identical; behavior under `pipefail` is now safe.

## Audit of other suspect pipes

\`\`\`
$ grep -n '| head ' bin/pk
\`\`\`

| Line | Shape | Risk |
|---|---|---|
| 52, 185, 307, 309, 416, 560, 758, 1287 | `head -1` over bounded grep/jq output | None — producer terminates first |
| 879 | `grep -A20 ... \| head -10` over markdown file | None — bounded producer |
| 796 (this fix) | `git log range \| head -20` | **SIGPIPE on long ranges** |

Only the `cmd_done` pipe was reading a potentially-unbounded stream.

## Test

Verified against the actual broken case (rs-vault RS-80 with 22 commits in the merge range):

- Before: `pk done RS-80` → exit 141, no output, state unchanged
- After: `pk done RS-80` → Linear comment posted, Linear UAT → Done, worktree removed, branch deleted, exit 0

## Test plan

- [ ] `pk done` on a branch with ≤20 commits in the merge range — works (always did)
- [ ] `pk done` on a branch with >20 commits in the merge range — now works (was the bug)
- [ ] `pk done` on a branch where the PR is not merged — still refuses with the existing error

🤖 Generated with [Claude Code](https://claude.com/claude-code)