### PR TITLE
feat(merge-strategy): retire squash, enforce merge-commit on main (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,35 +8,64 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ## v2.2.0 — 2026-05-09
 
-> Folder rename: `method/` → `pipekit/` for the synced canonical content. Breaking change for consumers.
+> Two paired changes: **synced-folder rename** (`method/` → `pipekit/`) and **squash retirement** (merge-commit-only on `main`, squash disabled repo-wide). Breaking changes for consumers — see Migration section.
 
-### What changed
+### What changed — folder rename
 
 - **Sync target folder renamed `method/` → `pipekit/`.** All consumer-side synced content (`sop/`, `templates/`, `method.md`, `GUIDE.md`, `STARTUP.md`, `.sync-changelog.md`) now lands under `pipekit/` instead of `method/`. This Pipekit source repo's layout is unchanged — only the destination path on the consumer side moves.
 - **Updated:** `scripts/sync-method.sh` (sync targets, snapshot path, override target paths), `scripts/drift-check.sh` (path filter regex), and all skill docs and templates that reference consumer-side paths (`pipekit-update`, `00-roadmap-review`, `01-light-spec`, `startup`, `templates/overrides-manifest.template.md`, `templates/rules/README.md`, `GUIDE.md`, `README.md`, `method.config.template.md`, `method.md`).
 - **Unchanged:** `method.config.md` filename (still at consumer repo root), Pipekit source layout (`sop/`, `templates/`, `method.md` at root of this repo), all override paths under `.claude/overrides/`, `bin/pk`, all skills and agents.
 
-### Why
+### What changed — merge strategy
+
+- **`scripts/pipekit-configure-repo.sh` rewritten** — repo-level `allow_squash_merge=false`; new `pipekit-main-merge-only` ruleset enforces `allowed_merge_methods=["merge"]` on PRs targeting main. The legacy `pipekit-main-squash-only` ruleset is auto-deleted on re-run.
+- **`sop/Git_and_Deployment.md` § Merge Strategy by Hop** — table rewritten. Squash row removed; merge-commit is the enforced strategy for dev → main. Rebase or merge-commit are both fine for feature → dev.
+- **`bin/pk` reminders updated** — `pk ship` no longer tells you to squash on main; `pk promote` PR body and prompt updated to "Create a merge commit."
+- **`RUNBOOK.md`, `method.md`, `STARTUP.md`, `GUIDE.md`** — all "squash" references updated to reflect the new policy.
+
+### Why — folder rename
 
 `method/` was generic and confusing — both Pipekit and consumer projects used "method" interchangeably, with no signal about ownership. Renaming the synced folder to `pipekit/` makes ownership immediately legible: `pipekit/` is upstream content (don't hand-edit; gets overwritten on sync). Pairs cleanly with whatever the consumer chooses to name its own engineering workspace folder (e.g., `engineering/` for piper, `local/` for rs-vault).
 
 The rename also eliminates a long-standing collision risk for consumers with a pre-existing `method/` folder (notably Piper, which had Piper-flavored v1 method docs there from the era when Pipekit was extracted from Piper). Sync now writes to a fresh `pipekit/` and leaves any pre-existing `method/` alone for manual dissolution.
 
+### Why — merge strategy
+
+v1.7.0 banned merge-commits everywhere. v1.8.0.6 reversed: rebase/merge for feature → dev, squash for dev → main. **Both schemes hit phantom conflicts in production.** Piper's `nebula-piper-migration-handoff.md:282` documents the v1.8.0.6 failure ("GitHub squash ruleset breaks parent linking. Every promote re-conflicts on files added on both sides"); rs-vault hit the identical trap on PR #173 / #175 in May 2026.
+
+The misdiagnosis: prior versions believed "merge-commits on main cause phantom conflicts." Squash on main causes them — by collapsing N atomic dev commits into one orphan commit on main, the next promote's merge-base finds two divergent histories that both modified the same files relative to the common ancestor. Merge-commits prevent the divergence: dev's atomic commits flow onto main with stable SHAs.
+
+The cleanup-via-squash use case (collapse messy WIP commits) doesn't apply: Pipekit's discipline rules already enforce "one atomic change per commit," and vbw-dev makes atomic commits per task. Squash was throwing away useful bisect/blame information for an aesthetic linear-history preference. `git log main --first-parent` gives the squash-equivalent view (one entry per merged PR) without the cost.
+
+### What this fixes
+
+- **Phantom conflicts on `pk promote`** — gone. Same SHAs flow feature → dev → main.
+- **`git bisect` and `git blame` on main** — newly useful. Today main is a series of squash-mega-commits attributed to whoever clicked the merge button.
+- **`git branch -d` after `pk done`** — would now succeed (latent improvement; `pk done` still uses `-D` for safety).
+
 ### Migration (consuming projects)
 
 After `./scripts/sync-method.sh v2.2.0`:
 
-```
-# Sync creates pipekit/ alongside any existing method/.
-# 1. Verify pipekit/ has the canonical content (sop/, templates/, method.md, etc.).
-# 2. Move any project-specific content out of method/ to its appropriate home
-#    (engineering/, .claude/overrides/, Strategy/_decisions/, etc.).
-# 3. Re-point references in CLAUDE.md, skills, and docs from method/* to pipekit/*.
-# 4. rm -rf method/ once empty.
-# 5. method.config.md filename unchanged — no action needed there.
+```bash
+# 1. Folder rename — sync creates pipekit/ alongside any existing method/.
+#    - Verify pipekit/ has the canonical content (sop/, templates/, method.md, etc.).
+#    - Move any project-specific content out of method/ to its appropriate home
+#      (engineering/, .claude/overrides/, Strategy/_decisions/, etc.).
+#    - Re-point references in CLAUDE.md, skills, and docs from method/* to pipekit/*.
+#    - rm -rf method/ once empty.
+#    - method.config.md filename unchanged — no action needed there.
+
+# 2. Merge strategy — re-run the configure script. It will:
+#    - Set allow_squash_merge=false at the repo level
+#    - Delete the legacy pipekit-main-squash-only ruleset
+#    - Create the new pipekit-main-merge-only ruleset
+bash scripts/pipekit-configure-repo.sh
 ```
 
-For consumers with extensive `method/` customization, see `engineering/Pipekit-Migration-Plan.md` (Piper's worked example) for a phased dissolution approach.
+If you have an open dev → main PR that's hitting a phantom conflict from the prior squash policy, resolve it once with a merge-commit (or close + reopen as a no-ff merge); subsequent promotes will be clean.
+
+For consumers with extensive `method/` customization, see Piper's worked example at `engineering/Pipekit-Migration-Plan.md` for a phased dissolution approach.
 
 ---
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -636,7 +636,7 @@ Skip PR review for pure copy/UI tweaks and internal-only refactors with no exter
 
 Test the feature against the spec's acceptance criteria under real usage conditions. The PR should already have a Vercel preview URL by the time you start UAT (Vercel auto-deploys on PR open).
 
-**Accept:** Merge the PR (squash). Then exit the worktree and run `pk done <ID>` from the parent repo — this cleans up the worktree + branch and posts commits + diffstat to Linear.
+**Accept:** Merge the PR (rebase or merge-commit; squash is disabled repo-wide). Then exit the worktree and run `pk done <ID>` from the parent repo — this cleans up the worktree + branch and posts commits + diffstat to Linear.
 
 **Reject:** Describe what's wrong — the issue re-enters execution with your feedback (return to Stage 2's `/work`).
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -174,10 +174,10 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        ▼
   ┌──────────────────────────────────────────────────────────┐
   │ [6] Merge PR (manual, GitHub UI)                         │
-  │     • feature → dev: merge-commit or rebase (NOT squash) │
-  │     • dev/beta → main: squash (single release commit)    │
-  │     Squash on feature → dev causes phantom conflicts on  │
-  │     the next promote. Emergency override only.           │
+  │     • feature → dev: rebase or merge-commit              │
+  │     • dev/beta → main: merge-commit (anchor per promote) │
+  │     Squash is disabled repo-wide (v2.2.0+) — caused      │
+  │     phantom conflicts on every subsequent dev → main.    │
   └──────────────────────────────────────────────────────────┘
        │
        ▼
@@ -217,7 +217,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
   │     pk promote                                           │
   │     • only runs if Promote to main: true in config       │
   │     • git pull dev, run pre-deploy gate                  │
-  │     • opens dev → main PR (squash-merge per ruleset)     │
+  │     • opens dev → main PR (merge-commit per ruleset)     │
   └──────────────────────────────────────────────────────────┘
 ```
 

--- a/STARTUP.md
+++ b/STARTUP.md
@@ -289,7 +289,7 @@ Before writing any feature code, verify the full v2 daily loop works end-to-end:
 [ ] /work <ID>                  (plan + execute; verdict gate before code)
 [ ] /verify                     (pre-deploy gate runs to green)
 [ ] pk ship                     (push, open PR, Linear → UAT; verify preview deploys)
-[ ] Merge PR (squash); verify dev deployment
+[ ] Merge PR (rebase or merge-commit); verify dev deployment
 [ ] pk done <ID>                (cleanup worktree, post commits to Linear, → Done)
 [ ] pk promote                  (if multi-tier — opens dev → main PR)
 [ ] /pk-exit                    (writes session log to Logs/Sessions/<date>_<HHMM>.md)

--- a/bin/pk
+++ b/bin/pk
@@ -682,18 +682,19 @@ cmd_ship() {
     echo "PR: $pr_url"
   fi
 
-  # Merge-strategy reminder. Squashing feature → dev collapses dev's commit
-  # identity and causes phantom conflicts on every subsequent dev → main
-  # promote. See sop/Git_and_Deployment.md § Merge Strategy by Hop.
+  # Merge-strategy reminder. Squash is disabled repo-wide (v2.2.0+) — it
+  # creates orphan SHAs that diverge dev and main, causing phantom conflicts
+  # on every subsequent dev → main promote. See sop/Git_and_Deployment.md
+  # § Merge Strategy by Hop.
   case "$target" in
     dev|beta)
       echo ""
-      echo "⚑ Merge with: 'Create a merge commit' or 'Rebase and merge'."
-      echo "  Do NOT squash feature → dev (causes phantom-conflict tax on promotes)."
+      echo "⚑ Merge with: 'Rebase and merge' or 'Create a merge commit'."
+      echo "  (Squash is disabled repo-wide — causes phantom conflicts on promotes.)"
       ;;
     main)
       echo ""
-      echo "⚑ Merge with: 'Squash and merge' (one release commit per promotion)."
+      echo "⚑ Merge with: 'Create a merge commit' (one anchor commit per promotion)."
       ;;
   esac
 
@@ -982,13 +983,13 @@ cmd_promote() {
   date=$(date +%Y-%m-%d)
   promote_url=$(pk_gh_pr_create --base main --head "$integration" \
     --title "Promote $integration → main ($date)" \
-    --body "Batch promote. Squash-merge per ruleset.") || return 1
+    --body "Batch promote. Merge-commit per ruleset (one anchor commit on main per promote).") || return 1
   echo "PR: $promote_url"
   if $stash_made; then
     echo ""
     echo "Note: your local edits are stashed. Run 'git stash pop' after the promote PR is merged."
   fi
-  echo "Open the PR in browser to squash-merge."
+  echo "Open the PR in browser and merge with 'Create a merge commit'."
 }
 
 cmd_log() {

--- a/method.md
+++ b/method.md
@@ -232,7 +232,7 @@ Every step forward is a PR. No direct merges between long-lived branches. Promot
 
 **Order of operations** (after Stage 3's UAT passes):
 
-1. Human merges the PR (squash) once UAT is green.
+1. Human merges the PR (rebase or merge-commit; see `sop/Git_and_Deployment.md` § Merge Strategy by Hop) once UAT is green.
 2. **`pk done <ID>`** cleans up the worktree + branch, posts commits + diffstat to Linear, and transitions the issue to Done.
 3. **`pk promote`** opens the next-tier promotion PR (dev → beta, beta → main) for multi-tier projects. Skipped for `Promote to main: false`.
 

--- a/scripts/pipekit-configure-repo.sh
+++ b/scripts/pipekit-configure-repo.sh
@@ -2,20 +2,30 @@
 # pipekit-configure-repo.sh
 #
 # Configure a GitHub repo with Pipekit's recommended merge strategy
-# (v1.8.0.6+):
+# (v2.2.0+):
 #
-#   - Repo level: rebase, squash, AND merge-commits all allowed
-#       → gives you flexibility on feature → dev (rebase or merge-commit, your choice)
-#   - main branch: squash-only enforced via GitHub Ruleset
-#       → prevents accidental merge-commits to main (the phantom-conflict trap)
+#   - Repo level: rebase + merge-commit allowed; squash DISABLED
+#       → squash creates orphan SHAs that diverge dev and main, causing
+#         phantom conflicts on every subsequent dev → main promote
+#   - main branch: merge-commit-only enforced via GitHub Ruleset
+#       → guarantees a single anchor commit per promote (revert -m 1, log
+#         --first-parent) and prevents accidental rebase or squash
 #   - delete_branch_on_merge: true (auto-delete remote branches)
 #
-# Why Rulesets instead of just disallowing merge_commit globally?
-# Earlier (v1.7.0–v1.8.0.5) we disallowed merge_commit at the repo level. That
-# prevented the phantom-conflict trap on main, but also banned merge bubbles
-# on dev — which some users prefer for feature-branch readability in
-# GitKraken / git-log. Rulesets let us be precise: main = squash-only,
-# dev/everything-else = your choice.
+# Why no squash anywhere?
+# v1.7.0–v2.1.x oscillated on this. v1.7.0 banned merge-commits everywhere
+# (caused phantom conflicts via a different topology). v1.8.0.6 split the
+# rules: rebase/merge for feature → dev, squash for dev → main. Both Piper
+# and rs-vault hit phantom conflicts under v1.8.0.6 — squash on dev → main
+# is the cause, not the cure. Squash collapses N atomic dev commits into
+# one orphan commit on main; the next promote's merge-base sees divergent
+# histories touching the same files and fails.
+#
+# v2.2.0 eliminates squash entirely. Atomic commits flow feature → dev →
+# main with stable SHAs. Pipekit discipline already enforces "one atomic
+# change per commit," so the cleanup-via-squash use case doesn't apply.
+# `git log main --first-parent` gives the squash-equivalent view (one
+# entry per promote) without losing the underlying commits for bisect/blame.
 #
 # Usage:
 #   bash scripts/pipekit-configure-repo.sh <org>/<repo>
@@ -35,13 +45,14 @@ if [ -z "$REPO" ]; then
   fi
 fi
 
-RULESET_NAME="pipekit-main-squash-only"
+RULESET_NAME="pipekit-main-merge-only"
+LEGACY_RULESET_NAME="pipekit-main-squash-only"
 
 echo "Repo: $REPO"
 echo
 
 # ---------------------------------------------------------------------------
-# Step 1: repo-level merge settings — allow rebase, squash, AND merge-commits
+# Step 1: repo-level merge settings — disallow squash globally
 # ---------------------------------------------------------------------------
 
 echo "Step 1 — Repo-level merge settings"
@@ -56,11 +67,11 @@ gh api "repos/$REPO" --jq '{
 }'
 echo
 
-echo "Applying: merge=on, squash=on, rebase=on, auto-delete=on..."
+echo "Applying: merge=on, squash=OFF, rebase=on, auto-delete=on..."
 gh api "repos/$REPO" --method PATCH \
   -f delete_branch_on_merge=true \
   -f allow_merge_commit=true \
-  -f allow_squash_merge=true \
+  -F allow_squash_merge=false \
   -f allow_rebase_merge=true \
   --jq '{
     delete_branch_on_merge,
@@ -72,13 +83,20 @@ gh api "repos/$REPO" --method PATCH \
 echo
 
 # ---------------------------------------------------------------------------
-# Step 2: main-branch ruleset — squash-only on PRs targeting main
+# Step 2: main-branch ruleset — merge-commit-only on PRs targeting main
 # ---------------------------------------------------------------------------
 
 echo "Step 2 — Main-branch ruleset ($RULESET_NAME)"
 echo
 
-# Check for existing ruleset by name
+# Migrate legacy v1.8.0.6+ ruleset if present (squash-only → merge-only).
+LEGACY_ID=$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$LEGACY_RULESET_NAME\") | .id" 2>/dev/null || echo "")
+if [ -n "$LEGACY_ID" ]; then
+  echo "Found legacy ruleset '$LEGACY_RULESET_NAME' (id=$LEGACY_ID) — deleting (will be replaced)..."
+  gh api "repos/$REPO/rulesets/$LEGACY_ID" --method DELETE >/dev/null
+fi
+
+# Check for existing v2.2.0+ ruleset by name
 EXISTING_ID=$(gh api "repos/$REPO/rulesets" --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || echo "")
 
 RULESET_BODY=$(cat <<JSON
@@ -101,7 +119,7 @@ RULESET_BODY=$(cat <<JSON
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,
-        "allowed_merge_methods": ["squash"]
+        "allowed_merge_methods": ["merge"]
       }
     }
   ]
