### PR TITLE
feat: /pk-bug pipeline skill + /work auto-branch ergonomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ VBW agents don't call skills — they read the consuming project's CLAUDE.md dir
 | `/spec-preflight` | Empirical pre-flight checks on a Linear issue's spec — verifies file paths, line refs, phase-detect baseline, Linear status, dependencies against reality. Read-only. |
 | `/pr-fix` | Precision PR review across 4 dimensions with confidence-gated findings, interactive discussion, and targeted remediation. |
 | `/pr-security-review` | Security-focused antagonistic PR review for migrations, RLS, SECURITY DEFINER, GRANT/REVOKE, auth, and Server Actions on privileged tables. |
+| `/pk-bug` | Bug pipeline — intake, reproduce, regression-test-first, fix, ship, postmortem. Wraps `/work` and `pk ship` with discipline gates. |
 | `/pipekit-help` | Reads project state, recommends the next pipeline step. |
 | `/strategy-sync` | Updates Strategy docs post-ship to match what was actually built. |
 | `/release-changelog` | Generates draft CHANGELOG entry from git commits between tags. |

--- a/skills/pk-bug/skill.md
+++ b/skills/pk-bug/skill.md
@@ -1,0 +1,244 @@
+---
+name: pk-bug
+description: Bug pipeline — intake, reproduce, regression-test-first, fix, ship, postmortem. Wraps /work and pk ship with discipline gates. Invoke when a bug is reported or spotted. Linear is the source of truth — resume by passing the issue ID.
+---
+
+# /pk-bug Skill
+
+You run the **bug pipeline**: a disciplined wrapper around the daily loop that enforces *regression-test-first* fixing. The point: a bug, once fixed, must never silently re-ship — there must be a test that would have caught it.
+
+## When to use
+
+Invoke when:
+- A bug is reported by a user
+- You spot a bug during dev or QA
+- You're resuming a bug already in flight (`/pk-bug <ISSUE-ID>`)
+
+Do NOT use for:
+- New features (use `pk next` → `/work`)
+- Spec work (use `/light-spec`)
+- PR review of an unrelated change (use `/pr-fix`)
+
+## Invocation forms
+
+```
+/pk-bug                       # new bug, prompts for everything
+/pk-bug "<one-liner>"         # new bug, description prefilled
+/pk-bug <ISSUE-ID>            # resume — reads Linear, routes to right phase
+```
+
+## Source of truth
+
+**Linear is authoritative.** This skill stores no local state. Every resume reads the Linear issue (status, body, comments) and routes to the correct phase. New session safe.
+
+Read `method.config.md` for:
+- Linear team ID, workflow state IDs
+- Pre-deploy gate commands
+- Backend (`vbw` or `native`) — passed through to `/work`
+
+## Resume routing
+
+When invoked with an existing `<ISSUE-ID>`, query Linear and enter the phase below:
+
+Routing keys off Linear's `statusType` (not display name) so projects with custom statuses like `Parked` route correctly.
+
+| Linear state                                                            | Enter phase |
+|------------------------------------------------------------------------|-------------|
+| Issue not yet created                                                   | 1 — Intake |
+| `statusType=backlog`, no "Reproduced:" comment                          | 2 — Reproduce |
+| `statusType=backlog` + "Reproduced:" comment, no test file              | 3 — Diagnose + Test |
+| Test file exists, no branch                                             | 4 — Worktree handoff |
+| `statusType=started` (e.g. In Progress)                                 | 5 — Fix + Ship |
+| `statusType=started` + PR open (or status named UAT/Review)             | 6 — PR review + merge to dev |
+| Merged to dev, not on main                                              | 7 — Promote dev → main |
+| `statusType=completed`, no postmortem comment (priority ≤ Medium = 3)   | 8 — Postmortem |
+| `statusType=completed`, postmortem present                              | report complete, exit |
+
+Heuristics for state detection:
+- "Reproduced" = Linear comment starting with `Reproduced:` (you write this in Phase 2)
+- "Test file exists" = grep the issue body for `## Regression Test` section filled in
+- "Branch exists" = `git branch --list <ISSUE-ID>` returns a result
+- "Postmortem present" = Linear comment containing `# Postmortem` heading
+
+---
+
+## Phase 1 — Intake
+
+**Goal:** create a well-formed Linear issue.
+
+1. Ask the user the questions in `templates/intake.md`. If a one-liner was passed, prefill the description hint.
+2. **Priority heuristic** to show the user (Linear `priority` field — native, no custom labels):
+   - `Urgent` (1) — data loss / auth bypass / money / production down
+   - `High` (2) — core flow broken (e.g. sign-out failing for magic-link users)
+   - `Medium` (3) — degraded UX, workaround exists
+   - `Low` (4) — cosmetic / single-user / edge case
+3. **Urgent fast path:** if user picks `Urgent`, skip detailed intake — capture one-liner + priority, mark issue body with `**Fast-path: Urgent** — fill in details during postmortem`. Postmortem becomes mandatory + reviewer sign-off in Phase 8.
+4. Create Linear issue:
+   - Team: from `method.config.md`
+   - Status: backlog-type (e.g. `Backlog` or `Parked` — anything with `statusType=backlog`)
+   - Priority: 1–4 per the heuristic above
+   - Labels: `Bug` (no severity labels — priority is the native field)
+   - Body: filled `templates/intake.md`
+5. Echo `<ISSUE-ID>` to the user. Advance to Phase 2.
+
+---
+
+## Phase 2 — Reproduce  *(GATE)*
+
+**Goal:** reproduce locally before any diagnosis.
+
+1. Read repro steps from the Linear issue body.
+2. Reproduce by the most direct path:
+   - **UI bug:** Playwright MCP, walk the steps
+   - **Backend logic:** `curl` / direct test invocation
+   - **Auth flow** (e.g. magic-link sign-out): full e2e — sign in, observe state, sign out, assert state changed
+3. **Gate decision:**
+   - **Reproduced** → comment on Linear:
+     ```
+     Reproduced: <one-line evidence>
+     - Method: <Playwright | curl | manual>
+     - Artifact: <screenshot path | log snippet | n/a>
+     ```
+     Advance to Phase 3.
+   - **Cannot reproduce** → Linear status to `Triage` or label `needs-info`, comment with everything tried. **STOP. Do not guess-fix.** Inform user, exit.
+
+---
+
+## Phase 3 — Diagnose + Failing Regression Test  *(GATE)*
+
+**Goal:** find root cause AND write a test that fails because the bug exists. **Done on `main` branch — test file is uncommitted.**
+
+### 3a — Diagnose
+
+Use the scientific method:
+1. State a hypothesis (1 sentence)
+2. Verify by reading the relevant code / logs / DB
+3. Narrow until you have a one-paragraph root-cause statement
+4. Append the root cause to the Linear issue body under `## Root Cause`
+
+If diagnosis takes more than ~30 minutes of investigation, consider spawning the `vbw-debugger` agent. Don't burn the main context on a deep dive.
+
+### 3b — Write the failing test
+
+Pick the right test type for the bug:
+
+| Bug type | Test type | Location convention |
+|----------|-----------|---------------------|
+| Logic / data layer | Unit or integration | colocated `*.test.ts` |
+| UI behavior | Playwright e2e | `tests/e2e/` |
+| Pure visual / spacing | Playwright visual snapshot (`toHaveScreenshot()`) | `tests/e2e/visual/` |
+| Auth / session flow | Playwright e2e (full session lifecycle) | `tests/e2e/auth/` |
+
+**Auth-flow test shape (illustrative — adapt to your stack):**
+```ts
+test('user state is fully cleared after sign-out', async ({ page }) => {
+  await signIn(page, testUser);
+  await expect(page).toHaveURL('/dashboard');
+  await signOut(page);
+  await expect(page).toHaveURL('/login');
+  // Critical: session is actually gone, not just UI redirect
+  const cookies = await page.context().cookies();
+  expect(cookies.find(c => c.name.includes('auth'))).toBeUndefined();
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL('/login');  // protected route bounces
+});
+```
+
+### Gate
+
+Run the test. It MUST fail for the **right reason** — the bug exists, not a setup error.
+
+- ✅ Test imports cleanly, the bug-specific assertion fails → continue
+- ❌ Import error / fixture missing / timeout / 500 from setup → fix the test, do not advance
+
+Append test path to Linear issue body under `## Regression Test`.
+
+---
+
+## Phase 4 — Worktree handoff
+
+**Goal:** move from main into an isolated worktree, with the test as the first commit.
+
+1. Run `pk branch <ISSUE-ID>`
+   - Creates worktree, branch, sets Linear → `In Progress`
+2. `cd` into the worktree
+3. Move the test file from main into the worktree (or recreate — usually a git stash + apply)
+4. Commit ONLY the test:
+   ```
+   git add <test-path>
+   git commit -m "test(<ISSUE-ID>): add failing regression test for <one-liner>"
+   ```
+5. Verify: `git log --oneline` shows the test commit. Run the test from the worktree — must still fail.
+
+This commit is the audit trail. Anyone reading `git log` later sees the test landed before the fix.
+
+---
+
+## Phase 5 — Fix + Verify + Ship
+
+**Goal:** make the test pass, ship.
+
+1. Hand off to `/work <ISSUE-ID>` with this directive in the prompt:
+   > A regression test exists at `<test-path>` and currently fails. Your job is to make it pass without modifying the test file. The root cause is documented in the issue body under `## Root Cause`.
+2. After `/work` completes:
+   - Run the regression test alone — must pass
+   - Run `/verify` — full pre-deploy gate
+3. `pk ship` — opens PR, Linear → `UAT`
+   - For auth / RLS / migration bugs: `pk ship --review` to invoke the antagonistic reviewer
+
+---
+
+## Phase 6 — PR review + merge to dev
+
+1. Optional but encouraged for priority ≤ Medium (1–3):
+   - Auth / security bugs → `/pr-security-review`
+   - General code quality → `/pr-fix`
+2. Address review feedback (commit on the same branch)
+3. Merge PR to `dev`
+4. `pk done <ISSUE-ID>` — verifies merged, cleans worktree+branch, posts commit summary to Linear
+
+---
+
+## Phase 7 — Promote dev → main
+
+- `Urgent` → run `pk promote` immediately (solo promote, do not batch)
+- `High` / `Medium` / `Low` → leave for the next batched promote. Comment on Linear: `Awaiting next dev → main promote.`
+
+After main deploys, Linear should auto-transition to `Done` (per the existing automation).
+
+---
+
+## Phase 8 — Postmortem
+
+**Mandatory for priority ≤ Medium (1–3). Optional but recommended for low.**
+
+1. Append a Linear comment using `templates/postmortem.md`:
+   - What broke (1 sentence)
+   - Which gate should have caught it
+   - One change to prevent recurrence
+2. **Urgent only:** request reviewer sign-off in the comment thread before marking complete.
+3. If "one change to prevent recurrence" is concrete (e.g. "add Playwright e2e for every auth-method × sign-out combo"), create a follow-up Linear issue or add a rule to `.claude/rules/`.
+
+---
+
+## Invariants
+
+| Rule | Enforcement |
+|------|-------------|
+| No fix code before failing test exists | Phase 3 gate; Phase 4 commits test first |
+| Cannot repro → STOP | Phase 2 gate; mark `needs-info`, exit |
+| Linear is the source of truth | Resume always re-reads Linear, never local state |
+| Postmortem mandatory for priority 1–3 | Phase 8; reviewer sign-off if Urgent |
+| Urgent → solo promote | Phase 7 |
+| Test commit lands before fix commit | Phase 4 step 4 |
+
+## Failure modes to avoid
+
+- **Don't skip Phase 2** because the bug "obviously" exists. Unrepro'd bugs get guess-fixed and ship as silent regressions.
+- **Don't write the test after the fix.** A test written against passing code tests the fix, not the spec — it won't catch the same bug class re-introduced later.
+- **Don't fold test + fix into one commit.** The audit trail is part of the value.
+- **Don't promote `Urgent` bugs in a batch.** Blast radius mismatch.
+
+## Origin
+
+Built locally in rs-vault, dogfooded on RS-94 (magic-link Enter-key OAuth misroute, 2026-05-07), promoted to Pipekit upstream after the first clean run. The pattern: build a candidate skill in a consuming project under `.claude/skills/<name>/`, dogfood on a real ticket, promote to `pipekit/skills/<name>/` once it earns its keep, sync back via `sync-method.sh`.

