### PR TITLE
v2.3.1 — sync RUNBOOK.md into consumer projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.3.1 — 2026-05-09
+
+> Patch: `RUNBOOK.md` is now synced into consumer projects.
+
+### What changed
+
+- **`scripts/sync-method.sh`** — adds `RUNBOOK.md` to the synced doc set alongside `method.md`, `GUIDE.md`, and `STARTUP.md`. Three edits: header comment listing what syncs, `sync_file` invocation, and the post-sync changelog comparison loop. Consumer projects now get `pipekit/RUNBOOK.md` populated and kept up-to-date on each sync.
+- **`PK_VERSION`** 2.3.0 → 2.3.1.
+
+### Why
+
+`RUNBOOK.md` exists in pipekit's main repo as the one-page operational doc — the canonical daily-loop flowchart. Until v2.3.1 it was never synced, so consumer projects had `pipekit/method.md` (deep methodology, ~700 lines) and `pipekit/GUIDE.md` (full manual, ~1200 lines) but no one-pager for daily reference. Surfaced during Piper's v2.3.0 sync canary (PR #242 on piper).
+
+`method.md` line 5 self-describes the relationship: "RUNBOOK is the canonical one-page operational doc; this document is the deeper methodology." Both have distinct, non-overlapping roles. Adding RUNBOOK to the sync gives consumers the daily-use surface.
+
+### Migration
+
+None. Re-run `./scripts/sync-method.sh v2.3.1` and `pipekit/RUNBOOK.md` lands in your project's `pipekit/` folder.
+
+---
+
 ## v2.3.0 — 2026-05-09
 
 > State machine maps 1:1 to environment. New `Released` Linear state for 3-tier projects. `pk promote` walks `Ship environments` one hop per call. `pk done` is cleanup-only.

--- a/bin/pk
+++ b/bin/pk
@@ -28,7 +28,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.3.0"
+PK_VERSION="2.3.1"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -10,7 +10,10 @@
 # What it syncs:
 #   pipekit/sop/        <- SOPs (Code Quality, Git, Linear, Skills, VBW)
 #   pipekit/templates/  <- Spec and review templates
-#   pipekit/method.md   <- The methodology overview
+#   pipekit/method.md   <- The deeper methodology overview
+#   pipekit/RUNBOOK.md  <- The one-page operational doc (v2.3.1+)
+#   pipekit/GUIDE.md    <- The full instruction manual
+#   pipekit/STARTUP.md  <- The bootstrap reference
 #   .claude/skills/    <- Portable skills (won't touch project-specific ones)
 #
 # What it does NOT touch:
@@ -175,6 +178,7 @@ mkdir -p "$PROJECT_ROOT/pipekit"
 sync_dir "$TEMP/sop" "$PROJECT_ROOT/pipekit/sop" "sop/"
 sync_dir "$TEMP/templates" "$PROJECT_ROOT/pipekit/templates" "templates/"
 sync_file "$TEMP/method.md" "$PROJECT_ROOT/pipekit/method.md" "method.md"
+sync_file "$TEMP/RUNBOOK.md" "$PROJECT_ROOT/pipekit/RUNBOOK.md" "RUNBOOK.md"
 sync_file "$TEMP/GUIDE.md" "$PROJECT_ROOT/pipekit/GUIDE.md" "GUIDE.md"
 sync_file "$TEMP/STARTUP.md" "$PROJECT_ROOT/pipekit/STARTUP.md" "STARTUP.md"
 
@@ -463,7 +467,7 @@ fi
 # --- Post-sync: generate changelog ---
 if ! $DRY_RUN; then
   # Compare method files
-  for f in method.md GUIDE.md STARTUP.md; do
+  for f in method.md RUNBOOK.md GUIDE.md STARTUP.md; do
     dst="$PROJECT_ROOT/pipekit/$f"
     if [ -f "$dst" ]; then
       old_hash=$(grep "$dst" "$SNAP/method.md5" 2>/dev/null | awk '{print $1}' || true)


### PR DESCRIPTION
## Summary

Adds `RUNBOOK.md` to `scripts/sync-method.sh` so consumer projects get the canonical one-page operational doc alongside `method.md`, `GUIDE.md`, and `STARTUP.md`.

## What changed

- `scripts/sync-method.sh` — three precise edits (header comment, sync_file list, post-sync changelog loop)
- `bin/pk` — `PK_VERSION` 2.3.0 → 2.3.1
- `CHANGELOG.md` — v2.3.1 entry

## Why

Surfaced during Piper's v2.3.0 sync canary (piper PR #242). Before v2.3.1, consumer projects had:
- `pipekit/method.md` (deep methodology, ~700 lines) ✓ synced
- `pipekit/GUIDE.md` (full manual, ~1200 lines) ✓ synced
- `pipekit/STARTUP.md` (bootstrap reference) ✓ synced
- **`pipekit/RUNBOOK.md` (one-page daily-loop doc) ✗ NOT synced**

`method.md:5` self-describes the relationship: "RUNBOOK is the canonical one-page operational doc; this document is the deeper methodology." Both files have distinct, non-overlapping roles. The previous sync omission left consumers without the daily-use reference.

## Test plan

- [x] `bash -n scripts/sync-method.sh` — syntax OK
- [x] `pk version` reports `2.3.1`
- [x] No existing sync targets modified — only RUNBOOK.md added to the list
- [ ] Verify on first consumer sync (will run on piper PR #242 against v2.3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)