### PR TITLE
v2.4.2 — daily-loop discipline polish (WIT-451 canary findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.4.2 — 2026-05-13
+
+> Patch: daily-loop discipline polish. Five doc-only fixes from the WIT-451 canary that ran today against Piper. Closes the "implicit UAT gate" and "auto-cascade past UAT" failure modes, plus two `/spec-preflight` Phase 3.6 false-positive reductions and a `/work` rule that auto-files follow-up WITs when a documented Risk-fallback is invoked.
+
+### What changed
+
+- **`method.md` Stage 3 + Stage 4** — Stage 3 renamed "Verify + Ship + UAT" so the UAT step is named, not implied. Adds the gate-clause: `pk done` and `pk promote` MUST NOT run until UAT signs off AND the PR merges. Stage 4 reframes both as "Deliberate human step — must NOT be auto-invoked by `/work`, `/verify`, `/pk-exit`, or any session-automation skill." Both anchor on the WIT-451 canary 2026-05-13 ("the worker session auto-fired `pk done` mid-test and wiped the worktree").
+- **`RUNBOOK.md` flowchart** — new explicit `[5e] Interactive UAT` box between PR review and merge, with the no-auto-chain rule inline so future readers don't need to re-derive it from `method.md`.
+- **`skills/work/skill.md` "What this skill does NOT do"** — adds two explicit bullets: "No `pk done` invocation, ever" and "No `pk promote` invocation, ever." Names the WIT-451 canary as the anchor incident. Tightens what the worker session is allowed to do at completion.
+- **`skills/pk-exit/skill.md`** — new "What this skill does NOT do" section with the same two bullets + "No Linear state writes." Closes the secondary path the worker session could have used to chain past UAT.
+- **`skills/work/skill.md` Step 6.5 Risk-fallback follow-up filing** — MANDATORY clause when a documented `R<N>: Mitigation` clause was invoked during implementation. Worker now must (1) identify the deferred scope, (2) `mcp__claude_ai_Linear__save_issue` to file the follow-up WIT in Approved state, (3) reference the new WIT-ID in the hand-off, (4) update parent spec's AC to mark as "partial per R<N>; tracked in <NEW-WIT-ID>". Closes WIT-451's R4 follow-up-rot pattern (dual-field inline NOTE editor only got filed in triage, not at ship time).
+- **`skills/spec-preflight/skill.md` Step 3a explicit-NEW marker** — file-paths probe now recognizes `**NEW**`, `(NEW)`, `, NEW`, `(new file)`, "Files to create" section heading, `NEW: <path>` prefix. NEW-marked paths record as `🆕 expected-new` instead of `✗ missing`. Verdict category treats them as `✓`. Eliminates the over-statement false positive on every WIT that legitimately introduces files (WIT-348, WIT-451 each hit this 2-3 times).
+- **`skills/spec-preflight/skill.md` Probe 3.6a Strategy-citation downgrade** — Canonical-doc cross-check now scans for inline Strategy citations (`Strategy/Doc<N>`, `Strategy/Doc<N> §<section>`, or an "Authority hierarchy" table naming a Strategy file). If ≥1 inline citation, downgrades `⚠ Cross-check Strategy` → `✓ Canonical docs: cross-check performed in-spec`. Probe still emits `⚠` when POC is mentioned but no inline Strategy citation exists. WIT-451's revised spec was the canonical example that motivated this — fully cited, still drew `⚠`.
+- **`PK_VERSION`** 2.4.1 → 2.4.2.
+
+### Why
+
+The WIT-451 canary 2026-05-13 against Piper ran the full v2 daily loop end-to-end and surfaced three procedural gaps. Listed from highest impact down:
+
+1. **No interactive UAT gate.** Stage 3's "Human performs UAT" line was prose-only. The worker session shipped PR #265, auto-merged on green CI, then auto-fired `pk done` and `pk promote beta` in the same ~60-second window while the user was still in the middle of UAT on `dev.withpiper.ai`. The worktree got wiped mid-test. Stage 3 now names UAT as the gate, names `pk done` and `pk promote` as deliberate human steps, and explicitly forbids `/work` and `/pk-exit` from chaining past them.
+2. **Worker sessions auto-firing `pk done` / `pk promote`.** Symptom of (1). Both skills now carry explicit "no pk done, ever / no pk promote, ever" bullets that name the anchor incident.
+3. **Risk-fallback follow-up rot.** WIT-451's spec documented R4 ("if the dual-field inline cell editor proves brittle, fall back to NOTE-via-modal-only"). The worker correctly invoked the fallback but only filed 2 follow-up WITs, missing the dual-field editor — that one got caught later in triage and became WIT-454. Step 6.5 of `/work` now makes the follow-up filing mandatory when an `R<N>: Mitigation` clause is invoked.
+
+Two adjacent Phase 3.6 probe-polish items also surfaced:
+
+4. **NEW-file false positives.** WIT-348 (3 NEW files) and WIT-451 (3 NEW files) each drew `⚠ File paths: N/M exist (missing: ...)` warnings on paths the spec explicitly marked NEW. Verdict noise that erodes signal.
+5. **Strategy-citation false positives on Probe 3.6a.** WIT-451's revised spec cited Strategy/Doc6 §2.1, §3.3, and Doc2 §3.3.1 throughout, with an explicit Authority hierarchy table — and the probe still emitted `⚠ Cross-check spec claims against Strategy` because the trigger fired blindly. Downgrade closes the false positive.
+
+All five are docs-only, low-blast-radius. A deeper code-level guard for (1) and (2) — `pk done` refuses when Linear state is `UAT` and a `--confirmed` flag isn't passed — is deliberately deferred to v2.4.3, after the doc gate has run in practice.
+
+### Migration
+
+None. Re-run `./scripts/sync-method.sh v2.4.2` in consumer projects. After sync:
+
+- `pk version` returns `2.4.2`
+- `method.md` Stage 3 / Stage 4 + `RUNBOOK.md` flowchart reflect the named UAT gate
+- `/work` and `/pk-exit` carry explicit "no pk done / no pk promote" bullets
+- `/spec-preflight` Phase 1 + Probe 3.6a emit fewer false positives on real specs
+
+### What this fixes (canary findings)
+
+- **WIT-451 canary finding "implicit UAT gate"** → method.md Stage 3 + Stage 4 + RUNBOOK.md [5e]
+- **WIT-451 canary finding "worker session auto-fired pk done / pk promote"** → /work + /pk-exit "does NOT do" sections
+- **WIT-451 canary finding "R-fallback follow-up filed only at triage time"** → /work Step 6.5 mandatory clause
+- **WIT-451 + WIT-348 finding "NEW-file false positives"** → /spec-preflight Step 3a
+- **WIT-451 finding "Strategy cited inline but probe still warned"** → /spec-preflight Probe 3.6a downgrade
+
+### Deferred to v2.4.3
+
+- Code-level guard in `bin/pk cmd_done`: refuse when Linear state is `UAT` unless `--confirmed` flag passed. Belt-and-suspenders with the v2.4.2 doc gate.
+- Same for `cmd_promote` when source-branch issues are still in UAT.
+
+---
+
 ## v2.4.1 — 2026-05-13
 
 > Patch: `/linear-todo-runner` creates real worktrees explicitly. Closes the empirically-observed "Agent isolation:`worktree` parameter is a no-op" failure mode where 4 parallel agents collapsed into one shared checkout and trampled each other's uncommitted work via branch switches.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -173,6 +173,25 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
        │
        ▼
   ┌──────────────────────────────────────────────────────────┐
+  │ [5e] Interactive UAT  (THE Stage 3 gate — non-skippable) │
+  │                                                          │
+  │      Human exercises the feature in the running app:     │
+  │      • Vercel PR preview URL (pre-merge), OR             │
+  │      • dev.<project> domain (post-merge to dev)          │
+  │                                                          │
+  │      Walk through every AC. Record the verdict —         │
+  │      Linear comment, PR comment, or session-log note     │
+  │      — so there's an audit trail.                        │
+  │                                                          │
+  │      Do NOT proceed to [6] / [8] / [9] until UAT signs   │
+  │      off. /work, /verify, /pk-exit must NOT auto-chain   │
+  │      past this step. Surfaced 2026-05-13 (WIT-451):      │
+  │      the worker session auto-fired pk done before UAT    │
+  │      completed and wiped the worktree mid-test.          │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
   │ [6] Merge PR (manual, GitHub UI)                         │
   │     • feature → dev: rebase or merge-commit              │
   │     • dev/beta → main: merge-commit (anchor per promote) │

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.4.1"
+PK_VERSION="2.4.2"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.md
+++ b/method.md
@@ -204,9 +204,9 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 
 ---
 
-## Stage 3: Verify + Ship (Build Quality Gate)
+## Stage 3: Verify + Ship + UAT (Build Quality Gate)
 
-**Steps:** 6–8 (`/verify` → `pk ship` → optional PR review → UAT)
+**Steps:** 6–8 (`/verify` → `pk ship` → optional PR review → **interactive UAT**)
 
 **Tools:** `/verify`, `pk ship`, optional `/pr-fix` and `/pr-security-review`, Human
 
@@ -216,11 +216,11 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 - **`pk ship --review`** posts a Linear comment flagging review-in-flight and prints the antagonistic reviewer invocation. The reviewer plays devil's advocate vs `/work` + `/verify` (which validate spec adherence) — surfaces cross-cutting concerns the spec didn't think to mention.
 - **`/pr-security-review`** is the right tool for migrations / RLS / SECURITY DEFINER / auth surface (use instead of, or alongside, the generic reviewer).
 - **`/pr-fix`** triages review findings into fixed / rejected / deferred and posts a summary comment to Linear.
-- Human performs **UAT** in the running app (preview URL) against the spec's AC.
+- **Interactive UAT (the gate).** Human exercises the feature in the running app (Vercel preview URL on the PR, or `dev.<project>` after merge — project-specific) against the spec's AC. This is **the** Stage 3 gate, not a doc artifact: `pk done` and `pk promote` MUST NOT run until UAT signs off AND the PR is merged. v2.4.2 surfaced the cost of an implicit UAT: the WIT-451 canary's worker session auto-ran `pk done` mid-test and wiped the worktree before the human finished. **Treat UAT as a deliberate human step. Do not chain past it from inside `/work`, `/verify`, `/pk-exit`, or any other session-automating skill.**
 
 **Output:** Verified PR open and UAT-accepted in Linear, ready for the human to merge.
 
-**Gate:** Feature matches spec behavior under real usage. All AC checkboxes satisfied. Critical/High review findings resolved or explicitly deferred.
+**Gate:** Feature matches spec behavior under real usage. All AC checkboxes satisfied. Critical/High review findings resolved or explicitly deferred. **Human UAT verdict recorded** (Linear comment, PR comment, or session-log note — pick one; the point is an audit trail).
 
 ---
 
@@ -230,11 +230,11 @@ Run before entering the spec pipeline to validate that Stage 0 is complete and t
 
 Every step forward is a PR. No direct merges between long-lived branches. Promotion is owned by `pk promote`, configured per project via `Ship environments` in `method.config.md` (e.g., `dev,main` or `dev,beta,main`).
 
-**Order of operations** (after Stage 3's UAT passes):
+**Order of operations** (after Stage 3's UAT passes AND the PR merges — both required):
 
 1. Human merges the PR (rebase or merge-commit; see `sop/Git_and_Deployment.md` § Merge Strategy by Hop) once UAT is green.
-2. **`pk done <ID>`** cleans up the worktree + branch and posts commits + diffstat to Linear. **Cleanup-only** — it does NOT transition state.
-3. **`pk promote <env>`** opens the next-tier promotion PR (one hop per invocation: `pk promote beta`, then `pk promote main`). Transitions matching issues optimistically at PR-open: → **Released** for intermediate hops, → **Done** for the final hop. 2-tier projects: `pk promote` with no arg picks the only hop. Skipped entirely for `Promote to main: false`.
+2. **`pk done <ID>`** cleans up the worktree + branch and posts commits + diffstat to Linear. **Cleanup-only** — it does NOT transition state. **Deliberate human step** — must NOT be auto-invoked by `/work`, `/verify`, `/pk-exit`, or any session-automation skill. The worker session that built the feature has no signal for "human UAT is complete" and will wipe the worktree mid-test if it auto-fires (WIT-451 canary 2026-05-13 — surfaced this gap).
+3. **`pk promote <env>`** opens the next-tier promotion PR (one hop per invocation: `pk promote beta`, then `pk promote main`). Transitions matching issues optimistically at PR-open: → **Released** for intermediate hops, → **Done** for the final hop. 2-tier projects: `pk promote` with no arg picks the only hop. Skipped entirely for `Promote to main: false`. **Deliberate human step**, same rationale as `pk done`.
 
 **Auto-machinery** firing on PR open / main merge (Pipekit owns none of these — they're project infrastructure):
 

--- a/skills/pk-exit/skill.md
+++ b/skills/pk-exit/skill.md
@@ -91,3 +91,9 @@ If the session was pure execution with no decisions, write "—".>
 - The v1 `/end-session` skill (now archived) was the prior art. This skill restores its core function (narrative session log) without the v1 baggage (NEXT.md updates, branch-status orchestration — those moved to `pk next` / `pk done`).
 - The bash Stop hook was retired because: (a) Stop fires on every assistant turn, producing duplicate commit-list entries; (b) bash can't write narrative; (c) `pk done` doesn't need a journal cache — it reads `git log` directly.
 - This skill writes one file per session. It does not update Linear (that's `pk done`'s job at issue-close) and does not update PHASES.md (that's `phase-plan`'s job).
+
+## What this skill does NOT do
+
+- **No `pk done` invocation, ever.** `pk done` is a deliberate human step after PR merge AND interactive UAT (the Stage 3 gate). `/pk-exit` writes the session log and stops — it does not chain into cleanup. The WIT-451 canary 2026-05-13 surfaced the cost of auto-chaining: a worker session ran `pk done` before the human finished UAT and wiped the worktree mid-test. If the user wants cleanup, they run `pk done <ID>` themselves from the parent repo after merge.
+- **No `pk promote` invocation, ever.** Same rationale. Promotion is a Stage 4 human step.
+- **No Linear state writes.** Comments and state transitions belong to `pk branch`, `pk ship`, `pk done`, and `pk promote` — each at its own deliberate human step.

--- a/skills/spec-preflight/skill.md
+++ b/skills/spec-preflight/skill.md
@@ -159,8 +159,9 @@ Each probe runs independently. A miss in one does not skip the others. Findings 
 1. Read `Strategy docs path` from `method.config.md` (default: `Strategy/`).
 2. `Glob` `<path>/*.md` and `<path>/**/*.md`. Capture the file list.
 3. For each Strategy doc, scan the first 200 lines (section index) for headings that overlap concept words from the spec body. Concept words: nouns appearing in the spec's §Goal, §Acceptance Criteria headings, or italicized key terms.
+4. **Strategy-citation check (v2.4.2):** scan the spec body for inline citations of any Strategy doc — patterns like `Strategy/Doc<N>`, `Strategy/Doc<N>_<name>.md`, `Strategy/Doc<N> §<section>`, or an `Authority hierarchy` table that names a Strategy file as the authority for a concern. If the spec body cites ≥1 Strategy doc inline, treat the cross-check as **performed** (the spec author already did the work the probe is asking for) and downgrade the emit to `✓ Canonical docs: Strategy cited inline at <doc>:<section>` instead of `⚠`.
 
-**Emit (always `⚠` — ambiguous; the human decides whether topic overlap is load-bearing):**
+**Emit (default `⚠` — ambiguous; the human decides whether topic overlap is load-bearing):**
 
 ```
 ⚠ Canonical docs: Strategy at <path> contains <N> doc(s); spec body references POC.
@@ -170,7 +171,16 @@ Each probe runs independently. A miss in one does not skip the others. Findings 
     Strategy is canonical for this project; POC may diverge.
 ```
 
+**Emit when Strategy is cited inline in the spec body (v2.4.2 downgrade):**
+
+```
+✓ Canonical docs: spec body cites Strategy inline (<list of cited docs+sections>);
+    cross-check performed in-spec. No further action.
+```
+
 If `Strategy docs path` is unset OR the directory is empty: record `n/a — no Strategy docs configured`. Do not warn — projects without Strategy docs are valid.
+
+Why the downgrade was added: WIT-451's revised spec body cited Strategy/Doc6 §2.1, Strategy/Doc6 §3.3 line 86, and Strategy/Doc2 §3.3.1 throughout — and had an explicit "Authority hierarchy" table naming Strategy as the canonical source for the 5-action button set, conversation surface, and line-item canonical fields. v2.4.0's probe still emitted `⚠ Cross-check spec claims against Strategy` because the trigger ("POC mentioned + Strategy/ exists") fired blindly. The downgrade keeps the probe useful for specs that haven't done the cross-check while letting fully-cited specs pass cleanly.
 
 #### 3.6b — Platform capability (handoff #20)
 

--- a/skills/spec-preflight/skill.md
+++ b/skills/spec-preflight/skill.md
@@ -85,6 +85,17 @@ For each path, prefer `Read` (cheaper than Glob for known paths). On `ENOENT`, f
 
 A missing file is a real divergence (fail-loud), not infrastructure noise.
 
+**Exception — explicit-NEW markers.** Before flagging a missing file as `✗`, check whether the surrounding spec text marks the path as a NEW file the implementation will create. Treat any of the following as an explicit-NEW marker on the line of the path, on the same line, on the line before, or in a section header within 5 lines above:
+
+- `NEW` (bold, plain, or in parentheses): `**NEW**`, `(NEW)`, `, NEW`
+- `(new)` / `(new file)`
+- "**Files to create**" or "**New files**" section heading that contains the path
+- `NEW: <path>` prefix
+
+When an explicit-NEW marker is present, record the path as `🆕 expected-new` instead of `✗ missing` — the spec is asserting this file will be created, not that it exists. The Phase 1–3 verdict treats `🆕 expected-new` as `✓` for the file-paths category. The pre-existing files in the same list still get verified normally; only the NEW-marked paths get the downgrade.
+
+Why: WIT-348 and WIT-451 (both Pipekit v2.4.x canary subjects) listed NEW components explicitly in their specs (`line-item-actions.tsx`, `line-item-edit-dialog.tsx`, `move-line-item-dialog.tsx`), each clearly annotated NEW in the Technical Context section. v2.4.0's preflight emitted `✗` for all of them, which over-stated the divergence and forced manual exception-noting in the verdict. v2.4.2 collapses that noise.
+
 #### 3b — Line citations
 
 For each `<file>:N` or `<file>:N-M`, call `Read` with `offset: N` and `limit: M-N+1` (or `1` for a single line). Record:

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -472,6 +472,8 @@ Before printing the hand-off, ask yourself: "Did the last shell command exit 0?"
 - No session log write (`/pk-exit` owns the session log).
 - No Linear status writes during work (`pk branch` set In Progress; `pk ship` will set UAT).
 - No `/end-session` invocation.
+- **No `pk done` invocation, ever.** `pk done` is a deliberate human step after PR merge AND interactive UAT — neither of which `/work` has signal for. The WIT-451 canary 2026-05-13 surfaced this: a worker session auto-ran `pk done` before the human finished UAT and wiped the worktree mid-test. Stage 3's UAT gate is non-skippable from inside this skill. If you complete an auto-rollover successfully, the hand-off line ends at `/pk-exit`, never at `pk done`.
+- **No `pk promote` invocation, ever.** Same rationale — promotion is a Stage 4 human step that runs from the parent repo after the user has signed off on UAT and merged. A worker session has no business advancing the workflow past its own scope.
 
 ## Comparison with v1
 

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -390,6 +390,23 @@ Why this is mandatory: RS-29 (rs-vault, 2026-05-05) shipped a working JPG export
 
 Tests whose names contain the *current* ticket's ID — especially predecessor tests that asserted the placeholder behavior was correct — are **almost always known-edit targets**, not bystanders. A green test for a placeholder is a TODO disguised as a check. When grep #1 above surfaces test names, do not read "the test passes" as confirmation; read it as "the test pins the world before this ticket shipped, and ought to be updated to assert the new behavior."
 
+### Risk-fallback follow-up filing — MANDATORY when a Risk-fallback was invoked
+
+If you used a documented Risk-fallback (`R<N>: Mitigation` clause from the spec body) during this run — i.e. you shipped the documented "if X is too hard, do Y instead" path — you MUST file the deferred work as a new Linear WIT before declaring complete. Do not bundle it into the hand-off summary as a "partial AC" footnote and hope the user files it later; they won't, and the follow-up rots.
+
+For each invoked fallback:
+
+1. Identify the AC the fallback covers and the deferred scope (the "proper" implementation the fallback is standing in for).
+2. Call `mcp__claude_ai_Linear__save_issue` to file a new WIT, scoped tightly to closing the fallback:
+   - **Title:** `<short noun phrase> — closes <ISSUE-ID> R<N> fallback`
+   - **State:** `Approved` (the design decisions are inherited from the original spec; the new WIT is execution-only)
+   - **Description:** Cite the parent ISSUE-ID + the specific R<N> clause + the AC numbers the fallback covers + the deferred scope spelled out
+   - **Project / Milestone:** Match the parent issue
+3. Reference the new WIT-ID in the hand-off summary.
+4. Update the original spec body (if you have permission to edit it post-implementation) to mark the AC as "partial per R<N>; full coverage tracked in <NEW-WIT-ID>".
+
+Why mandatory: WIT-451 canary 2026-05-13 shipped via the R4 documented fallback (NOTE editable only via Edit modal, not inline). The session correctly used the fallback but only filed 2 follow-up WITs and missed the dual-field inline editor; that one was caught later in triage. If R-fallback follow-ups had been automatic, the canary closeout would have been one round faster.
+
 If something fails this self-check, **surface it in the hand-off summary** — don't paper over. The user paces; they decide whether to ship-with-known-gap or revise.
 
 ### Anti-rationalization guard


### PR DESCRIPTION
## Summary

Five doc-only fixes from today's WIT-451 canary against Piper. Closes the "implicit UAT gate" and "auto-cascade past UAT" failure modes plus three smaller `/spec-preflight` and `/work` polish items. **No code changes** outside the `PK_VERSION` bump.

Six commits, each atomic per finding:

1. `d068cb0` — `docs(method): make interactive UAT an explicit Stage 3 gate` — method.md + RUNBOOK.md
2. `78c48b9` — `docs(skills): /work and /pk-exit must never auto-invoke pk done or pk promote` — skills/work + skills/pk-exit
3. `b491bdb` — `docs(skills): /work auto-files follow-up WIT when a Risk-fallback is invoked` — skills/work Step 6.5
4. `89ea3d5` — `docs(spec-preflight): Phase 1 file-paths probe recognizes explicit-NEW markers` — skills/spec-preflight Step 3a
5. `0b52263` — `docs(spec-preflight): Probe 3.6a downgrades to ✓ when Strategy is cited inline` — skills/spec-preflight 3.6a
6. `b0734fb` — `chore(release): v2.4.2 — daily-loop discipline polish from WIT-451 canary` — PK_VERSION + CHANGELOG

## Why this exists

WIT-451 canary today ran the full v2 daily loop end-to-end against Piper and surfaced three procedural gaps plus two probe-polish items:

| # | Finding | Anchor incident |
|---|---|---|
| 1 | **No interactive UAT gate.** Stage 3's "Human performs UAT" was prose-only. Worker session shipped PR #265, auto-merged on green CI, then auto-fired `pk done` + `pk promote beta` in the same ~60-second window while the user was still doing UAT on `dev.withpiper.ai`. Worktree wiped mid-test. | WIT-451 canary 17:53:48Z merge → 17:54:41Z Linear state Released |
| 2 | **Worker auto-firing `pk done` / `pk promote`.** Symptom of (1). | Same |
| 3 | **Risk-fallback follow-up rot.** WIT-451's spec documented R4 (NOTE-via-modal-only fallback). Worker invoked it correctly but only filed 2 follow-up WITs, missing the dual-field editor — caught later in triage as WIT-454. | WIT-451 R4 |
| 4 | **NEW-file false positives.** `/spec-preflight` Phase 1 emitted `✗` on every NEW-marked path. WIT-348 (3 NEW files) + WIT-451 (3 NEW files) each hit this. | WIT-451 re-preflight |
| 5 | **Strategy-citation false positives on Probe 3.6a.** Revised WIT-451 spec cited Strategy/Doc6 §2.1 + §3.3 + Doc2 §3.3.1 throughout with an explicit Authority hierarchy table — probe still emitted ⚠. | WIT-451 re-preflight |

All five close cleanly via doc-only edits. The code-level guard for (1)+(2) (`pk cmd_done` refuses when state=`UAT` without `--confirmed`) is deferred to v2.4.3 deliberately — let the doc gate run in practice first.

## Test plan

- [x] `bash -n bin/pk` — syntax clean
- [x] `pk version` returns `2.4.2`
- [x] `bash scripts/test-pk-config.sh` — 14/14 pass (no regression)
- [x] `bash scripts/test-pk-promote.sh` — 25/25 pass (no regression)
- [ ] Next time `/spec-preflight` runs on a real WIT in Piper, observe: NEW-marked paths render `🆕 expected-new` instead of `✗`; specs citing Strategy inline render `✓ Canonical docs: cross-check performed in-spec`
- [ ] Next time `/work` runs through to ship in Piper, observe: hand-off ends at "Run `/pk-exit`" with no `pk done` invocation
- [ ] Next time a `/work` run invokes a documented `R<N>: Mitigation`, observe: follow-up WIT filed via Linear MCP before hand-off prints

## Deferred to v2.4.3

- `bin/pk cmd_done`: refuse when Linear state is `UAT` unless `--confirmed` flag passed
- `bin/pk cmd_promote`: refuse when source branch's bundled issues are still in `UAT` unless `--confirmed`

These are belt-and-suspenders with the v2.4.2 doc gate. Designing them well needs one cycle of the doc gate running unaided so we can see which patterns the doc gate catches vs misses.

## References

- WIT-451 (Piper, Released) — canary subject
- WIT-454 (Piper, Approved) — dual-field inline NOTE editor follow-up that surfaced the R-fallback follow-up gap
- Prior: PRs #83 (v2.3.3 `pk promote` correctness), #84 (v2.4.0 Phase 3.6 probes), #85 (v2.4.1 linear-todo-runner worktrees), #86 (v2.4.x auto-tag workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)