@@ -126,5 +144,6 @@ fi
 echo
 echo "Done. Effective merge policy:"
 echo "  feature → dev      → Rebase OR Merge commit (your choice in the GitHub UI)"
-echo "  dev → main         → Squash (enforced by ruleset; UI dropdown will show only Squash)"
+echo "  dev → main         → Merge commit (enforced by ruleset; UI dropdown will show only Merge)"
+echo "  Squash             → Disabled repo-wide (causes phantom conflicts on promote)"
 echo "  Auto-delete remote branches on merge → enabled."

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -69,27 +69,29 @@ dev  (active development)
 | `beta` (three-tier only) | Protected. Requires PR + CI passing. No direct merges. |
 | `dev` | Default branch for PRs. CI runs on all PRs targeting dev. |
 
-### Merge Strategy by Hop (v1.8.0.6+)
+### Merge Strategy by Hop (v2.2.0+)
 
-Different hops want different strategies. The phantom-conflict trap (observed during v1.7.0 / v1.8.0 work) only happens when the **dev → main** hop uses a merge commit. Other hops can use whatever fits the project's history-readability preferences.
+**Squash is disabled. Atomic commits flow feature → dev → main with stable SHAs.** Pipekit discipline already enforces one atomic change per commit, so the cleanup-via-squash use case doesn't apply. `git log main --first-parent` gives the squash-equivalent view (one entry per merged PR) without losing the underlying commits.
 
 | Hop | Recommended | Also OK | Rationale |
 |---|---|---|---|
