### PR TITLE
docs: finish v2.3.0 cull — SOPs, templates, skills

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -665,7 +665,7 @@ feature/* → pk ship (PR to dev) → pk promote beta (PR to beta) → pk promot
 - `pk ship` opens the feature → dev PR (Linear → UAT)
 - `pk promote beta` opens dev → beta and transitions the issue → Released
 - `pk promote main` opens beta → main and transitions the issue → Done
-- After main merge, `pk done <ID>` transitions the issue to Done
+- `pk done <ID>` (whenever; cleanup-only, no state change)
 
 **Auto-machinery** firing on PR open / main merge (Pipekit owns none of these — they're project infrastructure):
 
@@ -783,7 +783,7 @@ If you want time-boxed sprints with capacity tracking, map phases to Linear Cycl
 
 ### Phase State Tracking
 
-Phases are tracked in `.vbw-planning/PHASES.md`, not in Linear. Linear tracks individual issue status (Needs Spec, Building, UAT, Done). PHASES.md tracks which issues belong to which phase and the phase's overall progress.
+Phases are tracked in `.vbw-planning/PHASES.md`, not in Linear. Linear tracks individual issue status (Needs Spec, Building, UAT, Released, Done). PHASES.md tracks which issues belong to which phase and the phase's overall progress.
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -245,8 +245,8 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 | **5b** | **Antagonistic review** | **`pk ship --review`** | **`./bin/pk ship --review`** | **worktree** | **prints reviewer invocation; posts Linear "review in flight" comment (v2.1.0)** |
 | **5c** | **/pr-fix triage** | **`/pr-fix`** | **— (skill)** | **worktree** | **interactive findings triage; cross-spec handoff scan; posts Linear summary (v2.1.0)** |
 | **5d** | **/pr-security-review (opt-in)** | **`/pr-security-review`** | **— (skill)** | **worktree** | **security-focused PR review for migrations / RLS / SECURITY DEFINER / auth (v2.1.0)** |
-| 7 | Cleanup | `pk done <ID>` | `./bin/pk done <ID>` | parent, dev | writes Linear (Done) + removes worktree + posts journal highlights |
-| 8 | Promote | `pk promote [--stash\|--take-remote]` | `./bin/pk promote [--stash\|--take-remote]` | parent, dev | dev → main batch (v2.0 added flag) |
+| 7 | Cleanup | `pk done <ID>` | `./bin/pk done <ID>` | parent, dev | removes worktree + posts journal highlights to Linear (no state transition; v2.3.0) |
+| 8 | Promote | `pk promote <env> [--stash\|--take-remote]` | `./bin/pk promote <env> [--stash\|--take-remote]` | parent, dev | one hop per call along Ship environments; transitions issues → Released or → Done (v2.3.0) |
 | meta | Diagnose | `pk doctor` | `./bin/pk doctor` | anywhere | config + API ping |
 | meta | Bootstrap | `pk init` | `./bin/pk init` | repo root | walks setup |
 | meta | Install | `pk install` | `./bin/pk install` | repo root | symlinks pk onto $PATH (v2.0) |

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -68,8 +68,8 @@ Best for: solo dev, small teams, projects where preview URLs replace a staging e
 | Preview | PR branches | Per-PR preview URLs |
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `main`
-**Promotion mechanism:** `pk ship` opens the feature → `dev` PR; `pk promote` opens the `dev` → `main` PR.
-**Linear transitions:** `pk ship` → UAT (or In Review); merge to `main` (via `pk promote` PR) → `pk done` posts to Linear and the issue moves to Done.
+**Promotion mechanism:** `pk ship` opens the feature → `dev` PR; `pk promote main` (or `pk promote` with no arg) opens the `dev` → `main` PR.
+**Linear transitions:** `pk ship` → UAT; `pk promote main` → Done (optimistic, at PR-open). `pk done` is cleanup-only — it does NOT transition state.
 
 ### Three-Tier (dev → beta → main)
 
@@ -83,8 +83,8 @@ Best for: teams with QA, projects needing a stable UAT environment, regulated in
 | Preview | PR branches | Per-PR preview URLs |
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `beta` → PR to `main`
-**Promotion mechanism:** `pk ship` opens the feature → `dev` PR; `pk promote` walks `dev` → `beta` and `beta` → `main` per `Ship environments` in the V2 block below.
-**Linear transitions:** `pk ship` → UAT (or In Review); merge to `beta` → issues stay in UAT; merge to `main` (via `pk promote` PR) → issues move to Done.
+**Promotion mechanism:** `pk ship` opens the feature → `dev` PR; `pk promote <env>` walks one hop per invocation (`pk promote beta` then `pk promote main`) per `Ship environments` in the V2 block below.
+**Linear transitions:** `pk ship` → UAT; `pk promote beta` → Released; `pk promote main` → Done. All transitions optimistic at PR-open. `pk done` is cleanup-only — it does NOT transition state.
 
 ### Environments
 

