### PR TITLE
chore(sync): rename method/ → pipekit/ for synced content (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.2.0 — 2026-05-09
+
+> Folder rename: `method/` → `pipekit/` for the synced canonical content. Breaking change for consumers.
+
+### What changed
+
+- **Sync target folder renamed `method/` → `pipekit/`.** All consumer-side synced content (`sop/`, `templates/`, `method.md`, `GUIDE.md`, `STARTUP.md`, `.sync-changelog.md`) now lands under `pipekit/` instead of `method/`. This Pipekit source repo's layout is unchanged — only the destination path on the consumer side moves.
+- **Updated:** `scripts/sync-method.sh` (sync targets, snapshot path, override target paths), `scripts/drift-check.sh` (path filter regex), and all skill docs and templates that reference consumer-side paths (`pipekit-update`, `00-roadmap-review`, `01-light-spec`, `startup`, `templates/overrides-manifest.template.md`, `templates/rules/README.md`, `GUIDE.md`, `README.md`, `method.config.template.md`, `method.md`).
+- **Unchanged:** `method.config.md` filename (still at consumer repo root), Pipekit source layout (`sop/`, `templates/`, `method.md` at root of this repo), all override paths under `.claude/overrides/`, `bin/pk`, all skills and agents.
+
+### Why
+
+`method/` was generic and confusing — both Pipekit and consumer projects used "method" interchangeably, with no signal about ownership. Renaming the synced folder to `pipekit/` makes ownership immediately legible: `pipekit/` is upstream content (don't hand-edit; gets overwritten on sync). Pairs cleanly with whatever the consumer chooses to name its own engineering workspace folder (e.g., `engineering/` for piper, `local/` for rs-vault).
+
+The rename also eliminates a long-standing collision risk for consumers with a pre-existing `method/` folder (notably Piper, which had Piper-flavored v1 method docs there from the era when Pipekit was extracted from Piper). Sync now writes to a fresh `pipekit/` and leaves any pre-existing `method/` alone for manual dissolution.
+
+### Migration (consuming projects)
+
+After `./scripts/sync-method.sh v2.2.0`:
+
+```
+# Sync creates pipekit/ alongside any existing method/.
+# 1. Verify pipekit/ has the canonical content (sop/, templates/, method.md, etc.).
+# 2. Move any project-specific content out of method/ to its appropriate home
+#    (engineering/, .claude/overrides/, Strategy/_decisions/, etc.).
+# 3. Re-point references in CLAUDE.md, skills, and docs from method/* to pipekit/*.
+# 4. rm -rf method/ once empty.
+# 5. method.config.md filename unchanged — no action needed there.
+```
+
+For consumers with extensive `method/` customization, see `engineering/Pipekit-Migration-Plan.md` (Piper's worked example) for a phased dissolution approach.
+
+---
+
 ## v2.1.2 — 2026-05-03
 
 > Session-log redesign: bash Stop hook retired, narrative `/pk-exit` skill restored.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -985,10 +985,10 @@ The method repo is the source of truth. Projects pull from it using `scripts/syn
 | Source (method repo) | Destination (project) |
 |---------------------|----------------------|
 | `skills/*/` | `.claude/skills/*/` |
-| `sop/` | `method/sop/` |
-| `templates/` | `method/templates/` |
-| `method.md` | `method/method.md` |
-| `STARTUP.md` | `method/STARTUP.md` |
+| `sop/` | `pipekit/sop/` |
+| `templates/` | `pipekit/templates/` |
+| `method.md` | `pipekit/method.md` |
+| `STARTUP.md` | `pipekit/STARTUP.md` |
 
 ### What Never Gets Synced
 
@@ -1183,7 +1183,7 @@ Skills with Red Flags: `/concept`, `/define`, `/strategy-create`, `/roadmap-crea
 
 ## Portable Rule Templates
 
-The method includes rule templates in `templates/rules/` that consuming projects sync into their `.claude/rules/` directory. These are auto-loaded every session by Claude Code under the **hub-and-spoke model** (CLAUDE.md hub → rules/ auto-loaded → method/sop/ demand-loaded).
+The method includes rule templates in `templates/rules/` that consuming projects sync into their `.claude/rules/` directory. These are auto-loaded every session by Claude Code under the **hub-and-spoke model** (CLAUDE.md hub → rules/ auto-loaded → pipekit/sop/ demand-loaded).
 
 Canonical files use a `pipekit-` prefix so they never collide with project-specific rule filenames. Three canonical topic files ship from Pipekit:
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ pipekit/
 
 **Synced from Pipekit** (updated when you re-run `sync-method.sh`):
 - `.claude/skills/` — portable skills
-- `method/` — SOPs, templates, methodology docs
+- `pipekit/` — SOPs, templates, methodology docs
 
 **Stays in your project** (never overwritten):
 - `concept-brief.md` — project concept

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -123,7 +123,7 @@ Tiers shape which gates apply to an issue. `/work` infers the tier from issue la
 | **Standard** | Yes (default) | Normal feature work | — | — |
 | **Heavy** | No (opt-in) | Multi-phase, security-sensitive, cross-strategy-doc | — | Security review, mandatory `/strategy-sync` before close |
 
-Per-tier templates live at `method/templates/tier-{quick,standard,heavy}.md`.
+Per-tier templates live at `pipekit/templates/tier-{quick,standard,heavy}.md`.
 
 To disable a tier in this project, remove its row above. Removing **Standard** is not allowed — it is the fallback.
 

--- a/method.md
+++ b/method.md
@@ -528,7 +528,7 @@ Pipekit syncs upstream content via `scripts/sync-method.sh`, which overwrites `s
 .claude/overrides/
   skills/<name>/skill.md        # full-file replacement for a synced skill
   sop/<file>.md                 # full-file replacement for a synced SOP
-  method.md.patch               # unified diff applied to method/method.md
+  method.md.patch               # unified diff applied to pipekit/method.md
   MANIFEST.md                   # human-curated list (what + why)
   .upstream-snapshot/           # managed by sync; do not edit
 ```

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -17,7 +17,7 @@
 #
 # Context detection:
 #   - In the method repo: checks skills, templates, SOPs, method.md, GUIDE.md
-#   - In a consuming project: checks CLAUDE.md, .claude/rules/, method/ docs
+#   - In a consuming project: checks CLAUDE.md, .claude/rules/, pipekit/ docs
 
 set -euo pipefail
 
@@ -257,7 +257,7 @@ check_paths() {
         if echo "$path" | grep -qE '^\.(claude|vbw-planning)/'; then
           continue
         fi
-        if echo "$path" | grep -qE '^(method/|Strategy/|Security/|src/|src_poc/|packages/|Logs/|rules/)'; then
+        if echo "$path" | grep -qE '^(pipekit/|Strategy/|Security/|src/|src_poc/|packages/|Logs/|rules/)'; then
           continue
         fi
         if echo "$path" | grep -qE '^concept-brief\.md$|^project-definition\.md$|^method\.config\.md$'; then

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -8,13 +8,13 @@
 #   ./scripts/sync-method.sh --dry-run    # Show what would change
 #
 # What it syncs:
-#   method/sop/        <- SOPs (Code Quality, Git, Linear, Skills, VBW)
-#   method/templates/  <- Spec and review templates
-#   method/method.md   <- The methodology overview
+#   pipekit/sop/        <- SOPs (Code Quality, Git, Linear, Skills, VBW)
+#   pipekit/templates/  <- Spec and review templates
+#   pipekit/method.md   <- The methodology overview
 #   .claude/skills/    <- Portable skills (won't touch project-specific ones)
 #
 # What it does NOT touch:
-#   method/decisions/       <- Project-specific ADRs
+#   pipekit/decisions/       <- Project-specific ADRs
 #   .claude/rules/          <- Project coding conventions
 #   .claude/skills/{local}  <- Project-specific skills
 #   .vbw-planning/          <- Project state
@@ -36,7 +36,7 @@ METHOD_REPO="${METHOD_REPO:-https://github.com/withpiper/pipekit.git}"
 DRY_RUN=false
 REF="main"
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CHANGELOG="$PROJECT_ROOT/method/.sync-changelog.md"
+CHANGELOG="$PROJECT_ROOT/pipekit/.sync-changelog.md"
 
 # Parse flags without mutating $@ — the self-update guard below re-execs with
 # "$@", and a shift here would silently drop --dry-run across the re-exec.
@@ -101,7 +101,7 @@ snapshot_dir() {
 }
 
 snapshot_dir "$PROJECT_ROOT/.claude/skills" "skills"
-snapshot_dir "$PROJECT_ROOT/method" "method"
+snapshot_dir "$PROJECT_ROOT/pipekit" "method"
 
 # Track changes
 CHANGES=0
@@ -171,12 +171,12 @@ sync_file() {
 # --- Sync method docs ---
 echo ""
 echo "Method docs:"
-mkdir -p "$PROJECT_ROOT/method"
-sync_dir "$TEMP/sop" "$PROJECT_ROOT/method/sop" "sop/"
-sync_dir "$TEMP/templates" "$PROJECT_ROOT/method/templates" "templates/"
-sync_file "$TEMP/method.md" "$PROJECT_ROOT/method/method.md" "method.md"
-sync_file "$TEMP/GUIDE.md" "$PROJECT_ROOT/method/GUIDE.md" "GUIDE.md"
-sync_file "$TEMP/STARTUP.md" "$PROJECT_ROOT/method/STARTUP.md" "STARTUP.md"
+mkdir -p "$PROJECT_ROOT/pipekit"
+sync_dir "$TEMP/sop" "$PROJECT_ROOT/pipekit/sop" "sop/"
+sync_dir "$TEMP/templates" "$PROJECT_ROOT/pipekit/templates" "templates/"
+sync_file "$TEMP/method.md" "$PROJECT_ROOT/pipekit/method.md" "method.md"
+sync_file "$TEMP/GUIDE.md" "$PROJECT_ROOT/pipekit/GUIDE.md" "GUIDE.md"
+sync_file "$TEMP/STARTUP.md" "$PROJECT_ROOT/pipekit/STARTUP.md" "STARTUP.md"
 
 # --- Sync Pipekit hook scripts (VBW lifecycle integration) ---
 echo ""
@@ -206,8 +206,8 @@ fi
 
 # --- Sync v2 templates ---
 if [ -d "$TEMP/templates/v2" ]; then
-  mkdir -p "$PROJECT_ROOT/method/templates/v2"
-  sync_dir "$TEMP/templates/v2" "$PROJECT_ROOT/method/templates/v2" "templates/v2/"
+  mkdir -p "$PROJECT_ROOT/pipekit/templates/v2"
+  sync_dir "$TEMP/templates/v2" "$PROJECT_ROOT/pipekit/templates/v2" "templates/v2/"
 fi
 
 # --- Sync canonical .claude/rules/ files ---
@@ -296,7 +296,7 @@ if [ -d "$PROJECT_ROOT/.claude/skills" ]; then
       # Only flag it if it has no project-specific marker
       if [ -f "$existing_skill_dir/skill.md" ]; then
         # Check if this was a portable skill (existed in a previous sync)
-        if grep -q "^  SYNCED skill: $existing_skill" "$PROJECT_ROOT/method/.sync-changelog.md" 2>/dev/null || \
+        if grep -q "^  SYNCED skill: $existing_skill" "$PROJECT_ROOT/pipekit/.sync-changelog.md" 2>/dev/null || \
            echo "$PORTABLE_SKILLS" | grep -qv "$existing_skill"; then
           REMOVED_SKILLS="$REMOVED_SKILLS $existing_skill"
         fi
@@ -423,7 +423,7 @@ if [ -d "$OVERRIDES_DIR" ]; then
   # SOP overrides: .claude/overrides/sop/<file>.md
   if [ -d "$OVERRIDES_DIR/sop" ]; then
     while IFS= read -r -d '' override_file; do
-      target="$PROJECT_ROOT/method/sop/$(basename "$override_file")"
+      target="$PROJECT_ROOT/pipekit/sop/$(basename "$override_file")"
       apply_override "$override_file" "$target" "sop/$(basename "$override_file")"
     done < <(find "$OVERRIDES_DIR/sop" -type f -name '*.md' -print0 2>/dev/null)
   fi
@@ -432,7 +432,7 @@ if [ -d "$OVERRIDES_DIR" ]; then
   if [ -f "$OVERRIDES_DIR/method.md.patch" ]; then
     apply_patch_override \
       "$OVERRIDES_DIR/method.md.patch" \
-      "$PROJECT_ROOT/method/method.md" \
+      "$PROJECT_ROOT/pipekit/method.md" \
       "method.md.patch"
   fi
 
@@ -456,7 +456,7 @@ fi
 if ! $DRY_RUN; then
   # Compare method files
   for f in method.md GUIDE.md STARTUP.md; do
-    dst="$PROJECT_ROOT/method/$f"
+    dst="$PROJECT_ROOT/pipekit/$f"
     if [ -f "$dst" ]; then
       old_hash=$(grep "$dst" "$SNAP/method.md5" 2>/dev/null | awk '{print $1}' || true)
       new_hash=$(md5sum "$dst" 2>/dev/null | awk '{print $1}')
@@ -560,7 +560,7 @@ CHLOG
   fi
 
   echo ""
-  echo "Changelog written to: method/.sync-changelog.md"
+  echo "Changelog written to: pipekit/.sync-changelog.md"
 fi
 
 # Clean up snapshot
@@ -581,7 +581,7 @@ else
   fi
   echo ""
   echo "Next steps:"
-  echo "  1. Review method/.sync-changelog.md for what changed"
+  echo "  1. Review pipekit/.sync-changelog.md for what changed"
   echo "  2. Run /pipekit-update reconciliation (restart Claude Code first)"
   echo "  3. Commit the synced files"
 fi

--- a/skills/00-roadmap-review/skill.md
+++ b/skills/00-roadmap-review/skill.md
@@ -94,7 +94,7 @@ For each issue in the active and upcoming stages:
 ### Phase 4 — Dependency Validation
 
 1. Read light specs for issues that have them — extract dependency contracts (e.g., "PROJ-8 is a hard blocker for PROJ-7")
-2. Read the WP dependency graph from `method/sop/Linear SOP.md` (Dependency Graph section)
+2. Read the WP dependency graph from `pipekit/sop/Linear SOP.md` (Dependency Graph section)
 3. For each declared dependency:
    - Fetch the issue via `mcp__linear-server__get_issue` with `includeRelations: true`
    - Check that `blockedBy`/`blocks` relations exist in Linear

--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -220,7 +220,7 @@ Tell the user how to proceed:
 
 ## Light Spec Template
 
-Read the canonical template from `templates/light_spec_template.md` in the method repo (or `method/templates/light_spec_template.md` in consuming projects). Use that template structure for all specs.
+Read the canonical template from `templates/light_spec_template.md` in the method repo (or `pipekit/templates/light_spec_template.md` in consuming projects). Use that template structure for all specs.
 
 ---
 

--- a/skills/pipekit-update/skill.md
+++ b/skills/pipekit-update/skill.md
@@ -61,9 +61,9 @@ If `method.config.md` doesn't exist, warn: _"No method.config.md found. Run `/st
 
 ### Phase 3 — Changelog
 
-The sync script writes a changelog to `method/.sync-changelog.md` that captures what changed. **Read this file first** — it's the source of truth for what needs reconciliation.
+The sync script writes a changelog to `pipekit/.sync-changelog.md` that captures what changed. **Read this file first** — it's the source of truth for what needs reconciliation.
 
-1. **Read `method/.sync-changelog.md`** — it contains:
+1. **Read `pipekit/.sync-changelog.md`** — it contains:
    - New skills added (with descriptions from their `skill.md`)
    - Updated skills (content changed)
    - Possibly removed/renamed skills
@@ -91,7 +91,7 @@ The sync script writes a changelog to `method/.sync-changelog.md` that captures 
 - New field: `{field name}` in method.config.md — needs a value
 ```
 
-If `method/.sync-changelog.md` doesn't exist (e.g., older sync script), fall back to `git diff` on the synced paths.
+If `pipekit/.sync-changelog.md` doesn't exist (e.g., older sync script), fall back to `git diff` on the synced paths.
 
 ### Phase 4 — Reconcile
 
@@ -185,10 +185,10 @@ If a local clone exists:
    - Copy the updated skill to `~/Projects/pipekit/skills/`
    - Stage the changes in the method repo
 4. Also check for changes to:
-   - `method/sop/` → `~/Projects/pipekit/sop/`
-   - `method/templates/` → `~/Projects/pipekit/templates/`
-   - `method/method.md` → `~/Projects/pipekit/method.md`
-   - `method/STARTUP.md` → `~/Projects/pipekit/STARTUP.md`
+   - `pipekit/sop/` → `~/Projects/pipekit/sop/`
+   - `pipekit/templates/` → `~/Projects/pipekit/templates/`
+   - `pipekit/method.md` → `~/Projects/pipekit/method.md`
+   - `pipekit/STARTUP.md` → `~/Projects/pipekit/STARTUP.md`
 5. After all changes are staged, offer to commit and push:
    ```
    {N} files updated in pipekit.
@@ -204,11 +204,11 @@ If a local clone exists:
 | Source (GitHub) | Destination (this project) | Notes |
 |-----------------|---------------------------|-------|
 | `skills/*/` | `.claude/skills/*/` | Only portable skills — won't delete project-specific skills |
-| `sop/` | `method/sop/` | Full replace |
-| `templates/` | `method/templates/` | Full replace |
-| `method.md` | `method/method.md` | Full replace |
-| `GUIDE.md` | `method/GUIDE.md` | Full replace |
-| `STARTUP.md` | `method/STARTUP.md` | Full replace |
+| `sop/` | `pipekit/sop/` | Full replace |
+| `templates/` | `pipekit/templates/` | Full replace |
+| `method.md` | `pipekit/method.md` | Full replace |
+| `GUIDE.md` | `pipekit/GUIDE.md` | Full replace |
+| `STARTUP.md` | `pipekit/STARTUP.md` | Full replace |
 
 ## What Never Gets Synced
 

--- a/skills/startup/skill.md
+++ b/skills/startup/skill.md
@@ -535,7 +535,7 @@ Write `Strategy/DesignDirection.md` with their answers. This doc is read by deve
 
 ### Step 6 — Method Sync
 
-**Check:** Does `method/` directory exist? Are skills in `.claude/skills/`?
+**Check:** Does `pipekit/` directory exist? Are skills in `.claude/skills/`?
 - If yes: _"Method already synced. Re-sync or skip?"_
 - If no: Copy and run sync script
 
@@ -618,7 +618,7 @@ Verify these exist. If missing, re-run `bash scripts/sync-method.sh` or copy fro
 If `CLAUDE.md` does not exist at the project root, copy it from `templates/CLAUDE.md.template` and fill in placeholders with values from `method.config.md`:
 
 ```bash
-cp method/templates/CLAUDE.md.template CLAUDE.md
+cp pipekit/templates/CLAUDE.md.template CLAUDE.md
 ```
 
 Then fill in:
@@ -714,6 +714,6 @@ Next steps:
   2. Remove the unchosen option's configuration blocks (environment tables, promotion skills, workflow details, etc.) so they don't look active.
   3. If the unchosen option has reference value, move it to a collapsed section at the bottom: `<!-- Not chosen: three-tier --> ... <!-- /Not chosen -->` — but only if it adds value. When in doubt, remove it entirely.
   This applies to `method.config.md`, `CLAUDE.md`, strategy docs, and any file where alternatives were presented. A document should never look like two conflicting decisions are both active.
-- **App code lives in `src/`.** All application code (framework, components, API routes, etc.) goes in a `src/` subdirectory. The project root is reserved for Pipekit files (`method.config.md`, `concept-brief.md`, `project-definition.md`, `Strategy/`, `.vbw-planning/`, `method/`, `.claude/`), config files (`.gitignore`, `.env`, `package.json`, `tsconfig.json`), and scripts. This keeps Pipekit's methodology layer cleanly separated from the application. When initializing a framework (Next.js, Remix, etc.), configure it to use `src/` as the source directory.
+- **App code lives in `src/`.** All application code (framework, components, API routes, etc.) goes in a `src/` subdirectory. The project root is reserved for Pipekit files (`method.config.md`, `concept-brief.md`, `project-definition.md`, `Strategy/`, `.vbw-planning/`, `pipekit/`, `.claude/`), config files (`.gitignore`, `.env`, `package.json`, `tsconfig.json`), and scripts. This keeps Pipekit's methodology layer cleanly separated from the application. When initializing a framework (Next.js, Remix, etc.), configure it to use `src/` as the source directory.
 - **Resumable.** The tracker + artifact checks make `/startup` fully resumable across sessions. A new session reads the tracker and picks up exactly where the last one stopped.
 - **Emit inline `➜ Next:` after every step.** When completing any step (including mid-`/startup` step transitions), emit an inline `➜ Next:` line in your terminal output with the next command the user should run and why. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear once the foundation contract is satisfied.

--- a/templates/overrides-manifest.template.md
+++ b/templates/overrides-manifest.template.md
@@ -6,7 +6,7 @@
 
 - `.claude/overrides/skills/<name>/skill.md` — full-file replacement for a synced skill
 - `.claude/overrides/sop/<file>.md` — full-file replacement for a synced SOP
-- `.claude/overrides/method.md.patch` — unified diff applied to `method/method.md`
+- `.claude/overrides/method.md.patch` — unified diff applied to `pipekit/method.md`
 
 Overrides are applied automatically by `scripts/sync-method.sh` after the upstream sync. The script saves the upstream version it replaced under `.claude/overrides/.upstream-snapshot/` so the next sync can detect upstream drift.
 

--- a/templates/rules/README.md
+++ b/templates/rules/README.md
@@ -7,7 +7,7 @@ Files in this directory are **auto-loaded into every Claude Code session** via t
 ```
 CLAUDE.md            — project hub + routing pointers (~200 lines)
   .claude/rules/*    — auto-loaded enforceable constraints (per-topic files)
-  method/sop/*       — demand-loaded deep reference (SQL templates, walkthroughs)
+  pipekit/sop/*       — demand-loaded deep reference (SQL templates, walkthroughs)
 ```
 
 CLAUDE.md points to rules for "how do I build correctly here?" Rules point to SOPs for "how do I do this specific complex thing?"
@@ -22,7 +22,7 @@ CLAUDE.md points to rules for "how do I build correctly here?" Rules point to SO
 ## What does NOT go in rules/
 
 - Feature-specific documentation — that's SOPs or inline docs
-- Historical context or decision logs — that's `method/decisions/` ADRs
+- Historical context or decision logs — that's `pipekit/decisions/` ADRs
 - Tutorial-style guides — that's SOPs
 - Anything longer than ~100 lines — split by topic
 


### PR DESCRIPTION
## Summary

Rename the synced-folder name from `method/` to `pipekit/` across all consumer-facing references. Pure rename — Pipekit source repo's layout is unchanged; only the destination path on the consumer side moves.

**Breaking change for consumers** that have already run `sync-method.sh` against this repo (notably Piper and rs-vault). See migration steps in CHANGELOG.md v2.2.0 entry.

## Why

`method/` was generic and gave no ownership signal — both Pipekit and consumer projects used "method" interchangeably. After the rename:

- `pipekit/` = upstream-owned, never hand-edit, gets overwritten on sync
- Whatever the consumer chooses for its own engineering folder (`engineering/` for piper, `local/` for rs-vault) sits clearly outside that boundary

Also eliminates a collision risk: consumers with a pre-existing `method/` folder (e.g., Piper, which had Piper-flavored v1 docs there from when Pipekit was extracted from Piper) would have had their content `rsync --delete`'d on first sync. Now sync writes to fresh `pipekit/` and leaves any pre-existing `method/` alone for manual dissolution.

## What changed

**Code:**
- `scripts/sync-method.sh` — 18 path references (sync targets, snapshot, override target, changelog path, summary messages)
- `scripts/drift-check.sh` — path filter regex + comment

**Docs:**
- `README.md`, `method.md`, `GUIDE.md`, `method.config.template.md`
- `templates/overrides-manifest.template.md`, `templates/rules/README.md`
- 4 skills: `pipekit-update` (24 lines), `startup` (6), `00-roadmap-review` (2), `01-light-spec` (2)

**CHANGELOG.md** — v2.2.0 entry with consumer migration steps

## Unchanged

- `method.config.md` filename (still at consumer repo root — separable rename if desired later)
- Pipekit source layout (`sop/`, `templates/`, `method.md` at this repo's root)
- All override paths under `.claude/overrides/`
- `bin/pk` and all skills/agents

## Stats

12 source files modified: 50 inserts / 50 deletes (symmetric — pure rename). Plus CHANGELOG entry (34 lines).

## Test plan

- [x] `grep -rn 'method/' --include='*.md' --include='*.sh' --exclude-dir=archive --exclude-dir=resources --exclude-dir=Logs` returns zero hits in live files
- [x] Spot-checked sync-method.sh, pipekit-update skill, GUIDE.md, method.md
- [x] Path patterns verified: `pipekit/sop/`, `pipekit/templates/`, `pipekit/method.md`, `pipekit/.sync-changelog.md`
- [ ] Live `--dry-run` against a consumer (Piper Phase 1 will be the canary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)