-| `feature/*` → `dev` | **Rebase** | Merge-commit | Rebase = linear atomic commits; merge-commit = bubble preserving feature scope. **Do not squash here.** Squashing feature → dev collapses dev's commit identity, and every subsequent `dev → main` promote then sees phantom conflicts (same content, different SHAs and boundaries). Emergency override only when dev tip is broken. |
-| `dev` → `beta` (three-tier) | Rebase or merge-commit | — | Same as feature → dev. |
-| **`dev` → `main`** (two-tier) or `beta` → `main` (three-tier) | **Squash (enforced)** | — | One release commit per promotion. Merge-commits here cause phantom conflicts on subsequent promotes. **Enforced by ruleset, not user discipline.** |
+| `feature/*` → `dev` | **Rebase** | Merge-commit | Rebase preserves atomic commits linearly; merge-commit preserves them under a feature bubble. Either keeps SHAs intact for downstream promotes. **Squash is disabled repo-wide.** |
+| `dev` → `beta` (three-tier) | Merge-commit | — | One anchor commit per promote (`git log --first-parent`, `git revert -m 1`). |
+| **`dev` → `main`** (two-tier) or `beta` → `main` (three-tier) | **Merge-commit (enforced)** | — | Same anchor rationale. **Enforced by ruleset, not user discipline.** |
 