--- a/method.md
+++ b/method.md
@@ -42,7 +42,7 @@ Development Pipeline (repeats per issue, contract-strict):
   Stage 1: Spec          /light-spec → agent review → human review
   Stage 2: Plan + Build  pk branch → /work    (→ /review-plan if vbw backend)
   Stage 3: Verify + Ship /verify → pk ship    (→ /pr-fix | /pr-security-review) → UAT
-  Stage 4: Release       pk done → pk promote
+  Stage 4: Release       pk promote <env> → pk done   (promote walks one hop per call; pk done is cleanup)
   Stage 5: Doc Loop      /strategy-sync       (after UAT)
 
 Per session (not per issue): /pk-exit          (last command of every Claude Code session)
@@ -233,8 +233,8 @@ Every step forward is a PR. No direct merges between long-lived branches. Promot
 **Order of operations** (after Stage 3's UAT passes):
 
 1. Human merges the PR (rebase or merge-commit; see `sop/Git_and_Deployment.md` § Merge Strategy by Hop) once UAT is green.
-2. **`pk done <ID>`** cleans up the worktree + branch, posts commits + diffstat to Linear, and transitions the issue to Done.
-3. **`pk promote`** opens the next-tier promotion PR (dev → beta, beta → main) for multi-tier projects. Skipped for `Promote to main: false`.
+2. **`pk done <ID>`** cleans up the worktree + branch and posts commits + diffstat to Linear. **Cleanup-only** — it does NOT transition state.
+3. **`pk promote <env>`** opens the next-tier promotion PR (one hop per invocation: `pk promote beta`, then `pk promote main`). Transitions matching issues optimistically at PR-open: → **Released** for intermediate hops, → **Done** for the final hop. 2-tier projects: `pk promote` with no arg picks the only hop. Skipped entirely for `Promote to main: false`.
 
 **Auto-machinery** firing on PR open / main merge (Pipekit owns none of these — they're project infrastructure):
 

--- a/skills/linear/skill.md
+++ b/skills/linear/skill.md
@@ -77,7 +77,10 @@ The workflow has 5 phases. At each phase transition, update the Linear issue sta
    - For **production** (merged to `main`): verify `vercel --prod` deployment succeeds.
    - For **hotfixes** (merged to `main`): immediately cherry-pick back to both `dev` and `beta`.
    - **Post a comment** confirming deployment target.
-3. **Move to Done** using `mcp__linear-server__save_issue` with `stateId: {Done state ID from method.config.md}`.
+3. **Transition state per environment.** Under v2.3.0, state maps 1:1 to environment:
+   - **2-tier project** (`Ship environments: dev,main`): on `main` merge → move to **Done** (`stateId: {Done state ID}`).
+   - **3-tier project** (`Ship environments: dev,beta,main`): on `beta` merge → move to **Released** (`stateId: {Released state ID}`); on `main` merge → move to **Done**.
+   - The recommended path is `pk promote <env>` which sets state at PR-open time. This manual step only applies if you opened the promote PR by hand without `pk promote`.
 
 ---
 

--- a/skills/pr-fix/skill.md
+++ b/skills/pr-fix/skill.md
@@ -331,7 +331,7 @@ git push
 
 ### 6.6 Post Linear comment (visibility)
 
-After fixes are pushed, post a Linear comment on the PR's linked issue summarizing the triage. This closes the mid-loop visibility gap — Linear sees `In Progress → UAT → Done` today, but the *what happened with this review* context lives only on the PR.
+After fixes are pushed, post a Linear comment on the PR's linked issue summarizing the triage. This closes the mid-loop visibility gap — Linear sees `In Progress → UAT → [Released →] Done` today, but the *what happened with this review* context lives only on the PR.
 
 Identify the Linear issue from:
 - The PR title's `<TEAM>-<N>:` prefix (e.g. `RS-73: …`), OR

--- a/skills/sync-linear/skill.md
+++ b/skills/sync-linear/skill.md
@@ -105,7 +105,7 @@ Analyzes project completion status and recommends moving the next batch of issue
 #### Workflow Status Ladder
 
 ```
-Future Phases → On Deck → Needs Spec → Specced → Approved → In Progress → Building → UAT → Done
+Future Phases → On Deck → Needs Spec → Specced → Approved → In Progress → Building → UAT → [Released →] Done
 ```
 
 State IDs are stored in `linear-map.json` under `states.*`. Always read from there — never hardcode.

--- a/skills/task-processor/skill.md
+++ b/skills/task-processor/skill.md
@@ -51,9 +51,10 @@ Ask which task to work on.
 - Create a worktree for the work (`pk branch <ID>` for Linear-issue-based work, or `git worktree add` directly for non-Linear work)
 - Execute actions based on issue description + spec (if any)
 - Validate against success criteria
-- When done, ask user: move to **Done** or **UAT**?
-  - Done: `stateId: {Done state ID from method.config.md}`
-  - UAT: `stateId: {UAT state ID from method.config.md}`
+- When done, ask user: move to **Done**, **Released**, or **UAT**?
+  - Done: `stateId: {Done state ID from method.config.md}` (live in production)
+  - Released: `stateId: {Released state ID from method.config.md}` (3-tier projects: merged to staging/beta, awaiting prod)
+  - UAT: `stateId: {UAT state ID from method.config.md}` (merged to integration/dev, awaiting acceptance)
 - Ask if user wants another task
 
 ### 4. Final Summary

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -28,8 +28,8 @@ dev  (active development)
 | **Preview** | PR branches | Per-PR preview URLs |
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `main`
-**Promotion mechanism:** `pk ship` opens the feature → `dev` PR (Linear → UAT). `pk promote` opens the `dev` → `main` PR.
-**Linear transitions:** `pk ship` → UAT; `pk done` (post-`main`-merge) → Done.
+**Promotion mechanism:** `pk ship` opens the feature → `dev` PR (Linear → UAT). `pk promote main` (or `pk promote` with no arg, since only one hop exists) opens the `dev` → `main` PR.
+**Linear transitions:** `pk ship` → UAT; `pk promote main` → Done (optimistic, at PR-open). `pk done` is cleanup-only — it does NOT transition state.
 
 ### Three-Tier (dev → beta → main)
 
@@ -50,8 +50,8 @@ dev  (active development)
 | **Preview** | PR branches | Per-PR preview URLs |
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `beta` → PR to `main`
-**Promotion mechanism:** `pk ship` opens the feature → `dev` PR. `pk promote` walks the chain (`dev` → `beta`, `beta` → `main`) per `Ship environments` in `method.config.md`.
-**Linear transitions:** `pk ship` → UAT; merge to `beta` keeps issue in UAT; `pk done` (post-`main`-merge) → Done.
+**Promotion mechanism:** `pk ship` opens the feature → `dev` PR. `pk promote <env>` walks the chain one hop per invocation (`pk promote beta`, then `pk promote main` after the beta merge) per `Ship environments` in `method.config.md`.
+**Linear transitions:** `pk ship` → UAT; `pk promote beta` → Released; `pk promote main` → Done. All transitions optimistic at PR-open. `pk done` is cleanup-only — it does NOT transition state.
 
 ### Branch Naming (both models)
 
@@ -197,16 +197,17 @@ For migrations / RLS / SECURITY DEFINER / auth, use `/pr-security-review` instea
 PR is reviewed, approved, and merged (rebase or merge-commit per § Merge Strategy by Hop). Feature available on dev. Vercel preview is automatic; for Supabase projects, GitHub Actions `db-pr-check.yml` validates migrations on PR open and `db-migrate.yml` applies them on `main` merge.
 
 ```
-pk done <ID>           # cleanup worktree+branch, post commits/diffstat to Linear, → Done (after main merge)
+pk done <ID>           # cleanup worktree+branch, post commits/diffstat to Linear (no state change)
 ```
 
 ### Step 6: Promote to Production
 
 ```
-pk promote             # opens dev → main (two-tier) or dev → beta → main (three-tier) PR per Ship environments
+# Two-tier:   pk promote main   (or pk promote with no arg — auto-picks the only hop)
+# Three-tier: pk promote beta   (then pk promote main after that PR merges)
 ```
 
-After `main` merge, referenced Linear issues move to **Done** (via `pk done`).
+`pk promote <env>` walks one hop along `Ship environments` per invocation. State transitions fire optimistically at PR-open: matching issues → **Released** for intermediate hops, → **Done** for the final hop.
 
 See **Batch vs Per-Issue Promotion** below for when to ship one issue at a time vs. accumulate several before promoting.
 
@@ -278,8 +279,8 @@ Beta is the UAT environment in three-tier. Don't promote partial beta — if RS-
 Run the pre-deploy gate **before** each promotion hop, not just before the first one. `/verify` (or `pk verify`) is the canonical entry point and reads § Pre-Deploy Gate from `method.config.md`:
 
 - Before `pk ship` (feature → dev): gate must pass on the feature branch (handled inline by `/verify`)
-- Before `pk promote dev → beta` (three-tier): gate must pass on dev tip
-- Before `pk promote dev → main` (two-tier) or `pk promote beta → main` (three-tier): gate must pass on the source branch
+- Before `pk promote beta` (three-tier, dev → beta): gate must pass on dev tip
+- Before `pk promote main` (two-tier dev → main, or three-tier beta → main): gate must pass on the source branch
 
 The gate at each boundary catches integration-level regressions that wouldn't show on the originating feature branch. CI also enforces the gate at PR open — don't skip "because it passed earlier."
 

--- a/templates/tier-heavy.md
+++ b/templates/tier-heavy.md
@@ -48,4 +48,4 @@ Heavy tier adds extra checks before `pk ship` opens the PR:
 3. `/strategy-sync` last-run timestamp is after this issue's last build commit
 4. No `pending-strategy-sync` marker in Pipekit's state dir (`bash scripts/pipekit-state-dir.sh`)
 
-If any check fails, `pk ship` is refused with a list of missing artifacts. Linear status only transitions to UAT once all checks pass. Post-merge: `pk done PROJ-XXX` cleanup + Linear → Done; `pk promote` walks the chain.
+If any check fails, `pk ship` is refused with a list of missing artifacts. Linear status only transitions to UAT once all checks pass. Post-merge: `pk done PROJ-XXX` does worktree cleanup only (no state change). `pk promote <env>` walks the chain — → Released for intermediate hops, → Done for the final hop.

--- a/templates/tier-quick.md
+++ b/templates/tier-quick.md
@@ -42,4 +42,4 @@
 
 ## Close path
 
-`pk ship` → Linear status to UAT. UAT pass → merge PR → `pk done PROJ-XXX` (cleanup + Linear → Done) → `pk promote` (multi-tier projects).
+`pk ship` → Linear → UAT. UAT pass → merge PR → `pk done PROJ-XXX` (cleanup only; no state change) → `pk promote <env>` walks the chain (→ Released for intermediate hops, → Done for the final hop; 2-tier: `pk promote` with no arg).

--- a/templates/tier-standard.md
+++ b/templates/tier-standard.md
@@ -41,4 +41,4 @@ Inside Standard, complexity still routes execution:
 
 ## Close path
 
-`pk ship` → Linear status to UAT. UAT pass → merge PR → `pk done PROJ-XXX` (cleanup + Linear → Done) → `pk promote` (multi-tier projects). `/strategy-sync` can be run per-issue or batched at end of phase.
+`pk ship` → Linear → UAT. UAT pass → merge PR → `pk done PROJ-XXX` (cleanup only; no state change) → `pk promote <env>` walks the chain (→ Released for intermediate hops, → Done for the final hop). `/strategy-sync` can be run per-issue or batched at end of phase.


### PR DESCRIPTION
## Summary

Follow-up to #77. The first cull pass missed `sop/Git_and_Deployment.md` and several skills/templates that still encoded pre-v2.3.0 state semantics (e.g., \"pk done → Done\", \"pk promote\" without target arg). This PR catches them up.

## What changed

**SOPs:**
- `sop/Git_and_Deployment.md` — Linear-transitions for both 2-tier and 3-tier rewritten; Steps 5/6 + pre-deploy-gate sub-section updated; pk promote target-arg form throughout.

**Constitutional docs:**
- `method.md` — Stage 4 mini-flowchart + order-of-operations paragraph corrected.
- `RUNBOOK.md` — command table rows 7 (Cleanup) and 8 (Promote).
- `GUIDE.md` — Linear-statuses enumeration adds Released; three-tier walkthrough last bullet.
- `method.config.template.md` — both 2-tier and 3-tier release-flow sections.

**Templates (3):**
- `templates/tier-quick.md`, `tier-standard.md`, `tier-heavy.md` — close-path lines.

**Skills (4):**
- `skills/linear/skill.md` — Phase 4 step 3 documents 2-tier vs 3-tier state transitions.
- `skills/sync-linear/skill.md` — workflow status ladder includes Released.
- `skills/task-processor/skill.md` — adds Released as a state option.
- `skills/pr-fix/skill.md` — visibility-gap description includes Released.

## Test plan

- [x] Sweep for `pk done.*Done` patterns returns only updated/correct contexts
- [x] Sweep for `pk promote` without target arg returns only legitimate 2-tier auto-pick references
- [x] Released state mentioned at every appropriate surface
- [x] No archive/, CHANGELOG, or historical-handoff content touched (those correctly preserve historical state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)