### PR TITLE
v2.3.3 — pk promote correctness (target guard + state ladder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.3.3 — 2026-05-13
+
+> Patch: `pk promote` correctness. Refuses when the target branch is missing on origin instead of exiting 128 silently; respects the Linear workflow ladder instead of force-transitioning every bundled WIT to the env's mapped state.
+
+### What changed
+
+- **`bin/pk` `cmd_promote` missing-target guard** — runs `git ls-remote --exit-code origin refs/heads/$target` after target validation. On miss, refuses with an actionable error containing the exact `gh api -X POST repos/<owner>/<repo>/git/refs` recovery command (owner/repo derived from the origin URL). New `--bootstrap` flag auto-recreates the branch at `origin/<source>` tip via `gh api`.
+- **`bin/pk` `pk_state_rank`** (new helper) — ranks Linear workflow states along the canonical ladder (`Triage` < `Ideas` < `Future Phases` < `On Deck` < `Needs Spec` < `Specced` < `Approved` < `Building` < `In Progress` < `UAT` < `Released` < `Done`). Unknown states return 0 (preserves current behavior for projects with custom workflows); `Canceled` / `Duplicate` outrank `Done` (never promote forward).
+- **`bin/pk` `pk_linear_set_state` ladder gate** — opt-in `mode="advance"` argument. When set, refuses backward transitions (logs "already at <state> (skip backward transition)") and refuses Approved-or-earlier → Released/Done leap-frogs (logs a loud warning to stderr; commits made it into a promote bundle without UAT verification).
+- **`bin/pk` `cmd_promote` issue-loop** — passes `"advance"` mode to `pk_linear_set_state`. Bundled WITs only move forward along the ladder; the audit trail stays monotonic across cycles.
+- **`scripts/test-pk-promote.sh`** (new) — fixture-based bash harness. Asserts pairwise ladder ordering, unknown-state fallback, terminal-off-ladder behavior, `git ls-remote --exit-code` semantics, and owner/repo extraction from both https and ssh origin URLs. 25 assertions; run with `bash scripts/test-pk-promote.sh`.
+- **`PK_VERSION`** 2.3.2 → 2.3.3.
+
+### Why
+
+The v2.3.1 recovery Gate 3 canary (WIT-348, closed 2026-05-13) surfaced 8 new findings. Two were direct regressions of the promote chain that v2.3.2 was supposed to stabilize:
+
+- **#25** — `pk promote beta` exited 128 with zero diagnostic output when `origin/beta` was missing. Root cause: `git fetch origin beta --quiet || true` swallowed the "couldn't find remote ref" message and masked the non-zero exit; the downstream `git log origin/beta..origin/dev` then exited 128 on the unknown revision. Without `bash -x`, the failure mode is essentially undebuggable. (The branch went missing because GitHub's repo-level auto-delete-on-merge removed it when a previous beta→main PR merged — handoff finding #26, fixed Piper-side via branch protection.)
+- **#28** — `pk promote beta` force-transitioned every WIT mentioned in commit messages to the env's mapped state, regardless of current Linear state. In the canary, this pulled 3 already-Done WITs backward to Released and leap-frogged 1 Approved WIT straight to Released, skipping Building/In Progress/UAT entirely. Audit-trail integrity loss compounds per cycle — the next `pk promote main` would have force-moved the Released WITs back to Done, producing a "shipped → unreleased → shipped" lifecycle on three issues that never actually un-shipped.
+
+Both regressions fired on the first real canary use. v2.3.2 happened to have `origin/beta` bootstrapped, so #25 (a direct regression of canary 3's loop-note #16) was deprioritized as parallel-track; v2.3.3 folds it in.
+
+### Migration
+
+None. Re-run `./scripts/sync-method.sh v2.3.3` in consumer projects. After sync:
+
+- `pk version` returns `2.3.3`
+- `pk promote <env>` refuses loudly when the target branch is missing on origin (instead of exiting 128 silently)
+- `pk promote <env> --bootstrap` recreates the missing target branch at the source tip via `gh api`
+- `pk promote <env>` only transitions Linear issues forward along the workflow ladder; backward and leap-frog attempts log and skip without mutating Linear state
+- `bash scripts/test-pk-promote.sh` exits 0 (25 assertions)
+
+### What this fixes (loop-notes references)
+
+- **#25** `pk promote` silent exit 128 on missing target branch → fixed (`git ls-remote` guard + `--bootstrap` flag)
+- **#28** `pk promote` force-transitions bundled WITs ignoring Linear state → fixed (ladder gate in `pk_linear_set_state` via opt-in `mode="advance"`)
+
+### Deferred to a future patch
+
+The Gate 3 canary also flagged `/spec-preflight` capability gaps (#20 managed-Supabase GUC probe, #21 canonical `Strategy/` cross-check, #22 test-runner/tooling availability, #24 migration data-shape probe) and three Piper-side infra items (#23 dev migration CI, #26 branch protection, #27 SessionStart `gh auth` hook). The `/spec-preflight` Phase 3.6 capability-probing extension lands in a separate Pipekit PR; the Piper-side items are tracked downstream.
+
+---
+
 ## v2.3.2 — 2026-05-12
 
 > Patch: closes the v2.3.1 canary cascade. `pk_config` reads the actual code-block config format; `pk config` subcommand exposed; `/verify` skill stops self-terminating; `pk done` no longer destroys its own CWD.

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.3.2"
+PK_VERSION="2.3.3"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null
@@ -288,10 +288,43 @@ pk_linear_issues_in_state() {
     | jq -r '.data.issues.nodes // []'
 }
 
+# Rank a Linear workflow state along the canonical forward ladder.
+# Higher rank = further along the lifecycle. Unknown states return 0
+# (treated as "before everything" so a callsite using --advance will
+# always allow the transition — preserves current behavior for projects
+# with custom workflows). Terminal-but-off-ladder states (Canceled,
+# Duplicate) return a sentinel rank that never matches a target.
+pk_state_rank() {
+  case "$1" in
+    'Triage')        echo 1 ;;
+    'Ideas')         echo 2 ;;
+    'Future Phases') echo 3 ;;
+    'On Deck')       echo 4 ;;
+    'Needs Spec')    echo 5 ;;
+    'Specced')       echo 6 ;;
+    'Approved')      echo 7 ;;
+    'Building')      echo 8 ;;
+    'In Progress')   echo 9 ;;
+    'UAT')           echo 10 ;;
+    'Released')      echo 11 ;;
+    'Done')          echo 12 ;;
+    'Canceled')      echo 99 ;;
+    'Duplicate')     echo 99 ;;
+    *)               echo 0 ;;
+  esac
+}
+
 # Update issue state by identifier + state name.