-#### Enforcement model (v1.8.0.6+): Rulesets, not repo flags
+#### Why no squash anywhere (v2.2.0 reversal)
 
-Earlier (v1.7.0–v1.8.0.5) Pipekit recommended disallowing merge-commits at the repo level (`allow_merge_commit=false`). That's machine-safe but blunt — it bans merge bubbles on dev too, which some users prefer for feature-branch readability.
+v1.7.0 banned merge-commits everywhere. v1.8.0.6 reversed: rebase/merge for feature → dev, squash for dev → main. **Both schemes hit phantom conflicts in production** — Piper's `nebula-piper-migration-handoff.md` documents the v1.8.0.6 failure, and rs-vault hit the same trap.
 
-v1.8.0.6 switches to **per-branch enforcement via GitHub Rulesets**:
+The misdiagnosis: v1.7.0–v2.1.x believed "merge-commits on main cause phantom conflicts." Squash on main causes them — by collapsing N atomic dev commits into one orphan commit on main, the next promote's merge-base sees divergent histories touching the same files. Merge-commits prevent the divergence by keeping SHAs stable across the promote boundary.
 
-- Repo level: all three merge methods enabled (rebase, squash, merge-commit).
-- A `pipekit-main-squash-only` ruleset enforces squash-only on `main` specifically.
-- Other branches (dev, beta, feature/*) inherit the repo-level flexibility.
+#### Enforcement model (v2.2.0+)
 
-Result: GitHub UI's "Merge pull request" dropdown shows all options on feature → dev PRs but only "Squash and merge" on PRs targeting main. Mistakes impossible.
+- **Repo level:** rebase + merge-commit allowed; **squash disabled** (`allow_squash_merge=false`).
+- **`pipekit-main-merge-only` ruleset:** enforces merge-commit-only on PRs targeting `main` (no rebase or squash).
+- The legacy `pipekit-main-squash-only` ruleset is auto-deleted on re-run of `pipekit-configure-repo.sh`.
+
+Result: GitHub UI's "Merge pull request" dropdown shows Rebase + Merge on feature → dev PRs, and only "Create a merge commit" on PRs targeting main. Mistakes impossible.
 
 **One-shot configure** (idempotent — safe to re-run on any consuming repo):
 
@@ -192,7 +194,7 @@ For migrations / RLS / SECURITY DEFINER / auth, use `/pr-security-review` instea
 
 ### Step 5: Merge to Dev
 
-PR is reviewed, approved, and merged (squash). Feature available on dev. Vercel preview is automatic; for Supabase projects, GitHub Actions `db-pr-check.yml` validates migrations on PR open and `db-migrate.yml` applies them on `main` merge.
+PR is reviewed, approved, and merged (rebase or merge-commit per § Merge Strategy by Hop). Feature available on dev. Vercel preview is automatic; for Supabase projects, GitHub Actions `db-pr-check.yml` validates migrations on PR open and `db-migrate.yml` applies them on `main` merge.
 
 ```
 pk done <ID>           # cleanup worktree+branch, post commits/diffstat to Linear, → Done (after main merge)


### PR DESCRIPTION
## Summary

- Reverses v1.8.0.6's squash-on-main policy that caused phantom conflicts on every promote (Piper docs at `resources/nebula-piper-migration-handoff.md:282`; rs-vault hit it on PRs #173/#175 in May 2026).
- Disables squash repo-wide. Enforces merge-commit on PRs targeting `main` via new `pipekit-main-merge-only` ruleset. Feature → dev can use rebase or merge-commit.
- `pipekit-configure-repo.sh` auto-deletes the legacy `pipekit-main-squash-only` ruleset on re-run — consuming projects only need to re-run once.

## Why this should stick (third oscillation)

v1.7.0 banned merge-commits everywhere. v1.8.0.6 reversed to squash-only on main. **Both schemes hit phantom conflicts in production.** The misdiagnosis was "merge-commits cause phantom conflicts." Squash on main causes them — by collapsing N atomic dev commits into one orphan commit, the next promote's merge-base sees divergent histories. Merge-commits keep SHAs stable across the boundary. Pipekit discipline already enforces atomic commits, so the cleanup-via-squash use case doesn't apply.

## What this fixes

- Phantom conflicts on `pk promote` — gone.
- `git bisect` / `git blame` on main — useful again.
- `git log main --first-parent` — squash-equivalent view, atomic commits preserved.

## Test plan

- [ ] CI passes (no shell scripts run; docs + bash syntax-check only).
- [ ] After merge: tag `v2.2.0` and push.
- [ ] Run `bash scripts/pipekit-configure-repo.sh` on rs-vault — verify legacy `pipekit-main-squash-only` ruleset is deleted and `pipekit-main-merge-only` is created with `allowed_merge_methods=["merge"]`.
- [ ] Manually merge rs-vault PR #175 with "Create a merge commit" once ruleset is flipped (one-time phantom-conflict resolution required since divergence already exists).
- [ ] Run a fresh `pk promote` cycle on rs-vault and confirm no phantom conflict.

## Migration (consuming projects)

```bash
./scripts/sync-method.sh v2.2.0
bash scripts/pipekit-configure-repo.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)