### PR TITLE
v2.2.2 — bin/pk: verify parser, doctor errors, worktree prefix

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -27,7 +27,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.1.3"
+PK_VERSION="2.2.2"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null
@@ -81,6 +81,24 @@ pk_integration_branch() {
 
 pk_linear_api_key_var() {
   pk_config "Linear API key env var" "LINEAR_API_KEY"
+}
+
+# Resolve worktree path prefix. Trailing char in the config value controls
+# join style: `-` → sibling-dir (~/Projects/foo-RS-30-x), `/` → subdir
+# ($root/.worktrees/RS-30-x). Default keeps backward-compat with projects
+# that never set the key.
+pk_worktree_prefix() {
+  local p
+  p=$(pk_config "Worktree prefix" "")
+  if [ -z "$p" ]; then
+    echo "$(pk_repo_root)/.worktrees/"
+    return 0
+  fi
+  case "$p" in
+    "~/"*) p="$HOME/${p#\~/}" ;;
+    "~")   p="$HOME" ;;
+  esac
+  echo "$p"
 }
 
 pk_linear_api_key() {
@@ -563,13 +581,9 @@ cmd_status() {
   # Local in-flight
   echo ""
   echo "── Local worktrees ──"
-  local root
-  root=$(pk_repo_root)
-  if [ -d "$root/.worktrees" ]; then
-    git worktree list | grep "\.worktrees/" || echo "  (none)"
-  else
-    echo "  (none)"
-  fi
+  local prefix
+  prefix=$(pk_worktree_prefix)
+  git worktree list | grep -F "$prefix" || echo "  (none)"
 }
 
 cmd_branch() {
@@ -588,9 +602,10 @@ cmd_branch() {
   title=$(echo "$issue" | jq -r '.title')
   slug=$(pk_slug "$title")
   local branch_name="feature/${id}-${slug}"
-  local root wt_path
+  local root prefix wt_path
   root=$(pk_repo_root)
-  wt_path="$root/.worktrees/${id}-${slug}"
+  prefix=$(pk_worktree_prefix)
+  wt_path="${prefix}${id}-${slug}"
 
   # Idempotent: worktree already exists?
   if [ -d "$wt_path" ]; then
@@ -875,9 +890,16 @@ $commits"
 
 cmd_verify() {
   local cmd
-  # `|| true` — same pipefail-grep-no-match issue as elsewhere
-  cmd=$({ grep -A20 "^## Pre-Deploy Gate" "$(pk_config_path)" 2>/dev/null \
-    | grep -A20 '^```' | grep -v '^```' | head -10; } || true)
+  cmd=$(awk '
+    /^## Pre-Deploy Gate[[:space:]]*$/ { in_section=1; next }
+    in_section && /^## / { exit }
+    in_section && /^```/ {
+      if (in_fence) exit
+      in_fence=1
+      next
+    }
+    in_section && in_fence { print }
+  ' "$(pk_config_path)" 2>/dev/null || true)
   if [ -z "$cmd" ]; then
     echo "No Pre-Deploy Gate configured in method.config.md."
     return 1
@@ -1470,14 +1492,23 @@ cmd_doctor() {
   fi
   # Linear API ping
   if [ -n "$key" ]; then
-    local resp
+    local resp viewer
     resp=$(pk_linear_gql 'query{viewer{name}}' 2>/dev/null || echo "")
-    local viewer
     viewer=$(echo "$resp" | jq -r '.data.viewer.name // empty' 2>/dev/null)
     if [ -n "$viewer" ]; then
       echo "  ✓ Linear API reachable (viewer: $viewer)"
     else
-      echo "  ✗ Linear API call failed"
+      local err_msg
+      err_msg=$(echo "$resp" | jq -r '.errors[0]?.extensions?.userPresentableMessage // .errors[0]?.message // empty' 2>/dev/null)
+      if [ -n "$err_msg" ]; then
+        echo "  ✗ Linear API call failed: $err_msg"
+      elif [ -n "$resp" ]; then
+        local snippet
+        snippet=$(echo "$resp" | tr '\n' ' ' | cut -c1-200)
+        echo "  ✗ Linear API call failed (unexpected response): $snippet"
+      else
+        echo "  ✗ Linear API call failed (no response — check network/DNS/firewall)"
+      fi
       fail=$((fail+1))
     fi
   fi


### PR DESCRIPTION
## Summary

Three `bin/pk` fixes resolving Pipekit-v2-Loop-Notes findings 1-3, plus a stale-version correction.

- **`pk verify`** — replace fragile chained-grep parser with awk section-extractor. Removes the gate-must-be-last constraint and the silent 10-command truncation cap.
- **`pk doctor`** — surface Linear GraphQL error messages instead of opaque "Linear API call failed". Distinguishes API errors (parsed `userPresentableMessage` / `.message`), unexpected response bodies (truncated 200-char snippet), and network failures (no response).
- **`pk branch`** — honor `Worktree prefix` from `method.config.md`. Previously hardcoded to `${root}/.worktrees/${id}-${slug}`. Trailing char in the prefix value controls join style: `-` → sibling-dir, `/` → subdir.
- **`PK_VERSION`** corrected from stale `2.1.3` → `2.2.2`.

## Migration note

Projects with `Worktree prefix` set to a sibling-dir form (e.g. `~/Projects/foo-`) will see new worktrees land at the configured location after syncing. To keep subdir behavior, set the key explicitly to your absolute path with trailing `/` (e.g. `/Users/me/code/repo/.worktrees/`) — the default is `${root}/.worktrees/` if the key is unset.

## Test plan

- [x] `bash -n bin/pk` — syntax OK
- [x] `pk verify` parser: 8/8 synthetic-config cases pass (gate-not-last, gate-last, 12-command, missing section, no fence, H3 inside section, missing file, no trailing heading)
- [x] `pk doctor` error surfacing: replay against synthetic responses (auth-error JSON, message-only JSON, HTML 502 body, empty response, unexpected JSON, 500-char body) — all branches resolve correctly
- [x] `pk_worktree_prefix`: 7/7 cases pass (empty default, tilde expansion, absolute sibling, absolute subdir, tilde-only, concatenation correctness)
- [x] `pk doctor` real run on pipekit (no method.config.md) — defaults clean
- [x] `pk --version` reports `2.2.2`
- [ ] Manual `pk verify` on a project with active gate (defer to Piper sync canary)
- [ ] Manual `pk branch <ID>` on a project with `Worktree prefix` set (defer to next pipekit-sync into Piper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)