### PR TITLE
chore(workflows): auto-tag releases on PR merge

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,74 @@
+name: Auto-tag release on merge
+
+# When a PR into main merges with a version like vX.Y.Z in its title,
+# tag the merge commit with that version and push the tag. Idempotent:
+# skips if the tag already exists. Skips silently if the PR title has
+# no vX.Y.Z token (the common case for daily-loop PRs).
+#
+# Why: the release flow bumps PK_VERSION + CHANGELOG inside the PR, but
+# the tag was a separate manual step that got skipped twice (v2.3.3 and
+# v2.4.1). Consumer-project syncs (./scripts/sync-method.sh vX.Y.Z) fail
+# without the tag. This workflow closes the gap structurally.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main at the merge commit
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Extract version from PR title
+        id: version
+        run: |
+          title='${{ github.event.pull_request.title }}'
+          if [[ "$title" =~ v([0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9.]+)?) ]]; then
+            version="v${BASH_REMATCH[1]}"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Detected version: $version"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No vX.Y.Z in PR title — nothing to tag."
+          fi
+
+      - name: Check if tag already exists
+        if: steps.version.outputs.found == 'true'
+        id: tag_exists
+        run: |
+          version='${{ steps.version.outputs.version }}'
+          if git rev-parse --verify --quiet "refs/tags/$version" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $version already exists locally — skipping create."
+          elif git ls-remote --exit-code --tags origin "$version" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag $version already exists on origin — skipping create."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create + push annotated tag
+        if: steps.version.outputs.found == 'true' && steps.tag_exists.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag -a "$VERSION" "$MERGE_SHA" -m "$VERSION — $PR_TITLE (#$PR_NUMBER)"
+          git push origin "$VERSION"
+          echo "✓ Tagged $MERGE_SHA as $VERSION"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-tag-release.yml` to close a procedural gap surfaced today: the release flow bumps `PK_VERSION` and the `CHANGELOG.md` entry inside each release PR, but **tagging was a separate manual step that got skipped on `v2.3.3` and `v2.4.1`**. Consumer-project syncs via `./scripts/sync-method.sh vX.Y.Z` clone-at-ref and fail without the tag — `rs-vault` hit this trying to test v2.4.1 today.

Both tags backfilled manually (`b32c63e → v2.3.3`, `0c463fe → v2.4.1`); this workflow prevents recurrence.

## Behavior

| PR title | Workflow action |
|---|---|
| `v2.4.1 — /linear-todo-runner real worktrees` | tags merge commit as `v2.4.1` |
| `v2.3.3 — pk promote correctness` | tags as `v2.3.3` |
| `v10.0.0-rc.1 prerelease test` | tags as `v10.0.0-rc.1` (prerelease suffixes supported) |
| `fix(skills): not a release PR` | silently skipped (no version in title) |
| `chore(workflows): auto-tag releases on PR merge` (this PR) | silently skipped — won't self-tag |

Idempotency: checks both local and origin before creating, so future runs against branches that already have tags (e.g., if someone manually pre-tags) are no-ops, not failures.

## Mechanics

- **Trigger:** `pull_request: types: [closed]`, `branches: [main]`, only runs if `merged == true`.
- **Auth:** `permissions: contents: write` — uses the default `GITHUB_TOKEN`, no PAT required.
- **Ref:** checks out the merge commit (`merge_commit_sha`), not `main`, so tag points at the exact merge SHA even if subsequent commits land before the workflow fires.
- **Tag message:** `vX.Y.Z — <PR title> (#<PR number>)` — gives `git show vX.Y.Z` useful context.

## Test plan

- [x] Local regex sanity against 5 representative title shapes (3 versions matched, 2 non-versions skipped)
- [x] YAML structure manually validated (`gh` accepted on push)
- [ ] Live test: this PR's title has no vX.Y.Z so it won't self-tag. The first real validation is the next release PR after this lands — that PR's merge should produce an automatic tag, observable via `git ls-remote --tags origin`.

## Out of scope (deliberately)

- **Tagging on push to main directly** (without a PR). The repo's branch protection forbids direct pushes anyway, so unnecessary.
- **Validating that `PK_VERSION` matches the title's version.** Mismatch would tag the wrong SHA; would be a useful add but needs its own design pass (e.g., should it fail loudly or warn?).
- **Auto-creating a GitHub Release** from the tag. Possible follow-up; would let `release-changelog` skill auto-populate release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)