### PR TITLE
v2.4.0 — /spec-preflight Phase 3.6 project signal probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.4.0 — 2026-05-13
+
+> Minor: `/spec-preflight` Phase 3.6 — project signal probing. Closes the "environmental blindness" class of bug surfaced by the WIT-348 Gate 3 canary. Four new probes: canonical-doc cross-check, platform capability, tooling availability, migration data shape.
+
+### What changed
+
+- **`skills/spec-preflight/skill.md`** — new Step 3.6 ("Project signal probes") between Steps 3 and 4. Steps 1–3 verify claims the spec explicitly makes; Step 3.6 probes claims the spec implies by referencing a tool, proposing a platform-specific mechanism, drafting a migration, or anchoring to a non-canonical source. Four probes:
+  - **3.6a — Canonical-doc cross-check (#21)** — when the spec body references POC and `Strategy docs path` resolves to an existing dir, surfaces Strategy docs + section hints for cross-check. `⚠` warning (ambiguous; human decides).
+  - **3.6b — Platform capability (#20)** — detects GUC patterns (`ALTER DATABASE`, `current_setting`, `app.X`). Hard-fails on managed-supabase (the postgres role lacks `SET DATABASE` privilege even as DB owner). Reads new `Platform` V2 key.
+  - **3.6c — Tooling availability (#22)** — detects test runner / quality tool names in ACs (Playwright, Cypress, Jest, Vitest, Storybook, Lighthouse, ESLint, Prettier, MSW, Testing Library). Greps repo-root + workspace `package.json` files for the corresponding package names. Hard-fails when AC requires a tool that isn't in `dependencies` or `devDependencies`. Auto-downgrades to warning when the same AC text acknowledges the gap ("to be added", "follow-up", "next phase").
+  - **3.6d — Migration data shape (#24)** — scans cited migration SQL for new `CHECK`, `NOT NULL`, type-narrowing, and column renames. Builds inverse-predicate `SELECT COUNT(*)` queries. Executes against the parent project via any bound `mcp__supabase-*__execute_sql` tool (read-only); otherwise surfaces the query templates. `⚠` warning with the violator counts (or templates).
+- **`skills/spec-preflight/skill.md` `--accept` flag** — downgrade Phase 3.6 hard-fails (`✗`) to warnings (`⚠`) for accepted-risk cases. Findings still appear; only the blocking verdict softens. Phase 1–3 hard-fails remain blocking (`--accept` does not bypass empirical claim divergence).
+- **`skills/spec-preflight/skill.md` verdict block** — now sectioned: "Empirical claims (Phase 1–3)" and "Project signal probes (Phase 3.6)". New output examples include the WIT-348 canary pattern (Strategy cross-check + Playwright tooling miss + migration data-shape probes firing simultaneously).
+- **`method.config.template.md`** — new `Platform` V2 key (values: `managed-supabase`, `self-hosted-postgres`, `none`; default `none`). `Migration dir` "Used by" column extended to call out `/spec-preflight` Probe 3.6d.
+- **`PK_VERSION`** 2.3.3 → 2.4.0.
+
+### Why
+
+The v2.3.x recovery established that Pipekit had two distinct classes of "trust but never verify" bug. v2.3.2 fixed parser blindness (`pk_config` returned defaults silently); v2.3.3 fixed promote-chain blindness (target branch and Linear ladder). v2.4.0 fixes the remaining class: environmental blindness — the spec is internally coherent and passes the Spec Review Agent, but it references tooling that isn't installed, a platform mechanism the deployment doesn't support, or a column model that contradicts the project's canonical Strategy docs. Every downstream gate (plan-reviewer, `/verify`, QA subagent) reads the spec body as ground truth; none of them re-check spec-vs-reality at the surroundings layer. The Gate 3 canary surfaced all four probe gaps in a single WIT (WIT-348):
+
+- **#21 (Strategy cross-check)** — spec claimed 5 lifecycle date fields with "parity with POC" framing. Strategy/Doc1 §3.1 + Strategy/Doc2 §3.2.3 define **6** fields with engagement-default scoping. Without the canonical-doc probe, `/light-spec` and every downstream gate would have shipped the wrong column set.
+- **#22 (Tooling)** — an AC required Playwright; `@playwright/test` was not in `package.json`. The AC was unsatisfiable as written; the `/work` agent had to invent a Vitest substitution mid-execution.
+- **#20 (Platform)** — WIT-450's prod-safety mechanism used `ALTER DATABASE postgres SET app.is_prod`; managed Supabase blocked the write with `42501: permission denied` at deploy-time, forcing a redesign to a sentinel-table pattern. The capability mismatch was knowable from the platform fact alone.
+- **#24 (Migration data shape)** — per-PR branch DBs run with `with_data: false`, so the migration's chronological `CHECK` constraint passed CI three times. At apply-time against populated piper-dev, 1 row violated `show_end_date <= onsite_end_date` because `end_date → show_end_date` and `wrap_date → onsite_end_date` reversed the natural project-closure ordering.
+
+All four are "the project has the answer; the toolchain didn't apply it." Phase 3.6 puts the probes at the earliest gate (`/spec-preflight`) so the spec author resolves divergence once, before downstream agents lock in.
+
+### Migration
+
+Optional. Re-run `./scripts/sync-method.sh v2.4.0` in consumer projects to pick up the updated `spec-preflight` skill and template. After sync:
+
+- `pk version` returns `2.4.0`
+- `/spec-preflight PROJ-XXX` emits a Phase 3.6 section in the verdict block. Probes that don't match the spec content render as `n/a` — projects with no GUC patterns / no Strategy dir / no migrations see the same flow they had pre-v2.4.0 plus four `n/a` lines.
+- Optional `Platform: managed-supabase` (or `self-hosted-postgres`) in `method.config.md` enables hard-fails on platform-incompatible GUC designs. Leave blank for projects without DB or with non-Postgres backends.
+- `/spec-preflight PROJ-XXX --accept` downgrades Phase 3.6 hard-fails to warnings (for tooling intentionally absent / to be bootstrapped later). Phase 1–3 hard-fails remain blocking.
+
+### What this fixes (loop-notes references)
+
+- **#20** Managed-Supabase blocks GUC parameter writes → Probe 3.6b refuses GUC-based prod-safety designs at spec time (reads `Platform` config key)
+- **#21** `/spec-preflight` doesn't cross-check `Strategy/*` canonical docs → Probe 3.6a surfaces Strategy docs + section hints when spec references POC
+- **#22** `/spec-preflight` doesn't probe test-runner / tooling availability → Probe 3.6c grep `package.json` for every tool mentioned in an AC; hard-fails when absent
+- **#24** Per-PR branch DBs lack production data; migrations pass CI then fail at apply-time → Probe 3.6d scans migration SQL for CHECK/NOT NULL/rename/narrowing, builds inverse-predicate SELECT COUNT(*) queries, runs them via Supabase MCP when bound
+
+### Deferred to future patches
+
+Piper-side infra items (#23 dev migration CI, #26 branch protection, #27 SessionStart `gh auth` hook) are tracked downstream in the Piper repo — they are project-specific operational hardening, not Pipekit upstream changes.
+
+---
+
 ## v2.3.3 — 2026-05-13
 
 > Patch: `pk promote` correctness. Refuses when the target branch is missing on origin instead of exiting 128 silently; respects the Linear workflow ladder instead of force-transitioning every bundled WIT to the env's mapped state.

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.3.3"
+PK_VERSION="2.4.0"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -151,7 +151,8 @@ Keys consumed by `bin/pk` and the `/work` + `/verify` skills. All have sensible 
 | **Default deep flag** | `true` \| `false` | `false` | `/work` (treats every issue as `--deep` if `true`) |
 | **Ship environments** | comma-separated list, ordered | `dev,main` | `pk ship --env=<name>` (multi-env projects only) |
 | **Linear API key env var** | name, e.g. `LINEAR_API_KEY` | `LINEAR_API_KEY` | `pk *` (Linear API access) |
-| **Migration dir** | e.g. `supabase/migrations/` | (none) | `/pr-security-review` (locate migrations to audit) |
+| **Migration dir** | e.g. `supabase/migrations/` | (none) | `/pr-security-review` (locate migrations to audit); `/spec-preflight` Probe 3.6d (migration data-shape) |
+| **Platform** | `managed-supabase` \| `self-hosted-postgres` \| `none` | `none` | `/spec-preflight` Probe 3.6b — refuses GUC-based prod-safety designs on managed-supabase (handoff #20, verified at WIT-450) |
 | **Spec ready state** | Linear state name | `Specced` | `pk spec-cycle` (refuses to trigger if issue is in any other state) |
 | **Spec approved state** | Linear state name | `Approved` | `pk spec-cycle` (transitions issue to this state on a Pass verdict) |
 | **Self-reference check** | `enabled` \| `disabled` | `disabled` | `pk verify` — runs `scripts/check-no-self-references.sh`; fails if current branch's source still references its own ticket ID (e.g. `RS-29`) in any file the branch did not edit. Catches predecessor-placeholder integration misses (RS-29 rs-vault, 2026-05-05). Bypass on a per-run basis with `AGREED_PLACEHOLDER=1 pk verify` after surfacing matches in the hand-off summary. |

--- a/skills/spec-preflight/skill.md
+++ b/skills/spec-preflight/skill.md
@@ -14,6 +14,7 @@ Read `method.config.md` for project context (Linear team prefix, state IDs, proj
 ## Triggers
 
 - `/spec-preflight PROJ-XXX` — verify a single specced issue
+- `/spec-preflight PROJ-XXX --accept` — downgrade Phase 3.6 hard-fails (`✗`) to warnings (`⚠`). Use for accepted-risk cases (e.g., tooling intentionally absent, to be bootstrapped later). The findings still appear in the report; only the blocking verdict softens.
 - "pre-flight PROJ-XXX" / "verify spec PROJ-XXX"
 
 ## When to use
@@ -41,6 +42,10 @@ For Quick-tier issues that skip agent review entirely, this skill is the only au
 | `phase-detect.sh` output | Bash via the v1.4.1 lookup chain (see Step 3) | Confirm stated VBW baseline is current |
 | Linear status (re-fetched) | `mcp__linear-server__get_issue` | Compare current status against spec body's claim |
 | Each `blocked_by` issue | `mcp__linear-server__get_issue` | Confirm dependency claims of "Done" |
+| `Strategy docs path` (from `method.config.md`) | `Glob` + `Read` | Probe 3.6a — canonical-doc cross-check (#21) |
+| `Platform` (from `method.config.md`) | none — heuristic match against spec body | Probe 3.6b — platform-capability check (#20) |
+| `package.json` + lockfile (root + workspace pkgs) | `Read` + `Grep` | Probe 3.6c — tooling availability (#22) |
+| Migration files cited in spec | `Read` (and optionally a Supabase MCP `execute_sql` for read-only `SELECT COUNT(*)` violator counts) | Probe 3.6d — migration data-shape (#24) |
 
 ## Algorithm
 
@@ -129,6 +134,128 @@ For each `blocked_by` identifier (from `relations` and from any narrative claims
 
 If the Linear MCP server times out or is unavailable on any individual fetch: record that specific dependency as `unverified — Linear API timeout` and continue. Do not fail the whole verdict on infrastructure flake. (See Graceful Degradation below.)
 
+### Step 3.6 — Project signal probes
+
+Steps 1–3 verify claims the spec **explicitly makes** (this file exists, that line resolves, this WIT is Done). Step 3.6 probes claims the spec **implies** — by referencing a tool, by proposing a platform-specific mechanism, by drafting a migration, or by anchoring to a non-canonical source. These are the "environmental blindness" gaps the v2.3.x recovery surfaced; without them, downstream agents read a spec that's internally consistent but reality-divergent.
+
+Each probe runs independently. A miss in one does not skip the others. Findings render as a separate category-block under the verdict. Where a probe needs `method.config.md` keys, fall through gracefully if the key is unset.
+
+#### 3.6a — Canonical-doc cross-check (handoff #21)
+
+**Trigger:** the spec body contains any of `POC`, `parity with POC`, `POC pattern`, `the POC` (case-insensitive) AND `method.config.md`'s `Strategy docs path` resolves to an existing directory.
+
+**Probe:**
+1. Read `Strategy docs path` from `method.config.md` (default: `Strategy/`).
+2. `Glob` `<path>/*.md` and `<path>/**/*.md`. Capture the file list.
+3. For each Strategy doc, scan the first 200 lines (section index) for headings that overlap concept words from the spec body. Concept words: nouns appearing in the spec's §Goal, §Acceptance Criteria headings, or italicized key terms.
+
+**Emit (always `⚠` — ambiguous; the human decides whether topic overlap is load-bearing):**
+
+```
+⚠ Canonical docs: Strategy at <path> contains <N> doc(s); spec body references POC.
+    Cross-check spec claims against:
+      - Strategy/<doc1>.md (sections: ...)
+      - Strategy/<doc2>.md (sections: ...)
+    Strategy is canonical for this project; POC may diverge.
+```
+
+If `Strategy docs path` is unset OR the directory is empty: record `n/a — no Strategy docs configured`. Do not warn — projects without Strategy docs are valid.
+
+#### 3.6b — Platform capability (handoff #20)
+
+**Trigger:** the spec body contains any of `ALTER DATABASE`, `SET app\.`, `current_setting\(`, `pg_db_role_setting`, `GUC`, or other Postgres custom-parameter patterns.
+
+**Probe:** (only runs when the trigger fires — if no GUC pattern appears in the spec, this probe renders as `✓ n/a`)
+
+1. Read `Platform` from `method.config.md`. Recognized values: `managed-supabase`, `self-hosted-postgres`, `none`. Default: unset (treated as "unconfigured").
+2. If `Platform: managed-supabase`: managed Supabase blocks the `postgres` role from `ALTER DATABASE … SET <custom>` even when role-owns the DB (verified empirically during WIT-450, handoff #20). Emit `✗` (hard fail) with the known-blocker note.
+3. If `Platform: self-hosted-postgres`: emit `⚠` reminder to confirm the role has `ALTER DATABASE` privilege on the target DB.
+4. If `Platform` unset or `none`: emit `⚠ Platform key not configured — GUC capability unverified for this deployment` and continue. Spec author should set `Platform` so the next preflight gives a definitive answer.
+
+**Emit (`✗` for managed-supabase, `⚠` otherwise):**
+
+```
+✗ Platform capability: spec proposes GUC-based mechanism (ALTER DATABASE … SET app.X);
+    Platform=managed-supabase blocks this — postgres role lacks SET DATABASE privilege
+    even as db owner (handoff #20, verified at WIT-450 against piper-prod + piper-dev).
+    Redesign with a sentinel-table pattern OR change Platform if the deployment moved.
+```
+
+#### 3.6c — Tooling availability (handoff #22)
+
+**Trigger:** an Acceptance Criterion line mentions any known test runner / quality tool / framework name. Detection list (extend as projects evolve):
+
+| Tool | Package(s) to grep for |
+|------|----------------------|
+| Playwright | `@playwright/test`, `playwright` |
+| Cypress | `cypress` |
+| Jest | `jest` |
+| Vitest | `vitest` |
+| Storybook | `@storybook/`, `storybook` |
+| Lighthouse | `lighthouse`, `lighthouse-ci`, `@lhci/cli` |
+| ESLint | `eslint` |
+| Prettier | `prettier` |
+| MSW | `msw` |
+| Testing Library | `@testing-library/` |
+
+**Probe:**
+1. Locate `package.json` files: repo root + every workspace `package.json` discoverable via `Glob` `**/package.json` (skip `node_modules/`).
+2. For each tool detected in an AC, `Grep` the combined package.json set for the package names listed above (check both `dependencies` and `devDependencies`).
+3. Also check the lockfile (`pnpm-lock.yaml` / `package-lock.json` / `yarn.lock`) — a package in the lockfile but not `package.json` means it's a transitive dep, not directly callable. Treat as absent.
+
+**Emit (`✗` hard fail — high-confidence blocker, downgradeable to `⚠` with `--accept`):**
+
+```
+✗ Tooling availability: AC #5 requires Playwright but @playwright/test not in
+    package.json (dependencies or devDependencies). The AC is unsatisfiable as
+    written. Either:
+      a) bootstrap @playwright/test (separate WIT first), or
+      b) rewrite AC against an existing test runner (Vitest is configured).
+```
+
+If the AC mentions a tool but the same AC also says "to be added" / "follow-up" / "next phase": downgrade to `⚠` automatically — the spec author already acknowledged the gap.
+
+#### 3.6d — Migration data shape (handoff #24)
+
+**Trigger:** the spec body cites a migration path under `Migration dir` (from `method.config.md`), OR proposes a migration with `CHECK`, `NOT NULL`, type narrowing (`varchar(255)` → `varchar(64)`), or column rename language.
+
+**Probe:**
+1. `Read` each cited migration file (or the spec's inline SQL block).
+2. Scan for:
+   - `ALTER TABLE … ADD CONSTRAINT … CHECK \(`
+   - `ALTER TABLE … ALTER COLUMN … SET NOT NULL`
+   - `ALTER TABLE … RENAME COLUMN`
+   - Type-narrowing `ALTER COLUMN … TYPE`
+3. For each constraint, build the inverse predicate as a `SELECT COUNT(*)` query. Example: `CHECK (show_end_date <= onsite_end_date)` becomes `SELECT COUNT(*) FROM <table> WHERE NOT (show_end_date <= onsite_end_date);`.
+4. **If a Supabase MCP is bound** (any `mcp__supabase-*__execute_sql` tool available in this session): run the query against the parent project (read-only `SELECT` — safe even on prod-tier). Emit the count.
+5. **If no MCP is bound**: emit the query template for the user to run manually.
+
+**Emit (`⚠` — surface for review; the spec author decides whether 0 violators is required or whether to add a backfill):**
+
+```
+⚠ Migration data shape: 2 new constraint(s) on populated columns.
+    Run violator counts against parent project before merging:
+
+      -- CHECK (show_end_date <= onsite_end_date)
+      SELECT COUNT(*) FROM projects WHERE NOT (show_end_date <= onsite_end_date);
+      -- count via piper-dev MCP: 1 violator
+
+      -- NOT NULL on projects.production_start
+      SELECT COUNT(*) FROM projects WHERE production_start IS NULL;
+      -- count via piper-dev MCP: 0 violators
+
+    Decide per row: backfill, default, or block migration until data is consistent.
+```
+
+This is the same shape gap as WIT-384's per-PR branch DBs running `with_data: false` — schema-only validation passes, data-incompatibility fails at apply-time against the populated parent. The probe shifts that discovery left, to spec-time.
+
+#### When `--accept` is in effect
+
+If the skill was invoked with `--accept`:
+- Phase 3.6 hard-fails (`✗`) downgrade to warnings (`⚠`).
+- A banner line appears above the verdict: `--accept: Phase 3.6 hard-fails downgraded to warnings.`
+- Steps 1–3 hard-fails are unaffected (file-presence / line-ref / dependency failures remain blocking — `--accept` does not bypass empirical claim divergence).
+
 ### Step 4 — Render verdict
 
 Print a single block to stdout. Use checkmarks (`✓`), warning markers (`⚠`), and failure markers (`✗`) so humans can scan it fast. Format:
@@ -136,11 +263,18 @@ Print a single block to stdout. Use checkmarks (`✓`), warning markers (`⚠`),
 ```
 Pre-flight checks for PROJ-XXX ({tier} tier):
 
+  ─ Empirical claims (Phase 1–3)
   ✓ File paths: {n_pass}/{n_total} exist
   ✓ Line refs: {n_pass}/{n_total} resolve
   ⚠ phase-detect baseline: spec says {field}={stated}, actual={observed}
   ✓ Linear status: {state} (matches spec)
   ✓ Dependencies: {n_done}/{n_total} Done
+
+  ─ Project signal probes (Phase 3.6)
+  {emoji} Canonical docs: {message or n/a}
+  {emoji} Platform capability: {message or n/a}
+  {emoji} Tooling availability: {message or n/a}
+  {emoji} Migration data shape: {message or n/a}
 
 Verdict: {PASS | REVISE} — {one-line reason if REVISE}
 {action hint if REVISE}
@@ -148,10 +282,11 @@ Verdict: {PASS | REVISE} — {one-line reason if REVISE}
 
 Verdict rules:
 
-- **PASS** — every category is `✓` or `n/a` (no claims of that type) or graceful-degradation `⚠ unverified` for phase-detect / Linear API. The user can proceed to `pk branch <ID>` without manual gut-checking.
-- **REVISE** — at least one real divergence: missing file, unresolved line, phase-detect mismatch, status mismatch, or non-Done dependency. The user updates the spec (or resolves the blocker) before `pk branch`.
+- **PASS** — every category is `✓` or `n/a` (no claims of that type) or graceful-degradation `⚠ unverified` for phase-detect / Linear API. Phase 3.6 may emit `⚠` (warnings) and still PASS — warnings inform but don't block.
+- **REVISE** — at least one real divergence in Phases 1–3 (missing file, unresolved line, phase-detect mismatch, status mismatch, non-Done dependency) OR a Phase 3.6 hard-fail (`✗`: managed-Supabase GUC pattern; tooling absent from `package.json`). The user updates the spec (or resolves the blocker) before `pk branch`.
+- **REVISE (downgraded with `--accept`)** — Phase 3.6 hard-fails alone don't force REVISE when `--accept` is in effect; they appear as warnings. Phase 1–3 hard-fails are never downgradeable.
 
-When emitting REVISE, point at *where* in the spec the divergence sits — by AC number, by section heading, or by the claim text — so the human can edit surgically rather than re-reading the whole spec.
+When emitting REVISE, point at *where* in the spec the divergence sits — by AC number, by section heading, by file path, or by the migration constraint — so the human can edit surgically rather than re-reading the whole spec.
 
 ### Step 5 — Stop
 
@@ -169,6 +304,10 @@ These rules are explicit so the skill stays useful when infrastructure is partia
 | Linear MCP timeout fetching a blocker | Record that dependency as `⚠ unverified`. Verdict is PASS-eligible if all other categories pass. |
 | File doesn't exist | Real divergence. Record `✗`. Triggers REVISE. Not graceful — file-presence is verifiable without infrastructure. |
 | Line range past EOF | Same as above — `✗`, REVISE. |
+| `Strategy docs path` unset / dir empty | Canonical-docs probe records `n/a`. Not a warning — projects without Strategy docs are valid. |
+| `Platform` key unset | Platform-capability probe records `⚠ Platform key not configured — capability unverified` only if the spec body triggered the probe (GUC pattern detected). |
+| No `package.json` discoverable | Tooling-availability probe records `⚠ no package.json found — tooling claims unverified`. Verdict PASS-eligible. |
+| No Supabase MCP bound | Migration-data-shape probe emits query templates for manual run. No `⚠` from this alone — surfacing the query is the deliverable. |
 
 Graceful degradation never *upgrades* the verdict (a `⚠` cannot become `✓`); it just keeps a single failure mode from blocking the rest of the report.
 
@@ -179,43 +318,99 @@ PASS verdict:
 ```
 Pre-flight checks for RS-87 (Standard tier):
 
+  ─ Empirical claims (Phase 1–3)
   ✓ File paths: 4/4 exist
   ✓ Line refs: 2/2 resolve
   ✓ phase-detect baseline: phase_count=1 (matches spec)
   ✓ Linear status: Approved (matches spec)
   ✓ Dependencies: 2/2 Done
 
+  ─ Project signal probes (Phase 3.6)
+  ✓ Canonical docs: n/a — no Strategy docs configured
+  ✓ Platform capability: n/a — no GUC pattern in spec
+  ✓ Tooling availability: 1/1 verified (Vitest in package.json)
+  ✓ Migration data shape: n/a — no migration cited
+
 Verdict: PASS — spec is empirically current. Proceed to pk branch RS-87.
 ```
 
-REVISE with a real divergence:
+REVISE with a Phase 1–3 divergence:
 
 ```
 Pre-flight checks for RS-51 (Standard tier):
 
+  ─ Empirical claims (Phase 1–3)
   ✓ File paths: 5/5 exist
   ✓ Line refs: 3/3 resolve
   ⚠ phase-detect baseline: spec says phase_count=0, actual=1
   ✓ Linear status: Approved (matches spec)
   ✓ Dependencies: 2/2 Done
 
+  ─ Project signal probes (Phase 3.6)
+  ✓ Canonical docs: n/a — no Strategy docs configured
+  ✓ Platform capability: n/a
+  ✓ Tooling availability: n/a — no test runner in ACs
+  ✓ Migration data shape: n/a
+
 Verdict: REVISE — phase-detect baseline divergence at AC #1.
 Update the spec's "currently returns phase_count=0" line before pk branch.
 ```
 
-REVISE with infrastructure degradation plus a real divergence:
+REVISE with the WIT-348 canary pattern (#21 + #22):
 
 ```
-Pre-flight checks for RS-92 (Quick tier):
+Pre-flight checks for WIT-348 (Standard tier):
 
-  ✗ File paths: 2/3 exist (missing: src/lib/old-auth.ts)
-  ✓ Line refs: 1/1 resolve
-  ⚠ VBW state unverified — phase-detect.sh unavailable
-  ✓ Linear status: Approved (matches spec)
-  ⚠ Dependencies: 1/2 verified — RS-89 Linear API timeout
+  ─ Empirical claims (Phase 1–3)
+  ⚠ File paths: 4/6 exist (renamed: projects.js → database/projects.js,
+                            budget-edit-main.js → pages/budget-edit-main.js)
+  ✓ Line refs: 2/2 resolve
+  ✓ phase-detect baseline: matches spec
+  ✓ Linear status: Specced (matches spec)
+  ✓ Dependencies: 1/1 Done
 
-Verdict: REVISE — src/lib/old-auth.ts cited in §Technical Context no longer exists.
-Likely renamed during recent refactor; update the spec path before pk branch.
+  ─ Project signal probes (Phase 3.6)
+  ⚠ Canonical docs: Strategy at Strategy/ contains 2 doc(s); spec body references POC.
+      Cross-check spec claims against:
+        - Strategy/Doc1_ConceptualOverview.md §3.1 (project lifecycle dates)
+        - Strategy/Doc2_TechnicalSpec.md §3.2.3 (six date fields, engagement defaults)
+      Strategy defines 6 lifecycle date fields; spec claims 5. Reconcile before approval.
+  ✓ Platform capability: n/a — no GUC pattern in spec
+  ✗ Tooling availability: AC #5 requires Playwright but @playwright/test not in
+      package.json. Either bootstrap (separate WIT) or rewrite against Vitest.
+  ⚠ Migration data shape: 5 chronological CHECK constraint(s) on projects (populated).
+      Run violator counts via piper-dev MCP before merging:
+        SELECT COUNT(*) FROM projects WHERE NOT (show_end_date <= onsite_end_date);
+        SELECT COUNT(*) FROM projects WHERE NOT (project_start_date <= production_start);
+        -- (3 more)
+
+Verdict: REVISE
+  - File path renames (2): update §Technical Context paths.
+  - Canonical-doc divergence: spec claims 5 fields, Strategy says 6. Reconcile §Goal + ACs.
+  - Tooling absent: AC #5 Playwright requirement unsatisfiable until bootstrap WIT lands.
+  - Migration data shape: 5 CHECKs on populated table — run violator counts first.
+```
+
+REVISE downgraded with `--accept`:
+
+```
+--accept: Phase 3.6 hard-fails downgraded to warnings.
+
+Pre-flight checks for WIT-348 (Standard tier):
+
+  ─ Empirical claims (Phase 1–3)
+  ✓ File paths: 6/6 exist
+  ✓ Line refs: 2/2 resolve
+  ✓ phase-detect baseline: matches spec
+  ✓ Linear status: Specced (matches spec)
+  ✓ Dependencies: 1/1 Done
+
+  ─ Project signal probes (Phase 3.6)
+  ⚠ Canonical docs: ...
+  ⚠ Tooling availability: AC #5 Playwright absent (--accept: hard-fail downgraded)
+  ⚠ Migration data shape: ...
+
+Verdict: PASS (with --accept warnings) — proceed knowing the listed gaps are accepted-risk.
 ```
 
 ## Rules of Engagement


### PR DESCRIPTION
## Summary

Closes Pipekit handoff findings **#20**, **#21**, **#22**, **#24** — the "environmental blindness" class of bug surfaced by the WIT-348 Gate 3 canary. Steps 1-3 verify claims the spec explicitly makes; the new **Step 3.6** probes claims the spec *implies* by referencing a tool, proposing a platform-specific mechanism, drafting a migration, or anchoring to a non-canonical source.

Four probes:

- **3.6a Canonical-doc cross-check (#21)** — surfaces Strategy docs + section hints when spec body references POC and `Strategy docs path` resolves. `⚠` warning.
- **3.6b Platform capability (#20)** — detects GUC patterns; hard-fails on `Platform: managed-supabase` (verified at WIT-450 against piper-prod + piper-dev). Reads new `Platform` V2 key.
- **3.6c Tooling availability (#22)** — scans ACs for test runners / quality tools, greps `package.json` + workspace `package.json` files. `✗` hard-fail when AC requires a tool absent from `dependencies`/`devDependencies`. Auto-downgrades when AC acknowledges the gap.
- **3.6d Migration data shape (#24)** — scans cited migration SQL for new `CHECK` / `NOT NULL` / type narrowing / column renames; builds inverse-predicate `SELECT COUNT(*)` queries. Runs against parent project via any bound `mcp__supabase-*__execute_sql` tool (read-only); otherwise surfaces query templates.

`--accept` flag downgrades Phase 3.6 hard-fails (`✗`) to warnings (`⚠`) for accepted-risk cases. Phase 1-3 hard-fails remain blocking — `--accept` does not bypass empirical claim divergence.

Architecturally: v2.3.2 fixed parser blindness (`pk_config` returned defaults silently). v2.3.3 fixed promote-chain blindness (target branch + Linear ladder). v2.4.0 fixes the remaining class: spec-vs-environment blindness. All three share the "trust but never verify" pattern at different layers.

## Test plan

- [x] `bash -n bin/pk` — syntax clean
- [x] `pk version` returns `2.4.0`
- [x] `bash scripts/test-pk-config.sh` — 14/14 pass (no regression)
- [x] `bash scripts/test-pk-promote.sh` — 25/25 pass (no regression)
- [x] Skill end-to-end re-read for coherence (sectioning + verdict-block grammar)
- [ ] Canary re-run per handoff: `/spec-preflight WIT-348` against piper's repo state at the spec-body-references-POC moment should emit Probe 3.6a (Strategy docs at `Strategy/Doc1`+`Doc2`) and Probe 3.6c (Playwright in AC #5 absent from `apps/web/package.json`). To be exercised by Piper after `sync-method.sh v2.4.0`.

## Deferred

Piper-side infra items (handoff #23 dev migration CI, #26 branch protection, #27 SessionStart `gh auth` hook) are downstream — they are project-specific operational hardening, not Pipekit upstream changes. Tracked separately.

## References

- `engineering/Handoff-Pipekit-v2.3.3.md` (Piper repo) — Track A Theme 2 spec
- `engineering/Pipekit-v2.3.1-Loop-Notes_WIT-280.md` findings #20/#21/#22/#24 (Piper repo)
- `CHANGELOG.md` — full v2.4.0 entry with per-finding fix descriptions and migration notes
- Prior: PR #83 (v2.3.3 — `pk promote` correctness — Track A Theme 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)