### PR TITLE
v2.4.3 — code-level UAT gate + pk install lag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## v2.4.3 — 2026-05-13
+
+> Patch: code-level enforcement of the v2.4.2 UAT-gate doc, plus a `pk install` lag fix surfaced when the v2.3.3 state-ladder gate failed to fire because the user's installed `pk` was at v2.3.2. Five fixes, one bundled PR.
+
+### What changed
+
+- **`bin/pk cmd_done`** — refuses with `exit 1` when the issue is in Linear state `UAT` unless `--confirmed` is passed. v2.4.2's doc gate told future sessions not to chain `pk done` past UAT; this is the belt-and-braces. Doc gates rely on the model reading prose; code gates rely on `exit 1` and don't lie. Anchor: WIT-451 worker session 2026-05-13, where auto-merge → auto `pk done` wiped the worktree mid-UAT.
+- **`bin/pk cmd_promote`** — same shape, narrower trigger: refuses when any bundled issue (scanned from `git log <target>..<source>`) is in `UAT`. Released / Done bundles still pass through (re-promote is fine). Approved-or-earlier is already caught by the v2.3.3 ladder leap-frog refusal in `pk_linear_set_state`, so no double-emit. `--confirmed` opt-out.
+- **`bin/pk pk_linear_get_state`** — new helper: fetches the current workflow-state name for a Linear issue by identifier. Returns empty string on lookup failure so callers can treat absence as "don't know" rather than aborting. Used by both UAT refusals above.
+- **`bin/pk cmd_install`** — `--force` now always re-links, even when the existing target already points at `$src`. Previously the `existing == src` short-circuit returned 0 before `--force` was evaluated, so `pk install --force` was a silent no-op against valid symlinks (anchor: Pendragon 2026-05-13). Reports `Re-linked: …` instead of `Installed: …` when the re-link was forced. Adjacent design question — should `pk install` default to symlinking the global `~/Projects/pipekit/bin/pk` clone instead of the calling project's `bin/pk`? — left for a future cycle; not in scope for v2.4.3.
+- **`scripts/sync-method.sh`** — after each sync, compares the synced `bin/pk` content against `~/.local/bin/pk` and `/usr/local/bin/pk` via `cmp -s` (follows symlinks). If they differ, warns with the `pk install --force` remediation. New `--auto-install` flag invokes `pk install --force` automatically post-sync for unattended sync paths (CI, batch scripts). Closes the lag-bug anchor: PR #270 ran the v2.3.3 state-ladder gate code path… except it didn't, because `~/.local/bin/pk` was at `pk 2.3.2` while the synced `bin/pk` was 2.4.2. WIT-275 got falsely transitioned Approved → Done and had to be reverted manually.
+- **`sop/Git_and_Deployment.md` § Hotfix Procedure**  — new sub-section "When the explicit beta cherry-pick is needed (three-tier)". The standard three-tier hotfix flow files three branches (`hotfix/*-main`, `*-cherrypick-dev`, `*-cherrypick-beta`), but the explicit beta cherry-pick is redundant when a `dev → beta` promote is imminent — the dev cherry-pick sweeps to beta via the next promote. Filing it anyway leaves an orphan branch. Anchor: WIT-455, 2026-05-13 — `hotfix/margin-cherrypick-beta` orphaned because the dev cherry-pick swept to beta via PR #268 the same day.
+- **`scripts/test-pk-v2.4.3.sh`** — new test harness covering: `pk install --force` re-links a valid symlink, `pk_linear_get_state` helper presence, `cmd_done` / `cmd_promote` `--confirmed` arg parsing, and end-to-end UAT-refusal trigger + bypass via a stubbed `pk_linear_get_state`. 9 assertions, network-free (Linear lookups stubbed inside subshells).
+- **`bin/pk cmd_help`** — adds `--confirmed` to the `pk done` and `pk promote` synopsis lines.
+- **`skills/pipekit-update/skill.md`** — new Phase 0 auto-detects upstream vs downstream mode by `git remote get-url origin` + sentinel files (`method.md` + `CHANGELOG.md` + `bin/pk`). Upstream mode (running inside the Pipekit repo itself) does `git fetch --tags && git checkout <tag>` + `pk install --force`; downstream mode keeps the existing `sync-method.sh` flow. Same `/pipekit-update v2.4.3` command works on both: a machine where `~/.local/bin/pk` symlinks to a consumer project's `bin/pk` AND a machine where it symlinks to the Pipekit clone itself. `--push` refuses in upstream mode (incoherent). Closes the multi-machine update divergence — every machine runs the same incantation.
+- **`PK_VERSION`** 2.4.2 → 2.4.3.
+
+### Why
+
+The v2.4.2 doc gate (Stage 3 + RUNBOOK [5e] + `/work`/`pk-exit` "does NOT do") is the right gate for normal use, but the empirical failure mode is an LLM session auto-chaining past prose. Doc gates rely on the model reading and respecting natural language; code gates rely on `exit 1`. Belt-and-braces. The same week the v2.4.2 doc gate landed, the v2.3.3 state-ladder gate (a code gate that DID exist) silently bypassed itself because the user's installed `pk` was old — surfacing the lag-bug that `sync-method.sh` now warns on. Both classes of failure now have explicit code-level guards.
+
+### Migration
+
+None for consumers. Re-run `./scripts/sync-method.sh v2.4.3` in consumer projects. After sync:
+
+- `pk version` returns `2.4.3`
+- `pk done <ID>` refuses with a clear message when the issue is in UAT — pass `--confirmed` once UAT is signed off
+- `pk promote <env>` refuses when any bundled issue is in UAT — pass `--confirmed` to override
+- `pk install --force` always re-links, even on valid symlinks (no more silent no-op)
+- `./scripts/sync-method.sh` warns when `~/.local/bin/pk` differs from the synced `bin/pk`; add `--auto-install` for unattended sync
+
+### What this fixes (anchor incidents from 2026-05-13)
+
+- **WIT-451 worker auto-firing `pk done` mid-UAT** → `cmd_done` UAT refusal
+- **Same root, narrower** → `cmd_promote` UAT refusal on bundled issues
+- **PR #270 / WIT-275 false transition: state-ladder gate didn't fire because installed `pk` was v2.3.2** → `sync-method.sh` install-lag warning + `--auto-install`
+- **Pendragon `pk install --force` silent no-op** → `cmd_install` force/symlink fix
+- **WIT-455 orphaned `hotfix/margin-cherrypick-beta` branch** → `sop/Git_and_Deployment.md` hotfix nuance
+
+### Tests
+
+```
+bash scripts/test-pk-promote.sh   # 25 assertions (v2.3.3 ladder + missing-target guard)
+bash scripts/test-pk-config.sh    # 14 assertions (pk_config parsing)
+bash scripts/test-pk-v2.4.3.sh    #  9 assertions (v2.4.3 additions)
+```
+
+---
+
 ## v2.4.2 — 2026-05-13
 
 > Patch: daily-loop discipline polish. Five doc-only fixes from the WIT-451 canary that ran today against Piper. Closes the "implicit UAT gate" and "auto-cascade past UAT" failure modes, plus two `/spec-preflight` Phase 3.6 false-positive reductions and a `/work` rule that auto-files follow-up WITs when a documented Risk-fallback is invoked.

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.4.2"
+PK_VERSION="2.4.3"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null
@@ -312,6 +312,17 @@ pk_state_rank() {
     'Duplicate')     echo 99 ;;
     *)               echo 0 ;;
   esac