+#
+# Modes:
+#   (default)   idempotent set — skip if already in target, otherwise mutate
+#   "advance"   ladder-gated: only mutate when target rank > current rank;
+#               refuse Approved-or-earlier → Released/Done leap-frogs with
+#               a warning (these imply commits shipped without verification).
 pk_linear_set_state() {
   local id="$1"
   local state_name="$2"
+  local mode="${3:-}"
   # Filter workflowStates by team NAME (reliable — pk_team_name reads
   # method.config.md robustly). Earlier versions used team.id.eq with
   # pk_team_id, but Team ID may be empty in many configs and the filter
@@ -325,6 +358,31 @@ pk_linear_set_state() {
   if [ "$current_state" = "$state_name" ]; then
     echo "  Linear: $id already in '$state_name' (skip)"
     return 0
+  fi
+  # Ladder gate (opt-in via mode="advance"): forward-only along the canonical
+  # workflow. Prevents promote bundles from pulling Done WITs backward and
+  # from leap-frogging Approved WITs past the verification states.
+  if [ "$mode" = "advance" ] && [ -n "$current_state" ]; then
+    local rank_current rank_target rank_approved
+    rank_current=$(pk_state_rank "$current_state")
+    rank_target=$(pk_state_rank "$state_name")
+    rank_approved=$(pk_state_rank "Approved")
+    # Unknown current OR target → fall through to mutate (preserve current
+    # behavior for projects with custom workflow states off the canonical ladder).
+    if [ "$rank_current" -gt 0 ] && [ "$rank_target" -gt 0 ]; then
+      if [ "$rank_target" -lt "$rank_current" ]; then
+        echo "  Linear: $id already at '$current_state' (target was '$state_name') — skip backward transition"
+        return 0
+      fi
+      # Leap-frog: current is Approved-or-earlier AND target is Released/Done.
+      # The WIT's commits made it into a promote bundle without UAT/In Progress —
+      # surface it loudly and refuse the transition.
+      if [ "$rank_current" -le "$rank_approved" ] && [ "$rank_target" -ge "$(pk_state_rank Released)" ]; then
+        echo "  Linear: $id at '$current_state' — refusing leap-frog to '$state_name'." >&2
+        echo "    Commits shipped without Building/In Progress/UAT. Review manually before transitioning." >&2
+        return 0
+      fi
+    fi
   fi
   local mutation='mutation($id: String!, $state: String!) { issueUpdate(id: $id, input: {stateId: $state}) { success } }'
   pk_linear_gql "$mutation" "$(jq -n --arg id "$issue_uuid" --arg state "$state_id" '{id:$id, state:$state}')" >/dev/null
@@ -988,11 +1046,12 @@ cmd_verify() {
 # (matches `pk ship`). Position-based state mapping: last hop → Done,
 # any non-last → Released.
 cmd_promote() {
-  local stash=false take_remote=false target=""
+  local stash=false take_remote=false bootstrap=false target=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --stash)       stash=true;       shift ;;
       --take-remote) take_remote=true; shift ;;
+      --bootstrap)   bootstrap=true;   shift ;;
       --*)           echo "pk promote: unknown arg $1" >&2; return 2 ;;
       *)             target="$1";      shift ;;
     esac