--- a/skills/pk-bug/templates/intake.md
+++ b/skills/pk-bug/templates/intake.md
@@ -1,0 +1,31 @@
+# Bug Report
+
+**Priority:** {Urgent | High | Medium | Low}  *(Linear native field — set on the issue, not in body)*
+**Suspected area:** {file path or feature, optional}
+
+## Repro Steps
+1.
+2.
+3.
+
+## Expected
+{what should happen}
+
+## Actual
+{what actually happens}
+
+## Environment
+- Browser/OS:
+- Auth method: {password | magic link | OAuth | n/a}
+- User role:
+- URL / route:
+- Date observed:
+
+## Repro Evidence
+{filled in during Phase 2 — screenshot path, log excerpt, curl output, or "Reproduced via Playwright"}
+
+## Root Cause
+{filled in during Phase 3 — 1-2 sentences}
+
+## Regression Test
+{filled in during Phase 3 — path to failing test}

--- a/skills/pk-bug/templates/postmortem.md
+++ b/skills/pk-bug/templates/postmortem.md
@@ -1,0 +1,22 @@
+# Postmortem — {ISSUE-ID}
+
+**Priority:** {Urgent | High | Medium}
+**Shipped:** {date}
+
+## What broke
+{1 sentence}
+
+## Which gate should have caught it?
+- [ ] Spec / planning
+- [ ] /verify (pre-deploy gate)
+- [ ] PR review (/pr-fix or /pr-security-review)
+- [ ] Existing test suite
+- [ ] None — net-new class of bug
+
+## One change to prevent recurrence
+{a concrete action — new test class, gate addition, rule in .claude/rules/, or "none — acceptable residual risk"}
+
+{Urgent only}
+## Reviewer sign-off
+- Reviewer:
+- Approved:

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -18,25 +18,45 @@ You are a focused work driver. Given a Linear issue ID, you read its spec, plan 
 
 ## Required preconditions
 