+}
+
+# Fetch the current workflow-state name for a Linear issue by identifier.
+# Empty string on lookup failure (network, missing issue, missing API key) so
+# callers can treat absence as "don't know" without aborting. Used by the
+# UAT-state code refusals in cmd_done / cmd_promote (v2.4.3).
+pk_linear_get_state() {
+  local id="$1"
+  local issue_q='query($id: String!) { issue(id: $id) { state { name } } }'
+  pk_linear_gql "$issue_q" "$(jq -n --arg id "$id" '{id:$id}')" 2>/dev/null \
+    | jq -r '.data.issue.state.name // empty' 2>/dev/null
 }
 
 # Update issue state by identifier + state name.
@@ -863,7 +874,15 @@ Reviewer subagent invocation printed in pk output. Findings will land as a PR re
 }
 
 cmd_done() {
-  local id="${1:-}"
+  local confirmed=false id=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --confirmed) confirmed=true; shift ;;
+      --*)         echo "pk done: unknown arg $1" >&2; return 2 ;;
+      *)           id="$1"; shift ;;
+    esac
+  done
+
   local current
   local issue
   if [ -n "$id" ]; then
@@ -884,6 +903,23 @@ cmd_done() {
     issue=$(pk_branch_issue_id)
     if [ -z "$issue" ]; then
       echo "ERROR: pass <ISSUE-ID> or run from a feature branch (e.g. pk done RS-60)" >&2
+      return 1
+    fi
+  fi
+
+  # UAT-state code refusal (v2.4.3) — belt-and-braces for v2.4.2's doc gate.
+  # The empirical failure: a worker session auto-merged PR #265 on green CI
+  # and immediately chained `pk done`, wiping the worktree while the user
+  # was still doing interactive UAT on dev. Doc gates rely on the model
+  # reading prose; this gate is exit-1 and doesn't lie. --confirmed bypasses.
+  if ! $confirmed; then
+    local current_state
+    current_state=$(pk_linear_get_state "$issue" 2>/dev/null || echo "")
+    if [ "$current_state" = "UAT" ]; then
+      echo "ERROR: $issue is still in 'UAT'." >&2
+      echo "  Complete interactive UAT and merge the PR first." >&2
+      echo "  Re-run with --confirmed once UAT is signed off:" >&2
+      echo "    pk done $issue --confirmed" >&2
       return 1
     fi
   fi
@@ -1046,12 +1082,13 @@ cmd_verify() {
 # (matches `pk ship`). Position-based state mapping: last hop → Done,
 # any non-last → Released.
 cmd_promote() {
-  local stash=false take_remote=false bootstrap=false target=""
+  local stash=false take_remote=false bootstrap=false confirmed=false target=""
   while [ $# -gt 0 ]; do
     case "$1" in
       --stash)       stash=true;       shift ;;
       --take-remote) take_remote=true; shift ;;
       --bootstrap)   bootstrap=true;   shift ;;
+      --confirmed)   confirmed=true;   shift ;;
       --*)           echo "pk promote: unknown arg $1" >&2; return 2 ;;
       *)             target="$1";      shift ;;
     esac
