### PR TITLE
fix(sync): preserve project-local agents (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.2.1 — 2026-05-09
+
+> Patch: stop wiping project-local agents on sync.
+
+### What changed
+
+- **`scripts/sync-method.sh` agents sync** — replaced `sync_dir --delete` with per-file `sync_file` over upstream agent files. Project-local agents in `.claude/agents/` (e.g., `code-reviewer.md`, `supabase-reviewer.md`, `{library}-pitfalls.md`) now persist across syncs.
+
+### Why
+
+Surfaced during Piper's v2 canary (PR #235): `rsync --delete` on `.claude/agents/` would have deleted 8 Piper-local agents because upstream pipekit ships only `plan-reviewer.md`. Patched manually in PR #235 by restoring from HEAD; this is the permanent fix. Mirrors the canonical-rules pattern (`README.md`, `pipekit-*.md`), which uses `sync_file` for the same reason — consumers extend `.claude/rules/` and `.claude/agents/` with project-specific files that must survive sync.
+
+### Migration
+
+None. Re-run `./scripts/sync-method.sh v2.2.1` and project-local agents are preserved.
+
+---
+
 ## v2.2.0 — 2026-05-09
 
 > Two paired changes: **synced-folder rename** (`method/` → `pipekit/`) and **squash retirement** (merge-commit-only on `main`, squash disabled repo-wide). Breaking changes for consumers — see Migration section.

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -236,11 +236,19 @@ if [ -d "$TEMP/templates/rules" ]; then
 fi
 
 # --- Sync Pipekit agents (subagents spawned by Pipekit skills) ---
+# Per-file copy (sync_file, not sync_dir --delete) so project-local agents
+# like code-reviewer, supabase-reviewer, or {library}-pitfalls helpers persist
+# across syncs. Mirrors the canonical-rules pattern above. Upstream agents
+# are enumerated by what's present in the source tree.
 if [ -d "$TEMP/agents" ]; then
   echo ""
   echo "Agents:"
   mkdir -p "$PROJECT_ROOT/.claude/agents"
-  sync_dir "$TEMP/agents" "$PROJECT_ROOT/.claude/agents" "agents/"
+  for agent_src in "$TEMP/agents"/*.md; do
+    [ -f "$agent_src" ] || continue
+    name=$(basename "$agent_src")
+    sync_file "$agent_src" "$PROJECT_ROOT/.claude/agents/$name" ".claude/agents/$name"
+  done
 fi
 
 # --- Sync portable skills ---


### PR DESCRIPTION
## Summary

- Replace `sync_dir --delete` with per-file `sync_file` for `.claude/agents/`, mirroring the canonical-rules pattern in the same script.
- Project-local agents (e.g., `code-reviewer.md`, `supabase-reviewer.md`, `{library}-pitfalls` helpers) now persist across syncs.

## Why

Surfaced during Piper's v2 canary (PR withpiper/piper#235): on a clean sync, `rsync --delete` would have deleted 8 Piper-local agents because upstream pipekit ships only `plan-reviewer.md`. PR #235 patched manually by restoring from HEAD; this is the permanent fix. Filed as upstream finding #5 in `engineering/Pipekit-v2-Loop-Notes.md`.

## Test plan

- [x] Dry-run from piper consumer: before fix → `WOULD UPDATE agents/ (8 files differ)` (would delete). After fix → `OK .claude/agents/plan-reviewer.md (no changes)`.
- [x] Self-update guard fires correctly across the change (verified via `=== sync-method.sh self-update detected — installing and re-execing ===`).
- [x] CHANGELOG entry added under v2.2.1.

## Release

Tag `v2.2.1` on merge so consumers can pin via `./scripts/sync-method.sh v2.2.1`.