-1. You are inside a worktree on a feature branch (not `dev`, not `main`, not `beta`, not `master`). Check with `git branch --show-current`. If on an integration branch, refuse with: `Run pk branch <ID> first to create the worktree.`
-2. The issue ID is passed as an argument or inferred from the current branch name (regex `[A-Z]+-[0-9]+`).
+1. Either (a) you are inside a worktree on a feature branch (not `dev`, `main`, `beta`, or `master`), OR (b) `<ISSUE-ID>` is passed as an argument so `/work` can auto-branch into a fresh worktree.
+2. If neither (a) nor (b) holds, refuse.
 3. `method.config.md` is readable in the repo root.
 
-## Step 0 — Verify preconditions
+## Step 0 — Verify or create the worktree
 
-Run:
+`/work` auto-branches when invoked from an integration branch with an explicit `<ISSUE-ID>` — creating worktree + branch via `pk branch` and `cd`-ing into it before continuing. This removes the manual `pk branch` step that v2.0–v2.2 required.
 
 ```bash
 CURRENT=$(git branch --show-current)
+
 case "$CURRENT" in
-  dev|main|master|beta) echo "ERROR: /work must run on a feature branch. Run 'pk branch <ID>' first." >&2; exit 1 ;;
+  dev|main|master|beta)
+    # Integration branch — auto-branch path.
+    if [ -z "$1" ]; then
+      echo "ERROR: /work invoked from integration branch '$CURRENT' with no <ISSUE-ID>." >&2
+      echo "Pass an ID (e.g. /work RS-123) or run 'pk branch <ID>' yourself first." >&2
+      exit 1
+    fi
+    ISSUE="$1"
+    echo "→ Auto-branching: pk branch $ISSUE"
+    pk branch "$ISSUE" || { echo "ERROR: pk branch failed for $ISSUE" >&2; exit 1; }
+    # pk branch creates the worktree and prints its path on the last line.
+    # Resolve and cd into it so the rest of /work runs in the right place.
+    WORKTREE=$(git worktree list --porcelain | awk -v id="$ISSUE" '
+      /^worktree / { wt=$2 }
+      /^branch / && index($0, id) { print wt; exit }
+    ')
+    [ -z "$WORKTREE" ] && { echo "ERROR: could not locate worktree for $ISSUE" >&2; exit 1; }
+    cd "$WORKTREE" || exit 1
+    CURRENT=$(git branch --show-current)
+    ;;
 esac
 ```
 