@@ -1208,6 +1245,39 @@ cmd_promote() {
     return 0
   fi
 
+  # UAT-state code refusal (v2.4.3) — belt-and-braces for v2.4.2's doc gate.
+  # Bundled issues still in 'UAT' mean the user hasn't signed off yet;
+  # opening the promote PR jumps that gate. Only refuses on UAT — Released
+  # / Done are fine (re-promote bundles), and Approved-or-earlier is already
+  # caught by the v2.3.3 ladder leap-frog refusal in pk_linear_set_state
+  # (so we don't double-emit here). --confirmed bypasses.
+  local issue_prefix
+  issue_prefix=$(pk_config "Issue prefix" "")
+  if ! $confirmed && [ -n "$issue_prefix" ]; then
+    local bundled_ids
+    bundled_ids=$(git log "origin/$target..origin/$source" --pretty=format:%s%n%b 2>/dev/null \
+      | grep -oE "${issue_prefix}-[0-9]+" | sort -u)
+    if [ -n "$bundled_ids" ]; then
+      local uat_ids=""
+      while IFS= read -r bid; do
+        [ -z "$bid" ] && continue
+        local bstate
+        bstate=$(pk_linear_get_state "$bid" 2>/dev/null || echo "")
+        if [ "$bstate" = "UAT" ]; then
+          uat_ids="${uat_ids:+$uat_ids }$bid"
+        fi
+      done <<< "$bundled_ids"
+      if [ -n "$uat_ids" ]; then
+        echo "ERROR: bundled issue(s) still in 'UAT': $uat_ids" >&2
+        echo "  Complete interactive UAT and merge the feature PR(s) first." >&2
+        echo "  Re-run with --confirmed once UAT is signed off:" >&2
+        echo "    pk promote $target --confirmed" >&2
+        $stash_made && echo "  Note: your edits are stashed (git stash list)." >&2
+        return 1
+      fi
+    fi
+  fi
+
   echo "  3. Open promote PR ($source → $target, $commits_ahead commits)"
   local date promote_url
   date=$(date +%Y-%m-%d)
@@ -1224,8 +1294,6 @@ cmd_promote() {
     target_state="Released"
   fi
 
-  local issue_prefix
-  issue_prefix=$(pk_config "Issue prefix" "")
   if [ -n "$issue_prefix" ]; then
     local issue_ids
     issue_ids=$(git log "origin/$target..origin/$source" --pretty=format:%s%n%b 2>/dev/null \
@@ -1620,11 +1688,16 @@ cmd_install() {
   if [ -L "$target" ] || [ -e "$target" ]; then
     local existing
     existing=$(readlink "$target" 2>/dev/null || echo "$target")
-    if [ "$existing" = "$src" ]; then
+    # v2.4.3: --force always re-links, even when the existing target already
+    # points at $src. Previously the "already installed" check returned 0
+    # before --force was evaluated, so `pk install --force` was a silent no-op
+    # against valid symlinks. Anchor: Pendragon 2026-05-13, where rerunning
+    # --force to refresh a stale lockstep did nothing.
+    if [ "$existing" = "$src" ] && ! $force; then
       echo "Already installed: $target → $src"
       return 0
     fi
-    if ! $force; then
+    if [ "$existing" != "$src" ] && ! $force; then
       echo "ERROR: $target exists and points elsewhere ($existing)." >&2
       echo "  Use 'pk install --force' to overwrite." >&2
       return 1
@@ -1633,7 +1706,11 @@ cmd_install() {
   fi
 
   ln -s "$src" "$target"
-  echo "Installed: $target → $src"
+  if $force && [ -n "${existing:-}" ] && [ "$existing" = "$src" ]; then
+    echo "Re-linked: $target → $src (--force)"
+  else
+    echo "Installed: $target → $src"
+  fi
 
   case ":$PATH:" in
     *:"$target_dir":*) ;;
@@ -1654,10 +1731,10 @@ Subcommands:
   pk status                       Quick triage of the Linear board + worktrees
   pk branch <ISSUE-ID>            Create worktree+branch, Linear → In Progress
   pk ship [--env=<env>] [--review]  Push, gh pr create, Linear → UAT (optional antagonistic review)
-  pk done                         Verify PR merged, cleanup worktree+branch (no Linear state change)
+  pk done [<ID>] [--confirmed]    Verify PR merged, cleanup worktree+branch (no Linear state change). Refuses if issue is in UAT — pass --confirmed once UAT is signed off.
   pk verify                       Run the project's pre-deploy gate
   pk config [<key> [<default>]]   Read a V2 key from method.config.md; no args = dump all known keys
-  pk promote <env> [--stash|--take-remote]  Walk one hop in Ship environments; transitions issues → Released (intermediate) or Done (final). Conflict flags resolve local edits vs incoming source.
+  pk promote <env> [--stash|--take-remote] [--confirmed]  Walk one hop in Ship environments; transitions issues → Released (intermediate) or Done (final). Conflict flags resolve local edits vs incoming source. Refuses if any bundled issue is in UAT — pass --confirmed to override.
   pk delegate <ID> <prompt>       Post an @Linear-mentioned comment to invoke Linear Agent
   pk spec-cycle <ID>              Trigger Spec Review Agent v5, poll, dispatch on verdict
   pk doctor                       Diagnose v2 setup (config, env, deps)

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -6,6 +6,9 @@
 #   ./scripts/sync-method.sh              # Sync from main
 #   ./scripts/sync-method.sh v1.0         # Sync from a specific tag/branch
 #   ./scripts/sync-method.sh --dry-run    # Show what would change
+#   ./scripts/sync-method.sh --auto-install   # After sync, auto-run pk install --force
+#                                             # (no prompt) so the global pk stays in
+#                                             # lockstep with the synced bin/pk.
 #
 # What it syncs:
 #   pipekit/sop/        <- SOPs (Code Quality, Git, Linear, Skills, VBW)
@@ -37,6 +40,7 @@ set -euo pipefail
 
 METHOD_REPO="${METHOD_REPO:-https://github.com/withpiper/pipekit.git}"
 DRY_RUN=false
+AUTO_INSTALL=false
 REF="main"
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHANGELOG="$PROJECT_ROOT/pipekit/.sync-changelog.md"
@@ -46,6 +50,7 @@ CHANGELOG="$PROJECT_ROOT/pipekit/.sync-changelog.md"
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
+    --auto-install) AUTO_INSTALL=true ;;
     -*) echo "WARN: unknown flag: $arg" >&2 ;;
     *) REF="$arg" ;;
   esac
@@ -577,6 +582,39 @@ fi
 
 # Clean up snapshot
 rm -rf "$SNAP"
+
+# --- v2.4.3: install-lag check ---
+# When the synced bin/pk differs from the globally-installed pk on PATH,
+# warn (or auto-install with --auto-install). Closes the lag-bug anchor:
+# Pendragon 2026-05-13, where ~/.local/bin/pk was at pk 2.3.2 but the
+# synced bin/pk was 2.4.2, silently bypassing the v2.3.3 state-ladder
+# gate. cmp -s follows symlinks, so symlinked installs that already point
+# at the synced file produce no warning.
+if ! $DRY_RUN && [ -f "$PROJECT_ROOT/bin/pk" ]; then
+  install_lag=""
+  for installed in "$HOME/.local/bin/pk" "/usr/local/bin/pk"; do
+    if [ -e "$installed" ] && ! cmp -s "$installed" "$PROJECT_ROOT/bin/pk" 2>/dev/null; then
+      install_lag="$installed"
+      break
+    fi
+  done
+  if [ -n "$install_lag" ]; then
+    echo ""
+    if $AUTO_INSTALL; then
+      echo "→ --auto-install: refreshing $install_lag from synced bin/pk"
+      if bash "$PROJECT_ROOT/bin/pk" install --force; then
+        :
+      else
+        echo "  ⚠ pk install --force reported non-zero — re-run manually:"
+        echo "    bash $PROJECT_ROOT/bin/pk install --force"
+      fi
+    else
+      echo "⚠ Installed pk ($install_lag) differs from synced bin/pk."
+      echo "  Run 'pk install --force' from this repo to refresh the global command,"
+      echo "  or re-run sync-method.sh with --auto-install for unattended sync."
+    fi
+  fi
+fi
 
 # --- Summary ---
 echo ""

--- a/scripts/test-pk-v2.4.3.sh
+++ b/scripts/test-pk-v2.4.3.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# test-pk-v2.4.3.sh — fixture-based tests for the v2.4.3 additions:
+#   #1   pk done UAT-state code refusal (--confirmed opt-out)
+#   #2   pk promote UAT-state code refusal (--confirmed opt-out)
+#   #3a  pk install --force re-links valid symlinks (was silent no-op)
+#
+# Network-dependent paths (real Linear lookups) are exercised by stubbing
+# pk_linear_get_state so the harness doesn't need LINEAR_API_KEY.
+#
+# Run: bash scripts/test-pk-v2.4.3.sh   (exit 0 on pass, 1 on first failure)
+
+set -uo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+fail=0
+pass=0
+
+ok()   { pass=$((pass + 1)); printf '  ok  %s\n' "$1"; }
+nope() { fail=$((fail + 1)); printf '  FAIL %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; }
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    ok "$name"
+  else
+    nope "$name" "expected: $(printf %q "$expected") got: $(printf %q "$actual")"
+  fi
+}
+
+# ─── Finding 3a: pk install --force re-links a valid symlink ────────────────
+echo "pk install --force: re-links a valid symlink (was silent no-op pre-v2.4.3)"
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+# Two parallel "bin/pk" sources — content-identical (since we only test the
+# symlink re-link semantics, not source-of-truth resolution).
+mkdir -p "$stage/projA/bin" "$stage/projB/bin" "$stage/install"
+cp "$repo_root/bin/pk" "$stage/projA/bin/pk"
+cp "$repo_root/bin/pk" "$stage/projB/bin/pk"
+chmod +x "$stage/projA/bin/pk" "$stage/projB/bin/pk"
+
+# Pre-install: ~/.local/bin/pk → projA/bin/pk
+ln -s "$stage/projA/bin/pk" "$stage/install/pk"
+
+# Sanity: existing symlink resolves to projA
+existing_target=$(readlink "$stage/install/pk")
+assert_eq "pre-state: install symlink points at projA" "$stage/projA/bin/pk" "$existing_target"
+
+# Run pk install --force with HOME=$stage so target_dir is $stage/.local/bin.
+# This validates the --force path no longer short-circuits on "Already installed".
+# We invoke projA's bin/pk so $src resolves to projA — same as $existing_target.
+# Without the v2.4.3 fix this prints "Already installed" and returns 0 without
+# touching the symlink. With the fix, --force re-links (rm -f + ln -s), and
+# prints "Re-linked".
+mkdir -p "$stage/home/.local/bin"
+ln -sf "$stage/projA/bin/pk" "$stage/home/.local/bin/pk"
+pre_inode=$(ls -i "$stage/home/.local/bin/pk" | awk '{print $1}')
+
+# Invoke install --force via the projA copy. Use HOME override to point at our
+# staged install dir; /usr/local/bin/ on the real machine isn't writable in the
+# common case, so install will fall back to $HOME/.local/bin. We inherit the
+# caller's PATH so the dispatcher's jq/gh preconditions resolve.
+out=$(HOME="$stage/home" bash "$stage/projA/bin/pk" install --force 2>&1) || true
+if echo "$out" | grep -qiE 're-linked|installed'; then
+  ok "pk install --force emits a re-link/install message (not silent)"
+else
+  nope "pk install --force should report what it did" "got: $out"
+fi
+if echo "$out" | grep -q "Already installed"; then
+  # Strictly speaking the v2.4.3 fix replaces "Already installed" with
+  # "Re-linked" when --force is set. If we still see "Already installed"
+  # under --force, the early-return bug is back.
+  nope "pk install --force should not short-circuit with 'Already installed'" "got: $out"
+fi
+
+post_inode=$(ls -i "$stage/home/.local/bin/pk" | awk '{print $1}')
+# After rm -f + ln -s, the inode of the new symlink differs from the old one.
+# (Symlink itself is a new filesystem object even if it points at the same target.)
+if [ "$pre_inode" != "$post_inode" ]; then
+  ok "pk install --force creates a fresh symlink inode (rm -f + ln -s ran)"
+else
+  nope "pk install --force did not replace the symlink (inode unchanged)" "pre=$pre_inode post=$post_inode"
+fi
+
+# ─── Findings 1 + 2: pk_linear_get_state helper presence ────────────────────
+echo ""
+echo "pk_linear_get_state: helper defined and callable"
+# shellcheck disable=SC1091
+source "$repo_root/bin/pk"
+if declare -F pk_linear_get_state >/dev/null; then
+  ok "pk_linear_get_state is defined"
+else
+  nope "pk_linear_get_state should be defined"
+fi
+
+# ─── Finding 1: cmd_done --confirmed arg parsing ────────────────────────────
+echo ""
+echo "cmd_done: --confirmed arg parses without erroring"
+# We can't run cmd_done end-to-end without a real Linear issue + git branch.
+# What we CAN test cheaply: the arg parser. Run cmd_done with an obviously
+# fake ID and --confirmed; it should reach the "no local feature branch
+# found" exit (return 1), NOT the "unknown arg" exit (return 2). That
+# differentiates "flag parsed" from "flag rejected".
+set +e
+(
+  cd "$stage"
+  git init -q .
+  out=$(cmd_done FAKE-99999 --confirmed 2>&1)
+  echo "$out" >&2
+  echo "exit=$?" >&2
+) 2>"$stage/cmd_done.err"
+err_body=$(cat "$stage/cmd_done.err")
+set -e
+if echo "$err_body" | grep -q "unknown arg"; then
+  nope "cmd_done --confirmed flag was rejected as unknown arg" "$err_body"
+else
+  ok "cmd_done --confirmed flag accepted by arg parser"
+fi
+if echo "$err_body" | grep -qE "no local feature branch found|not in a git repo"; then
+  ok "cmd_done with fake ID reaches the expected refusal path"
+else
+  nope "cmd_done with fake ID should refuse on missing branch" "$err_body"
+fi
+
+# ─── Finding 2: cmd_promote --confirmed arg parsing ─────────────────────────
+echo ""
+echo "cmd_promote: --confirmed arg parses without erroring"
+set +e
+(
+  cd "$stage"
+  out=$(cmd_promote --confirmed beta 2>&1)
+  echo "$out" >&2
+  echo "exit=$?" >&2
+) 2>"$stage/cmd_promote.err"
+prom_body=$(cat "$stage/cmd_promote.err")
+set -e
+if echo "$prom_body" | grep -q "unknown arg"; then
+  nope "cmd_promote --confirmed flag was rejected as unknown arg" "$prom_body"
+else
+  ok "cmd_promote --confirmed flag accepted by arg parser"
+fi
+
+# ─── Finding 1: cmd_done UAT-state refusal logic ────────────────────────────
+echo ""
+echo "cmd_done: UAT-state refusal triggers without --confirmed, bypasses with"
+# Stub pk_linear_get_state to return 'UAT' regardless of arg. We need a
+# fake git branch matching feature/FAKE-99999-* so cmd_done resolves
+# past the branch lookup and into the UAT gate.
+(
+  cd "$stage"
+  git init -q test-uat 2>/dev/null
+  cd test-uat
+  git config user.email test@local
+  git config user.name test
+  git commit --allow-empty -q -m "init"
+  git branch feature/FAKE-99999-uat-test 2>/dev/null
+
+  # Source pk into this subshell, then stub the helper.
+  # shellcheck disable=SC1091
+  source "$repo_root/bin/pk"
+  pk_linear_get_state() { echo "UAT"; }
+
+  # Without --confirmed: should error with "still in 'UAT'"
+  out_no_confirm=$(cmd_done FAKE-99999 2>&1) || true
+  if echo "$out_no_confirm" | grep -q "still in 'UAT'"; then
+    echo "OK_REFUSE"
+  else
+    echo "NO_REFUSE: $out_no_confirm"
+  fi
+
+  # With --confirmed: should bypass the UAT gate and proceed to the
+  # PR-merge check (which will fail because there's no real PR). The key
+  # is the output should NOT mention "still in 'UAT'".
+  out_confirm=$(cmd_done FAKE-99999 --confirmed 2>&1) || true
+  if echo "$out_confirm" | grep -q "still in 'UAT'"; then
+    echo "BAD_BYPASS: $out_confirm"
+  else
+    echo "OK_BYPASS"
+  fi
+) > "$stage/uat-test.out" 2>&1
+uat_out=$(cat "$stage/uat-test.out")
+if echo "$uat_out" | grep -q "OK_REFUSE"; then
+  ok "cmd_done refuses when state == UAT and --confirmed missing"
+else
+  nope "cmd_done should refuse UAT without --confirmed" "$uat_out"
+fi
+if echo "$uat_out" | grep -q "OK_BYPASS"; then
+  ok "cmd_done with --confirmed bypasses the UAT refusal"
+else
+  nope "cmd_done --confirmed should bypass UAT refusal" "$uat_out"
+fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  printf '✓ %d assertions passed\n' "$pass"
+  exit 0
+else
+  printf '✗ %d failed, %d passed\n' "$fail" "$pass"
+  exit 1
+fi

--- a/skills/pipekit-update/skill.md
+++ b/skills/pipekit-update/skill.md
@@ -26,6 +26,90 @@ You are a method sync coordinator. Your job is to pull the latest Pipekit conten
 
 ## Execution Steps
 
+### Phase 0 — Detect Mode (upstream vs downstream)
+
+The same `/pipekit-update v<tag>` command works in two places:
+
+- **Downstream** (consuming project, e.g. piper, rs-vault) — sync FROM Pipekit's GitHub release.
+- **Upstream** (the Pipekit repo itself, e.g. `~/Projects/pipekit`) — `git pull` + checkout the tag locally.
+
+Auto-detect:
+
+```bash
+origin_url=$(git remote get-url origin 2>/dev/null || echo "")
+mode="downstream"
+# Pipekit's canonical origins: withpiper/pipekit or any pipekit-shaped fork.
+# Also require a sentinel (method.md + CHANGELOG.md at root) to avoid false
+# positives in consuming projects that happen to have "pipekit" in a URL.
+if echo "$origin_url" | grep -qE '[:/](withpiper|ethan-piper|Ethros19)/pipekit(\.git)?$' \
+   && [ -f method.md ] && [ -f CHANGELOG.md ] && [ -f bin/pk ]; then
+  mode="upstream"
+fi
+echo "Mode: $mode"
+```
+
+Tell the user which mode was detected before proceeding. If detection is wrong (rare — a fork with a non-canonical name), the user can override by running the underlying command directly (`git pull` for upstream, `./scripts/sync-method.sh <tag>` for downstream).
+
+- **Downstream mode** → continue to Phase 1.
+- **Upstream mode** → jump to Phase U.
+
+### Phase U — Upstream Update (Pipekit repo itself)
+
+You're inside the Pipekit clone. The equivalent of "sync from GitHub" is "checkout the tag locally."
+
+**U1. Refuse if working tree is dirty.** The checkout would either fail or stash work. Print the dirty paths and exit:
+
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+  echo "ERROR: working tree is dirty. Commit or stash before updating." >&2
+  git status --short
+  return 1
+fi
+```
+
+**U2. Fetch tags + main:**
+
+```bash
+git fetch --tags --quiet origin
+git fetch --quiet origin main
+```
+
+**U3. Checkout target.** If a tag arg was passed (e.g. `v2.4.3`), check it out. Else fast-forward `main`:
+
+```bash
+if [ -n "$tag_arg" ]; then
+  git checkout "$tag_arg"
+else
+  git checkout main
+  git pull --ff-only origin main
+fi
+```
+
+**U4. Refresh the global `pk` install.** Idempotent — for symlinked installs this just re-links (v2.4.3+ `--force` is no-op-safe); for copied installs this overwrites the stale copy. Closes the install-lag bug class on the upstream side (anchor: Pendragon 2026-05-13, `~/.local/bin/pk` at v2.3.2 while the repo was at v2.4.2):
+
+```bash
+bash ./bin/pk install --force
+```
+
+**U5. Show the CHANGELOG entry for the newly-checked-out ref:**
+
+```bash
+# Grab the entry for the current tag (or "main" → top entry).
+awk -v tag="${tag_arg:-}" '
+  /^## v/ {
+    if (printing) exit
+    if (tag == "" || index($0, tag)) printing = 1
+  }
+  printing { print }
+' CHANGELOG.md | head -60
+```
+
+**U6. Done.** Skip Phases 3-4 — you ARE the source of truth, so there's no `.sync-changelog.md` and no project-config reconciliation. Verify with:
+
+```bash
+pk version   # should match the tag (or main HEAD)
+```
+
 ### Phase 1 — Ensure Sync Script Exists
 
 Check if `scripts/sync-method.sh` exists in the current project.
@@ -166,7 +250,17 @@ Restart Claude Code to load updated skills.
 
 ### Phase 5 — Push Improvements Back (--push only)
 
-When invoked with `--push`, this mode captures improvements made to portable skills *in the current project* and pushes them back to the method repo.
+**Refuse in upstream mode.** If Phase 0 detected `mode=upstream`, `--push` is incoherent — you ARE the method repo, there's nowhere to push improvements TO. Print and exit:
+
+```bash
+if [ "$mode" = "upstream" ]; then
+  echo "ERROR: --push is for downstream projects pushing improvements back to Pipekit."
+  echo "  You're already inside the Pipekit repo. Use git directly (commit + git push)."
+  return 1
+fi
+```
+
+When invoked with `--push` from a downstream project, this mode captures improvements made to portable skills *in the current project* and pushes them back to the method repo.
 
 **Requires a local clone** at `~/Projects/pipekit/` (or wherever `METHOD_REPO_LOCAL` points). If no local clone exists, explain:
 

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -317,7 +317,7 @@ gh pr create --base main --title "hotfix(<scope>): <desc>" --body "..."
 # Two-tier:
 git checkout dev && git pull && git cherry-pick <hash> && git push origin dev
 
-# Three-tier (also cherry-pick to beta):
+# Three-tier (see § When the explicit beta cherry-pick is needed below):
 git checkout dev && git pull && git cherry-pick <hash> && git push origin dev
 git checkout beta && git pull && git cherry-pick <hash> && git push origin beta
 
@@ -327,6 +327,19 @@ git worktree remove ../<project>-hotfix-<slug>
 ```
 
 If the hotfix corresponds to a Linear issue, post the merge commit back to that issue manually — `pk done` is for `pk branch`-created branches.