@@ -1045,6 +1104,55 @@ cmd_promote() {
   fi
 
   local source="${envs_arr[$((target_idx - 1))]}"
+
+  # Guard against missing target branch on origin. GitHub's repo-level
+  # "auto-delete head branches" will silently remove long-lived release
+  # branches (e.g. beta) when a beta→main PR merges, and the previous
+  # behavior was for the downstream `git log origin/$target..origin/$source`
+  # to exit 128 with --quiet swallowing the diagnostic. Refuse loudly here.
+  if ! git ls-remote --exit-code origin "refs/heads/$target" >/dev/null 2>&1; then
+    if $bootstrap; then
+      echo "  → --bootstrap: creating origin/$target at origin/$source tip"
+      git fetch origin "$source" --quiet
+      local origin_url owner_repo source_sha
+      origin_url=$(git remote get-url origin)
+      owner_repo=$(echo "$origin_url" | sed -E 's#\.git$##' | sed -E 's#^.*github\.com[:/]##')
+      source_sha=$(git rev-parse "origin/$source")
+      if ! gh api -X POST "repos/$owner_repo/git/refs" \
+        -f ref="refs/heads/$target" -f sha="$source_sha" >/dev/null; then
+        echo "ERROR: --bootstrap failed to create origin/$target via gh api." >&2
+        echo "  Verify gh auth (gh auth status) and write permission on $owner_repo." >&2
+        return 1
+      fi
+      echo "  → origin/$target created at $source_sha"
+    else
+      local origin_url owner_repo
+      origin_url=$(git remote get-url origin 2>/dev/null || echo "")
+      owner_repo=$(echo "$origin_url" | sed -E 's#\.git$##' | sed -E 's#^.*github\.com[:/]##')
+      echo "ERROR: origin/$target does not exist." >&2
+      echo "" >&2
+      echo "  The remote branch '$target' is missing. This usually means GitHub's" >&2
+      echo "  'auto-delete head branches' setting removed it after a previous" >&2
+      echo "  promote PR merged. Recreate it from origin/$source:" >&2
+      echo "" >&2
+      if [ -n "$owner_repo" ]; then
+        echo "    gh api -X POST repos/$owner_repo/git/refs \\" >&2
+        echo "      -f ref=refs/heads/$target \\" >&2
+        echo "      -f sha=\$(git rev-parse origin/$source)" >&2
+      else
+        echo "    gh api -X POST repos/<owner>/<repo>/git/refs \\" >&2
+        echo "      -f ref=refs/heads/$target \\" >&2
+        echo "      -f sha=\$(git rev-parse origin/$source)" >&2
+      fi
+      echo "" >&2
+      echo "  Or rerun with --bootstrap to auto-create it:" >&2
+      echo "    pk promote $target --bootstrap" >&2
+      echo "" >&2
+      echo "  Long-term fix: protect '$target' against deletion (see Pipekit handoff #26)." >&2
+      return 1
+    fi
+  fi
+
   echo "Promote $source → $target"
   echo "  1. Sync $source"
   git checkout "$source"
@@ -1127,7 +1235,7 @@ cmd_promote() {
       id_count=$(echo "$issue_ids" | wc -l | tr -d ' ')
       echo "  4. Transitioning $id_count issue(s) → $target_state"
       while IFS= read -r issue_id; do
-        if ! pk_linear_set_state "$issue_id" "$target_state" 2>/dev/null; then
+        if ! pk_linear_set_state "$issue_id" "$target_state" "advance"; then
           if [ "$target_state" = "Released" ]; then
             echo "    Linear: $issue_id — Released state not configured. Add it via Linear UI + method.config.md, then re-run." >&2
           else

--- a/scripts/test-pk-promote.sh
+++ b/scripts/test-pk-promote.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# test-pk-promote.sh — fixture-based tests for pk_state_rank and the
+# missing-target-branch guard in cmd_promote.
+#
+# Covers regressions from the Gate 3 canary (Pipekit v2.3.3 handoff):
+#   #25  pk promote exits 128 silently when origin/<target> is missing
+#   #28  pk promote force-transitions Linear issues regardless of current state
+#
+# Run: bash scripts/test-pk-promote.sh   (exit 0 on pass, 1 on first failure)
+
+set -uo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+# shellcheck disable=SC1091
+source "$repo_root/bin/pk"
+
+fail=0
+pass=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass + 1))
+    printf '  ok  %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %s\n       expected: %q\n       got:      %q\n' "$name" "$expected" "$actual"
+  fi
+}
+
+assert_lt() {
+  local name="$1" small="$2" big="$3"
+  if [ "$small" -lt "$big" ]; then
+    pass=$((pass + 1))
+    printf '  ok  %s (%d < %d)\n' "$name" "$small" "$big"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %s\n       expected: %d < %d\n' "$name" "$small" "$big"
+  fi
+}
+
+# ─── pk_state_rank: canonical ladder ordering ───────────────────────────────
+echo "pk_state_rank: canonical ladder is strictly monotonic"
+prev=$(pk_state_rank "Triage")
+for state in "Ideas" "Future Phases" "On Deck" "Needs Spec" "Specced" "Approved" "Building" "In Progress" "UAT" "Released" "Done"; do
+  cur=$(pk_state_rank "$state")
+  assert_lt "$state ranks above previous" "$prev" "$cur"
+  prev=$cur
+done
+
+# ─── pk_state_rank: pairwise checks that matter for the gate ────────────────
+echo "pk_state_rank: gate-relevant pairs"
+assert_lt "Approved < Released" "$(pk_state_rank Approved)" "$(pk_state_rank Released)"
+assert_lt "UAT < Released"      "$(pk_state_rank UAT)"      "$(pk_state_rank Released)"
+assert_lt "Released < Done"     "$(pk_state_rank Released)" "$(pk_state_rank Done)"
+assert_lt "On Deck < Approved"  "$(pk_state_rank "On Deck")" "$(pk_state_rank Approved)"
+
+# Done must NOT rank below Released (no backward promote main → beta).
+done_rank=$(pk_state_rank Done)
+released_rank=$(pk_state_rank Released)
+if [ "$done_rank" -gt "$released_rank" ]; then
+  pass=$((pass + 1))
+  printf '  ok  Done > Released (rejects backward Done→Released)\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL Done > Released\n       Done=%d Released=%d\n' "$done_rank" "$released_rank"
+fi
+
+# ─── pk_state_rank: unknown + terminal-off-ladder ───────────────────────────
+echo "pk_state_rank: unknown and terminal-off-ladder states"
+assert_eq "Unknown state → 0 (allow transition for custom workflows)" "0" "$(pk_state_rank 'In Review')"
+assert_eq "Empty state → 0"                                            "0" "$(pk_state_rank '')"
+canceled_rank=$(pk_state_rank Canceled)
+if [ "$canceled_rank" -gt "$done_rank" ]; then
+  pass=$((pass + 1))
+  printf '  ok  Canceled outranks Done (never promotes forward)\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL Canceled > Done\n       Canceled=%d Done=%d\n' "$canceled_rank" "$done_rank"
+fi
+
+# ─── Missing-target-branch guard ────────────────────────────────────────────
+# Build a temp bare "origin" with only `dev` present, then assert that
+# git ls-remote --exit-code origin refs/heads/beta returns non-zero.
+echo "missing-target-branch guard: git ls-remote semantics"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+(
+  cd "$tmp"
+  git init -q --bare origin.git
+  git init -q work
+  cd work
+  git config user.email test@local
+  git config user.name test
+  git commit --allow-empty -q -m "init"
+  git branch -M dev
+  git remote add origin "$tmp/origin.git"
+  git push -q origin dev
+)
+cd "$tmp/work"
+
+# beta does not exist on origin → exit non-zero
+if git ls-remote --exit-code origin refs/heads/beta >/dev/null 2>&1; then
+  fail=$((fail + 1))
+  printf '  FAIL ls-remote should have refused missing beta\n'
+else
+  pass=$((pass + 1))
+  printf '  ok  ls-remote --exit-code refuses missing origin/beta\n'
+fi
+
+# dev exists on origin → exit 0
+if git ls-remote --exit-code origin refs/heads/dev >/dev/null 2>&1; then
+  pass=$((pass + 1))
+  printf '  ok  ls-remote --exit-code accepts existing origin/dev\n'
+else
+  fail=$((fail + 1))
+  printf '  FAIL ls-remote should have accepted existing dev\n'
+fi
+cd "$repo_root"
+
+# ─── owner/repo extraction (used in the recovery-command message) ───────────
+echo "owner/repo extraction from origin URL"
+extract_owner_repo() {
+  echo "$1" | sed -E 's#\.git$##' | sed -E 's#^.*github\.com[:/]##'
+}
+assert_eq "https URL"        "withpiper/piper" "$(extract_owner_repo 'https://github.com/withpiper/piper.git')"
+assert_eq "https no .git"    "withpiper/piper" "$(extract_owner_repo 'https://github.com/withpiper/piper')"
+assert_eq "ssh URL"          "withpiper/piper" "$(extract_owner_repo 'git@github.com:withpiper/piper.git')"
+assert_eq "ssh no .git"      "withpiper/piper" "$(extract_owner_repo 'git@github.com:withpiper/piper')"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  printf '✓ %d assertions passed\n' "$pass"
+  exit 0
+else
+  printf '✗ %d failed, %d passed\n' "$fail" "$pass"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Closes Pipekit handoff findings **#25** and **#28**, both regressions of `pk promote` surfaced by the WIT-348 Gate 3 canary on 2026-05-13. Without these fixes, every promote cycle either exits 128 silently (when the target branch was auto-deleted) or corrupts Linear audit trail (pulling Done WITs backward, leap-frogging Approved WITs past UAT).