-If `<ISSUE-ID>` not passed, extract from `$CURRENT`:
+If `<ISSUE-ID>` not passed and `$CURRENT` is a feature branch, extract from `$CURRENT`:
 
 ```bash
-ISSUE=$(echo "$CURRENT" | grep -oE '[A-Z]+-[0-9]+' | head -1)
+ISSUE=${ISSUE:-$(echo "$CURRENT" | grep -oE '[A-Z]+-[0-9]+' | head -1)}
 [ -z "$ISSUE" ] && { echo "ERROR: no issue ID in branch name and none provided." >&2; exit 1; }
 ```
 
@@ -79,7 +99,7 @@ Use the Linear MCP tool `mcp__linear-server__get_issue` with the issue ID. Captu
 
 - `title`
 - `description` (the spec body)
-- `state.name` (must be `In Progress` or `Building`; if `Approved`, refuse — the user forgot `pk branch`)
+- `state.name` (expected: `In Progress` or `Building`. `Approved` is also fine — Step 0's auto-branch will have transitioned it. If `Backlog`/`Todo` and Step 0 did not just auto-branch, refuse.)
 - `labels`
 
 Validate the description contains either `## Light Spec` or `## Acceptance Criteria`. If neither:

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -49,6 +49,7 @@ These skills work across any project that follows the method. They read `method.
 | `pk ship [--review]` | Push, open PR, Linear → UAT. `--review` flags review-in-flight + prints reviewer invocation. | Stage 3: Verify + Ship |
 | `/pr-fix` | Triage PR review findings: fixed / rejected / deferred, with Linear summary | Stage 3: Verify + Ship |
 | `/pr-security-review` | Security-focused antagonistic review for migrations / RLS / SECURITY DEFINER / auth | Stage 3: Verify + Ship |
+| `/pk-bug` | Bug pipeline: intake → reproduce → regression-test-first → fix → ship → postmortem. Wraps `/work` + `pk ship` with discipline gates. | Anytime (parallel pipeline) |
 | `pk done <ID>` | Post-merge cleanup: worktree+branch, commits to Linear, → Done | Stage 4: Release |
 | `pk promote` | Multi-tier: open dev → main (or dev → beta → main) PR per `Ship environments` | Stage 4: Release |
 | `/strategy-sync` | Update Strategy docs after shipping | Stage 5: Doc Loop |


### PR DESCRIPTION
## Summary

Two related changes promoted upstream from rs-vault dogfooding:

- **`/pk-bug`** — new 8-phase bug pipeline skill that wraps the daily loop with regression-test-first discipline. Built locally in rs-vault, dogfooded on RS-94 (magic-link Enter-key OAuth misroute), promoted after first clean run.
- **`/work` auto-branch** — `/work <ISSUE-ID>` invoked from `dev`/`main`/`beta`/`master` now auto-runs `pk branch` and `cd`s into the new worktree, removing the manual step that v2.0–v2.2 required between `pk next` and `/work`. Discovered via the same `/pk-bug` dogfood — the bug pipeline already auto-branched, and the user observed it was strictly better than the main pipeline's manual step.

## /pk-bug invariants

- Cannot advance from Phase 2 without local repro
- Failing test must exist before fix code (Phase 3 gate)
- Test commit lands as first commit on the branch (Phase 4 — preserves audit trail)
- Postmortem mandatory for Linear priority Urgent / High / Medium
- Linear is source of truth — resume routing keys off `statusType`, not display name (so projects with custom statuses like `Parked` work correctly)

## /work auto-branch behavior matrix

| Starting state | Behavior |
|---|---|
| Already in a feature worktree | Unchanged — uses current branch |
| On integration branch + `<ISSUE-ID>` passed | Auto-branch, cd, continue |
| On integration branch + no ID | Refuse with the same message as before |

## Test plan

- [ ] Sync this PR's branch into rs-vault (after merge) via `sync-method.sh`
- [ ] After sync: delete `rs-vault/.claude/skills/pk-bug/` (project-local copy will be replaced by upstream)
- [ ] Use `/work` on a fresh Approved Linear issue from `dev` and confirm it auto-branches
- [ ] Use `/pk-bug "..."` on a new bug and confirm it routes through all 8 phases via Linear status
- [ ] Confirm `/pk-exit` session log captures the run

## Related

- rs-vault RS-94 (magic-link sign-out) — the dogfood case
- Cross-project execution rule saved as feedback memory (`feedback_cross_project_execution.md`) — informed the workflow that produced this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)