+
+### When the explicit beta cherry-pick is needed (three-tier)
+
+The standard three-tier flow files three branches: `hotfix/*-main`, `*-cherrypick-dev`, and `*-cherrypick-beta`. But if a `dev → beta` promote is imminent within one cycle of the hotfix landing on dev, the explicit beta cherry-pick is **redundant** — the dev cherry-pick will sweep onto beta automatically via the next `pk promote beta`.
+
+**File the explicit beta cherry-pick only when:**
+
+- Production is bleeding from the bug and beta needs the fix **before** the next scheduled `dev → beta` promote.
+- The next `dev → beta` promote is unscheduled or blocked (feature freeze, awaiting unrelated UAT, marketing hold).
+
+**Otherwise:** skip the beta cherry-pick branch. The dev cherry-pick will land on beta naturally on the next promote. Filing it anyway produces an orphan branch that needs manual cleanup (anchor: WIT-455, 2026-05-13 — `hotfix/margin-cherrypick-beta` orphaned because the dev cherry-pick swept to beta via PR #268 the same day).
+
+If you're unsure, ask: "Will the next `dev → beta` promote happen within ~24h of this hotfix landing on dev?" If yes, skip beta cherry-pick. If no or unknown, file it.
 
 ---
 


### PR DESCRIPTION
## Summary

Belt-and-braces release closing the failure modes surfaced by the WIT-451 canary close-out and the Pendragon empirical observation (both 2026-05-13). Five findings, one bundled PR.

| # | Finding | Surface |
|---|---|---|
| 1 | `pk done` UAT-state code refusal (`--confirmed` opt-out) | `bin/pk cmd_done` |
| 2 | `pk promote` UAT-bundle code refusal (`--confirmed` opt-out) | `bin/pk cmd_promote` |
| 3 | `pk install` lag fix — sync-method.sh warns + `--auto-install` flag | `scripts/sync-method.sh` |
| 3a | `pk install --force` re-links valid symlinks (was silent no-op) | `bin/pk cmd_install` |
| 4 | Hotfix beta cherry-pick SOP nuance | `sop/Git_and_Deployment.md` |
| Bonus | `/pipekit-update` auto-detects upstream vs downstream mode | `skills/pipekit-update/skill.md` |

## Why

- v2.4.2's doc gate (Stage 3 + RUNBOOK [5e] + `/work`/`pk-exit` "does NOT do") is the right gate for normal use, but the empirical failure mode is an LLM session auto-chaining past prose. Doc gates rely on the model reading natural language; code gates rely on `exit 1`.
- Same week the v2.4.2 doc gate landed, the v2.3.3 state-ladder gate (a code gate that DID exist) silently bypassed itself because the user's installed `pk` was v2.3.2 — surfacing the lag-bug that `sync-method.sh` now warns on.
- `/pipekit-update` previously had no path for "running from inside the Pipekit repo itself" — Pendragon had to `git pull` manually while Nebula ran `/pipekit-update v2.4.3` via the sync script. Now the same command works on both.

## Anchor incidents (all 2026-05-13)

- **WIT-451 worker auto-fired `pk done` mid-UAT, wiped worktree** → Finding 1
- **Same root, narrower** → Finding 2
- **PR #270 / WIT-275 false transition: state-ladder gate didn't fire because installed pk was v2.3.2** → Finding 3
- **Pendragon `pk install --force` silent no-op on valid symlinks** → Finding 3a
- **WIT-455 orphaned `hotfix/margin-cherrypick-beta` because dev cherry-pick swept to beta via PR #268** → Finding 4

## Test plan

- [x] `bash scripts/test-pk-promote.sh` — 25 assertions pass (v2.3.3 ladder + missing-target guard, unchanged)
- [x] `bash scripts/test-pk-config.sh` — 14 assertions pass (pk_config parsing, unchanged)
- [x] `bash scripts/test-pk-v2.4.3.sh` — 9 NEW assertions pass: `pk install --force` re-links a valid symlink, `pk_linear_get_state` helper presence, `cmd_done`/`cmd_promote` `--confirmed` arg parsing, end-to-end UAT-refusal trigger + bypass via stubbed `pk_linear_get_state`
- [x] `bash -n` syntax check on all modified scripts
- [x] `pk version` returns `2.4.3`
- [x] `pk help` shows `--confirmed` on `pk done` and `pk promote` synopsis lines

## Migration

None for consumers. Once merged + tagged:

```
/pipekit-update v2.4.3
```

Same command on every machine. The skill auto-detects whether you're running from a consuming project (sync-method.sh path) or from the Pipekit clone itself (git checkout + pk install --force path).

After update:
- `pk done <ID>` refuses when issue is in UAT — pass `--confirmed` once UAT is signed off
- `pk promote <env>` refuses when any bundled issue is in UAT — pass `--confirmed` to override
- `pk install --force` always re-links (no more silent no-op on valid symlinks)
- `sync-method.sh` warns when `~/.local/bin/pk` differs from synced `bin/pk`; add `--auto-install` for unattended sync

## Auto-tag

`.github/workflows/auto-tag-release.yml` should fire on merge and auto-tag `v2.4.3`. Verify post-merge:

```bash
git ls-remote --tags origin | grep v2.4.3
gh run list --repo withpiper/pipekit --workflow=auto-tag-release.yml --limit 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)