- **#25** — `pk promote` now refuses loudly when `origin/<target>` is missing, with an actionable `gh api` recovery snippet. New `--bootstrap` flag auto-recreates the branch at the source tip.
- **#28** — `pk_linear_set_state` gains opt-in `mode="advance"`; `cmd_promote` uses it so bundled WITs only move forward along the canonical Linear ladder (Triage → … → Done). Backward transitions skip with a log line; Approved-or-earlier → Released/Done leap-frogs refuse with a stderr warning.

Theme 2 of the v2.3.3 handoff (`/spec-preflight` Phase 3.6 — findings #20/#21/#22/#24) is deferred to a separate PR. Piper-side infra items (#23/#26/#27) are downstream.

## Test plan

- [x] `bash -n bin/pk` — syntax clean
- [x] `bash scripts/test-pk-promote.sh` — 25/25 assertions pass (ladder rank monotonic; unknown-state fallback; terminal-off-ladder rank; `git ls-remote --exit-code` semantics; owner/repo extraction for https + ssh URLs)
- [x] `bash scripts/test-pk-config.sh` — 14/14 assertions still pass (no regression in shared helper)
- [x] `pk version` returns `2.3.3`
- [ ] Live smoke canary against `withpiper/piper` after sync (per handoff step 4) — to be run by Piper after `sync-method.sh v2.3.3`

## References

- `engineering/Handoff-Pipekit-v2.3.3.md` (Piper repo) — Track A Theme 1 spec
- `engineering/Pipekit-v2.3.1-Loop-Notes_WIT-280.md` findings #25 + #28 (Piper repo)
- `CHANGELOG.md` — full v2.3.3 entry with loop-notes back-references and migration notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)