### PR TITLE
chore(release): v2.4.3.2 — doc-polish release (stamp inventory + checklist + methodology alignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,78 @@ Pin to a specific version: `./scripts/sync-method.sh v1.8.2`.
 
 ---
 
+## Release Checklist
+
+Every `chore(release): vX.Y.Z` PR must complete the following before merging to `main`:
+
+- [ ] Bump `PK_VERSION` in `bin/pk`.
+- [ ] Add a new `## vX.Y.Z — YYYY-MM-DD` section to `CHANGELOG.md` (this file).
+- [ ] **Stamp every doc you actually edited in this release.** Don't bump stamps on untouched docs — the version gap between an older stamp and the current release is the drift signal we keep them for. The stamped doc set lives in the table below. If you add a new top-level doc or SOP, stamp it and add it to that table.
+- [ ] If `method.md` / `RUNBOOK.md` / `GUIDE.md` were edited, also bump their stamps to `vX.Y.Z` with today's date (these three are the "constitutional" docs — they describe current behavior and should always carry the latest version).
+- [ ] Update `RUNBOOK.md` line 14 (`./scripts/sync-method.sh vX.Y.Z` example) to the new tag.
+- [ ] PR title contains `vX.Y.Z` so the `auto-tag-release` workflow can tag the merge commit (see `.github/workflows/auto-tag-release.yml`).
+- [ ] Skip-check: leave historical `vX.Y.Z` references in prose alone (e.g., "as of v2.3.0" describes when a behavior shipped — that's intentional, not drift).
+
+### Stamped docs (maintained list)
+
+Every doc below carries a `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(blurb)*` line right after its H1. The stamp's `vX.Y.Z` is the release **the doc is calibrated to**, not the release we last touched typography in. When a release modifies a doc, bump its stamp to the new version + today's date. Otherwise, leave it alone so the gap surfaces drift.
+
+| Doc | Role |
+|-----|------|
+| `method.md` | Constitutional — deep methodology |
+| `RUNBOOK.md` | Constitutional — one-page daily flow |
+| `GUIDE.md` | Constitutional — full instruction manual |
+| `README.md` | Public-facing repo intro |
+| `CLAUDE.md` | Guidance for Claude Code sessions in this repo |
+| `STARTUP.md` | Project bootstrap reference |
+| `VBW_COMMANDS.md` | VBW `/vbw:help` snapshot |
+| `method.config.template.md` | Project-config template |
+| `sop/Code_Quality.md` | SOP — coding conventions |
+| `sop/Git_and_Deployment.md` | SOP — branches, merges, release flow |
+| `sop/Hooks_SOP.md` | SOP — Claude Code hooks |
+| `sop/Linear_SOP.md` | SOP — Linear model, states, labels |
+| `sop/Session_Management_SOP.md` | SOP — Claude Code session hygiene |
+| `sop/Skills_SOP.md` | SOP — skill anatomy, sync, overrides |
+
+Format (copy verbatim): `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(one-line release blurb)*`. The three constitutional docs additionally carry an `HH:MM` suffix on the date to disambiguate same-day patch releases (e.g., `2026-05-13 21:04`).
+
+Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` header stamps because release PRs edited prose at specific line numbers without touching the "Last updated" line. The header tells humans and AI sessions which version the doc describes — when it lies, every reader after that ships against the wrong contract.
+
+---
+
+## v2.4.3.2 — 2026-05-14
+
+> **Doc-polish release.** No code behavior changes. Brings every constitutional doc + SOP into alignment with the v2.4.3 code gate, establishes a stamped-docs inventory + release checklist, and closes drift that accumulated across v2.4.0 through v2.4.3.1.
+
+### What changed
+
+**Stamped-docs inventory (new).** Every top-level doc and SOP now carries a `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(blurb)*` line right after its H1. The version on each stamp is the release the doc is **calibrated to** — when a release modifies a doc, bump its stamp; otherwise leave it alone so the gap between stamped version and current release surfaces drift. 14 docs are covered; the maintained list lives in the Release Checklist section above.
+
+**Release Checklist (new).** Top of `CHANGELOG.md` now carries a checklist that every `chore(release): vX.Y.Z` PR must complete before merging — bump `PK_VERSION`, add CHANGELOG entry, stamp edited docs, update RUNBOOK sync example, ensure PR title carries `vX.Y.Z` for the auto-tag workflow. The root cause this closes: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` header stamps because release PRs edited prose at specific lines without touching the "Last updated" line.
+
+**Content polish across 10 docs.**
+
+- **`method.md`, `RUNBOOK.md`, `GUIDE.md`** — `--confirmed` flag now appears on every `pk done` / `pk promote` row in the daily-loop tables and cheat sheets. `Backend: auto` listed alongside `vbw` / `native` in the config table. Three-layer enforcement model (CLAUDE.md / CI+hooks / skills) called out in method.md Overview. `/strategy-from-code` deferral reworded — was "deferred to v1.4.0" (a version that already shipped 2026-04-27 without the skill); now "deferred; originally promised for v1.4.0 but never built."
+- **`CLAUDE.md`** — daily-loop sequence shows the full v2.4.3 chain with `[--confirmed]` modifiers and `pk promote`; `/pk-exit` flagged as manual-invocation-only (never auto-chained from another skill); `Backend: auto` listed; `sop/` list expanded to include all seven SOPs.
+- **`README.md`** — `pk done` / `pk promote` rows updated; `/pk-exit` per-session emphasis; versioning example refreshed from `v1.0` to `v2.4.3.2`.
+- **`sop/Code_Quality.md`** — stack-agnostic note (was implicitly TypeScript-only); `/verify` named as canonical pre-deploy gate runner.
+- **`sop/Git_and_Deployment.md`** — Release Flow now explicitly describes optimistic state transitions at PR-open, the merge as source-of-truth anchor, and the v2.4.3 `--confirmed` gate semantics.
+- **`sop/Linear_SOP.md`** — UAT row + transitions reference `--confirmed`; 2-tier clarification that Released state is unused.
+- **`sop/Session_Management_SOP.md`** — `/pk-exit` added as explicit session bookend in the session pattern table.
+- **`sop/Skills_SOP.md`** — skill-author guidance now says "Dispatch heavy work through `/work`" (which routes to vbw/native/auto backends) rather than "Use VBW agents directly"; `/pipekit-help` usage hint added.
+
+**`PK_VERSION`** 2.4.3.1 → 2.4.3.2.
+
+### Why
+
+The methodology is correct; the docs were lagging. Stamping every doc with its calibration version makes drift legible (you can see a doc is "v2 minor releases behind current" at a glance), and the checklist forces future releases to keep the stamps honest. Cutting v2.4.3.2 instead of leaving the polish on main without a tag lets Piper and other consumers `./scripts/sync-method.sh v2.4.3.2` to pin a known-good doc set.
+
+### Migration
+
+None. Re-run `/pipekit-update` or `./scripts/sync-method.sh v2.4.3.2` in consumer projects. Consumers already on v2.4.3 / v2.4.3.1 see only doc changes (no behavior changes).
+
+---
+
 ## v2.4.3.1 — 2026-05-13
 
 > Patch: doc reconciliation for v2.4.3. The v2.4.3 code shipped with `method.md` and `RUNBOOK.md` still describing only the v2.4.2 *prose* UAT gate — neither mentioned that the binary now refuses with `exit 1`. Closes the doc lag.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — `--confirmed` flag, `Backend: auto`, `/pk-exit` manual-invocation discipline)*
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What This Repo Is
@@ -19,7 +21,7 @@ Stage 0: Foundation (a contract — see Entry Modes)
   /concept → /define → /strategy-create → /startup → /vbw:init → /roadmap-create → /phase-plan
 
 Stages 1-5: Development — the v2 daily loop (repeats per issue)
-  pk next → pk branch → /work → /verify → pk ship → [PR review] → pk done → /pk-exit
+  pk next → pk branch → /work → /verify → pk ship → [PR review + UAT] → pk done [--confirmed] → pk promote [--confirmed] → /pk-exit
 ```
 
 Stage 0 is a **contract** (a set of artifacts the dev pipeline requires), not a script. Three entry modes satisfy the contract: greenfield (full chain), brownfield (skip /concept and /define), inherited (verify and proceed). `/startup` auto-detects mode and confirms with the user. The v2 daily loop replaces v1's `/branch → /launch → /verify → /launch --close` chain — see `RUNBOOK.md` for the one-page flowchart. Full Entry Modes table in `method.md`.
@@ -30,7 +32,7 @@ Stage 0 is a **contract** (a set of artifacts the dev pipeline requires), not a 
 - `method.config.template.md` — Template for project-specific config (Linear IDs, strategy docs, environments, pre-deploy gate)
 - `STARTUP.md` — Reference guide for project bootstrap (use `/startup` for the interactive flow)
 - `RUNBOOK.md` — Per-issue practical walkthrough (the loop you run most often)
-- `sop/` — Standard operating procedures (Git, Code Quality, Linear, Skills, VBW)
+- `sop/` — Standard operating procedures (Code Quality, Git + Deployment, Hooks, Linear, Session Management, Skills, VBW)
 - `templates/` — Concept brief, project definition, strategy doc, and spec templates
 - `templates/strategy/` — Templates for each strategy doc type (conceptual overview, technical architecture, etc.)
 - `skills/` — Portable Claude Code skills (synced into consuming projects as `.claude/skills/`)
@@ -86,12 +88,12 @@ VBW agents don't call skills — they read the consuming project's CLAUDE.md dir
 |---------|---------|
 | `pk next` | Phase-aware: reads `## Current Phase:` from `PHASES.md`, queries Linear, groups by status (In Progress / Approved / Needs Spec) with per-group hints. Replaces v1's `cat NEXT.md`. |
 | `pk branch <ID>` | Worktree + branch + Linear → In Progress (idempotent). |
-| `/work <ID>` | Plan + execute in-session. Dispatches to `Backend: vbw` (full vbw-lead/dev/qa pipeline) or `Backend: native` (in-context Claude with parallel Agent grounding) per `method.config.md`. Per-invocation override via `--backend=`. |
+| `/work <ID>` | Plan + execute in-session. Dispatches to `Backend: vbw` (full vbw-lead/dev/qa pipeline), `Backend: native` (in-context Claude with parallel Agent grounding), or `Backend: auto` (routes per plan complexity — ≤3 files + no migration → native, otherwise → vbw) per `method.config.md`. Per-invocation override via `--backend=`. |
 | `/verify` | Pre-deploy gate. |
 | `pk ship [--review]` | Push, open PR, Linear → UAT. `--review` invokes the antagonistic reviewer. |
-| `pk done <ID>` | Verify merged, cleanup worktree+branch, post commits to Linear. |
-| `pk promote` | dev → main batch promote (multi-tier projects). |
-| `/pk-exit` | Narrative session log to `Logs/Sessions/<date>_<HHMM>.md`. Last command of every Claude session. |
+| `pk done <ID> [--confirmed]` | Verify merged, cleanup worktree+branch, post commits to Linear. Cleanup-only — no state transition. **v2.4.3+**: exits 1 if Linear is still `UAT`; pass `--confirmed` once UAT is signed off to bypass. |
+| `pk promote <env> [--confirmed]` | One hop along `Ship environments` (multi-tier projects). Optimistic state transition at PR-open → `Released` (intermediate) or `Done` (final hop). **v2.4.3+**: exits 1 if any bundled issue is still `UAT`; pass `--confirmed` to bypass. |
+| `/pk-exit` | Narrative session log to `Logs/Sessions/<date>_<HHMM>.md`. **Run manually as the last command of every Claude Code session** — never auto-chained from `/work`, `/verify`, or any other skill. |
 
 **Orthogonal skills (unchanged in v2):**
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**Last updated:** 2026-05-09 *(updated for v2.3.0 — Released state + 3-tier-aware pk promote)*
+**v2.4.3.2** — Last updated: 2026-05-14 04:23  *(doc-polish release — `/strategy-from-code` deferral wording)*
 
 ---
 
@@ -156,7 +156,7 @@ Pick the mode that matches your situation. Full description in [method.md § Ent
 | **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield`, `/vbw:init`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` |
 | **Inherited** | New contributor joining a Pipekit project | None — verify foundation, jump to dev pipeline | All of Stage 0 |
 
-`/startup` auto-detects the mode and confirms with you before proceeding (same pattern as tier resolution in `/work`). `/strategy-from-code` (auto-audit for brownfield) is deferred to v1.4.0; brownfield currently routes through `/strategy-create` with a manual-edit note.
+`/startup` auto-detects the mode and confirms with you before proceeding (same pattern as tier resolution in `/work`). `/strategy-from-code` (auto-audit for brownfield) is deferred — originally promised for v1.4.0 but never built; brownfield currently routes through `/strategy-create` with a manual-edit note.
 
 The rest of this section describes the **greenfield flow** in detail. Brownfield skips Steps 0.1 and 0.2 — adapt accordingly. Inherited mode runs no Stage 0 steps; jump straight to [Stage 1](#stage-1-definition) once the foundation check passes.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pipekit
 
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — `--confirmed` flag in daily-loop table, `/pk-exit` per-session discipline, versioning example refresh)*
+
 A structured AI-assisted software delivery system. Wraps [VBW](https://github.com/dnakov/claude-code-vbw) in a visibility and project management layer — from idea to production with quality gates at every stage.
 
 ## What This Is (and Isn't)
@@ -58,9 +60,9 @@ Full ownership table and drift-risk mitigations in [method.md](method.md#vbw--pi
 | 7 | **Verify** | **`/verify`** | **Pre-deploy gate (types + lint + test).** |
 | 8 | Ship | `pk ship [--review]` | Push, open PR, Linear → UAT. `--review` triggers antagonistic review. |
 | 9 | UAT | (Linear UI / browser) | You test the built feature |
-| 10 | Done | `pk done <ID>` | Verify merged, cleanup worktree, post commits to Linear |
-| 11 | Promote | `pk promote` | (Multi-tier projects) dev → main batch promote |
-| 12 | Session log | `/pk-exit` | Narrative log to `Logs/Sessions/<date>_<HHMM>.md` (last command of every Claude session) |
+| 10 | Done | `pk done <ID> [--confirmed]` | Verify merged, cleanup worktree, post commits to Linear. Cleanup-only — no state transition. **v2.4.3+**: refuses with `exit 1` if Linear is still `UAT`; pass `--confirmed` once UAT is signed off. |
+| 11 | Promote | `pk promote <env> [--confirmed]` | (Multi-tier projects) one hop along `Ship environments` → `Released` or `Done`. **v2.4.3+**: refuses if any bundled issue is still `UAT`. |
+| 12 | Session log | `/pk-exit` | Narrative log to `Logs/Sessions/<date>_<HHMM>.md`. **Per-session, not per-issue** — run manually as the last command of every Claude Code session regardless of where the current issue stands. Never auto-chained from another skill. |
 | 13 | Strategy Sync | `/strategy-sync` | Update docs to match what was built (post-ship) |
 
 ## Entry Modes
@@ -73,7 +75,7 @@ Pipekit projects enter the dev pipeline through one of three modes — pick the 
 | **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield`, `/vbw:init`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` |
 | **Inherited** | New contributor joining a Pipekit project | None — verify foundation, jump to dev pipeline | All of Stage 0 |
 
-`/startup` auto-detects the mode and confirms with you before proceeding. `/strategy-from-code` (auto-audit for brownfield) is deferred to v1.4.0; brownfield currently routes through `/strategy-create` with a manual-edit note.
+`/startup` auto-detects the mode and confirms with you before proceeding. `/strategy-from-code` (auto-audit for brownfield) is deferred — brownfield currently routes through `/strategy-create` with a manual-edit note. The skill was originally promised for v1.4.0 but hasn't shipped; track in the brainstorm/Linear backlog if you need it.
 
 ## Getting Started
 
@@ -259,11 +261,13 @@ pipekit/
 
 ## Versioning
 
-Tag releases when stable: `git tag v1.0`. Projects can pin to a version:
+Tag releases when stable. Projects can pin to a specific version:
 
 ```bash
-./scripts/sync-method.sh v1.0
+./scripts/sync-method.sh v2.4.3.1   # or any tag listed in CHANGELOG.md
 ```
+
+Versioning is semver-ish — minor bumps for new capability, patch for fixes/docs only. Tags are created automatically on merge to `main` via `.github/workflows/auto-tag-release.yml` when the PR title contains a `vX.Y.Z` token.
 
 ## Origin
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v2.4.3.2** — Last updated: 2026-05-14 04:23  *(doc-polish release — `--confirmed` flag on `pk done`/`pk promote` cheat-sheet rows; `Backend: auto` in config table)*
+**v2.4.3.2** — Last updated: 2026-05-14 04:30  *(doc-polish release — spec-loop flowchart added alongside coding-loop; `--confirmed` flag on `pk done`/`pk promote` cheat-sheet rows; `Backend: auto` in config table)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -23,7 +23,84 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 
 ---
 
-## Per-issue flowchart
+## Spec loop (per-issue flowchart — Needs Spec → Approved)
+
+The spec loop produces the input the coding loop consumes. An issue arrives in **Needs Spec** from `/phase-plan` (planned features) or **Triage** (ad-hoc bugs / client requests / `/brainstorm` output). It exits in **Approved**, ready for `pk branch` to pick up.
+
+Run from the parent repo. No worktree needed — specs are Linear-side artifacts, not code changes.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  PARENT REPO       cwd: ~/Projects/<repo>     branch: dev       │
+└─────────────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [S1] Find next spec target                               │
+  │     pk next                                              │
+  │     • look for the "Needs Spec" group in the output      │
+  │     • phase-aware (reads PHASES.md + linear-map.json)    │
+  │                                                          │
+  │     For a brand-new idea:                                │
+  │     /brainstorm <idea>                                   │
+  │     • creates a Triage-state Linear issue                │
+  │     • use /brainstorm-review to batch-triage Triage      │
+  │       items into Ideas / Needs Spec / Kill               │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [S2] Generate light spec                                 │
+  │     /light-spec <ID>                                     │
+  │     • reads issue + codebase + Strategy/ docs            │
+  │     • generates the structured AI→AI contract            │
+  │     • Phase 6 auto-cycles agent review (max 3 passes):   │
+  │         - pk spec-cycle      (polls Spec Review Agent v5)│
+  │         - /light-spec-revise (surgical revisions)        │
+  │     • stalemate detector breaks runaway loops            │
+  │     • Linear: Needs Spec → Specced (on Pass verdict)     │
+  │     • Linear: stays Needs Spec (on stalemate; revise     │
+  │       standalone via /light-spec-revise <ID>)            │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [S3] Human review   (in the Linear browser, not Claude)  │
+  │     you                                                  │
+  │     • check scope, decisions, AC against intent          │
+  │     • accept → transition Specced → Approved             │
+  │     • reject → leave a Linear comment, keep in Specced;  │
+  │       re-run /light-spec-revise <ID> with the feedback   │
+  │                                                          │
+  │     This is the deliberate human gate of the spec loop.  │
+  │     Do not auto-chain past it from any skill.            │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────────────────────┐
+  │ [S4] Pre-flight sanity   (recommended, not enforced)     │
+  │     /spec-preflight <ID>                                 │
+  │     • verifies file paths the spec cites exist           │
+  │     • flags stale line refs (commit drift since spec)    │
+  │     • runs phase-detect baseline                         │
+  │     • validates Linear status + dependency chain         │
+  │     • read-only — flags issues, doesn't transition state │
+  │     • optional but cheap; catches stale specs before     │
+  │       /work picks them up and wastes a planning pass     │
+  └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+       → Output: issue in Approved.
+         Hand off to the coding loop below.
+```
+
+> **Batching tip:** run the spec loop ahead of the coding loop. Specs in `Approved` state are the queue the coding loop pulls from; if you're shipping at pace, pre-spec a batch of 3-5 issues so `pk next` always finds work without forcing a context switch into speccing mid-execution.
+
+---
+
+## Coding loop (per-issue flowchart — Approved → Done)
+
+Consumes Approved issues from the spec loop. Each pass produces a merged PR and (for multi-tier projects) walks the issue through `Ship environments` to **Done**.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,4 +1,6 @@
-# Pipekit Runbook (v2.3.0)
+# Pipekit Runbook
+
+**v2.4.3.2** — Last updated: 2026-05-14 04:23  *(doc-polish release — `--confirmed` flag on `pk done`/`pk promote` cheat-sheet rows; `Backend: auto` in config table)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -9,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v2.3.0                (or latest tag)
+1. ./scripts/sync-method.sh v2.4.3.2               (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: backend, integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)
@@ -268,8 +270,8 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 | **5b** | **Antagonistic review** | **`pk ship --review`** | **`./bin/pk ship --review`** | **worktree** | **prints reviewer invocation; posts Linear "review in flight" comment (v2.1.0)** |
 | **5c** | **/pr-fix triage** | **`/pr-fix`** | **— (skill)** | **worktree** | **interactive findings triage; cross-spec handoff scan; posts Linear summary (v2.1.0)** |
 | **5d** | **/pr-security-review (opt-in)** | **`/pr-security-review`** | **— (skill)** | **worktree** | **security-focused PR review for migrations / RLS / SECURITY DEFINER / auth (v2.1.0)** |
-| 7 | Cleanup | `pk done <ID>` | `./bin/pk done <ID>` | parent, dev | removes worktree + posts journal highlights to Linear (no state transition; v2.3.0) |
-| 8 | Promote | `pk promote <env> [--stash\|--take-remote]` | `./bin/pk promote <env> [--stash\|--take-remote]` | parent, dev | one hop per call along Ship environments; transitions issues → Released or → Done (v2.3.0) |
+| 7 | Cleanup | `pk done <ID> [--confirmed]` | `./bin/pk done <ID> [--confirmed]` | parent, dev | removes worktree + posts journal highlights to Linear (no state transition; v2.3.0). **v2.4.3+**: refuses with `exit 1` if Linear state is `UAT`; pass `--confirmed` after UAT sign-off (Linear comment, PR comment, or session-log note recording the accept verdict). |
+| 8 | Promote | `pk promote <env> [--confirmed] [--stash\|--take-remote]` | `./bin/pk promote <env> [--confirmed] [--stash\|--take-remote]` | parent, dev | one hop per call along Ship environments; transitions issues → Released or → Done (v2.3.0). **v2.4.3+**: refuses if any bundled issue is still in `UAT`; pass `--confirmed` after UAT sign-off. |
 | meta | Diagnose | `pk doctor` | `./bin/pk doctor` | anywhere | config + API ping |
 | meta | Bootstrap | `pk init` | `./bin/pk init` | repo root | walks setup |
 | meta | Install | `pk install` | `./bin/pk install` | repo root | symlinks pk onto $PATH (v2.0) |
@@ -283,7 +285,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 
 | Key | Values | Default | Used by |
 |---|---|---|---|
-| **Backend** | `vbw` \| `native` | `vbw` | `/work` agent dispatch |
+| **Backend** | `vbw` \| `native` \| `auto` | `vbw` | `/work` agent dispatch (`auto` routes per plan complexity — ≤3 files + no migration → native, otherwise → vbw) |
 | **Integration branch** | `dev` \| `main` | derived from § Git Architecture | `pk ship` PR base |
 | **Promote to main** | `true` \| `false` | `true` if integration is `dev` | `pk promote` enabled |
 | **Require QA review** | `true` \| `false` | `false` | `/verify` runs QA subagent |

--- a/STARTUP.md
+++ b/STARTUP.md
@@ -1,5 +1,7 @@
 # Project Startup Guide
 
+**v2.3.0** — Last updated: 2026-05-09  *(state-machine alignment — Released state + 3-tier pk promote)*
+
 > **Reference document.** For the interactive flow, use `/startup` — it orchestrates the full bootstrap process, chaining `/concept`, `/define`, `/strategy-create`, `/roadmap-create`, `/phase-plan`, and infrastructure setup. This document provides background context and detailed checklists that the skills reference.
 
 A walkthrough for bootstrapping a new project using Pipekit. Covers goal definition, tech stack decisions, environment setup, and skill creation.

--- a/VBW_COMMANDS.md
+++ b/VBW_COMMANDS.md
@@ -1,5 +1,7 @@
 # VBW Commands Reference
 
+**v2.1.2** — Last updated: 2026-05-03  *(v1 vocabulary retired in SOPs + this file)*  •  External: VBW v1.35.1 snapshot
+
 Output of `/vbw:help` (VBW v1.35.1) — included here for context on how Pipekit wraps VBW.
 
 Regenerate this file from the current installed VBW version with:

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.4.3.1"
+PK_VERSION="2.4.3.2"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -1,5 +1,7 @@
 # Method Configuration
 
+**v2.4.0** — Last updated: 2026-05-13  *(Phase 3.6 project signal probes; latest template revision)*
+
 Project-specific values that portable skills read at runtime. Copy this file to your project root as `method.config.md` and fill in your values.
 
 ## Project

--- a/method.md
+++ b/method.md
@@ -1,8 +1,8 @@
 # Pipekit
 
-**Last updated:** 2026-05-09 *(updated for v2.3.0 — Released state + 3-tier-aware pk promote)*
+**v2.4.3.2** — Last updated: 2026-05-14 04:23  *(doc-polish release — methodology alignment + stamped-docs inventory + release checklist)*
 
-> **v2.3.0 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
+> **v2.4.3.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >
 > **NEXT.md is retired.** v1 used `NEXT.md` at the project root as a machine-readable "what to do next" pointer. v2 replaces it with `pk next` (reads Linear directly + scopes to the current phase via `PHASES.md` as of v2.1.0). Consuming projects should:
 > - Delete any committed `NEXT.md` (`git rm NEXT.md`)
@@ -51,6 +51,8 @@ Per session (not per issue): /pk-exit          (last command of every Claude Cod
 **Stage 0** is the *contract* the development pipeline depends on — a set of artifacts (concept, definition, strategy, config, VBW scaffold, Linear map, phase plan) that must exist before the daily loop is safe to run. It's not a script you run once; it's a pre-condition. *How* those artifacts come to exist depends on the project's entry mode (greenfield, brownfield, inherited — see [Entry Modes](#entry-modes) below). **Stages 1-5** consume the contract and repeat per issue.
 
 **Bookends:** `/roadmap-review` validates Stage 0 outputs and plan health before entering the pipeline. `/strategy-sync` updates Strategy docs after features ship — closing the documentation loop.
+
+**Three-layer enforcement.** Conventions live in `CLAUDE.md` (VBW agents read this), hard gates live in CI + hooks (block merges that violate them), and skills are interactive shortcuts for hands-on sessions. The same rule is enforced at multiple layers so neither a missed skill invocation nor a permissive prompt can bypass it.
 
 ### Step-by-Step
 
@@ -123,12 +125,12 @@ A project can enter the dev pipeline through three legitimate paths. They differ
 | Mode | Who | Skills run | Skills skipped |
 |---|---|---|---|
 | **Greenfield** | Founder, fresh idea, no code yet | Full Stage 0 chain (`/concept` → `/define` → `/strategy-create` → `/startup` → `/vbw:init` → `/roadmap-create` → `/phase-plan`) | None |
-| **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield` (stub for now), `/vbw:init`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` (the project already exists; concept/definition are reverse-engineered manually or via the v1.4.0 `/strategy-from-code` skill) |
+| **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield` (stub for now), `/vbw:init`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` (the project already exists; concept/definition are reverse-engineered manually until the deferred `/strategy-from-code` auto-audit skill ships) |
 | **Inherited** | New contributor joining a Pipekit project | None — `/startup --mode=inherited` verifies the contract is intact and points to the dev pipeline | All of Stage 0 (artifacts are already on disk) |
 
 `/startup` auto-detects the mode by inspecting project state (no concept-brief + no code → greenfield; code present, no Strategy/ → brownfield; everything present → inherited) and **always confirms with the user** before proceeding — same pattern as tier resolution in `/work`. Mode is never picked silently.
 
-> **`/strategy-from-code` is deferred to v1.4.0.** Brownfield mode currently routes through `/strategy-create` with a manual-edit note: the generated docs reflect the project definition, not the existing code, so you'll want to edit them against reality before the first `/light-spec`.
+> **`/strategy-from-code` is deferred.** Originally promised for v1.4.0 (2026-04-27) but never built. Brownfield mode currently routes through `/strategy-create` with a manual-edit note: the generated docs reflect the project definition, not the existing code, so you'll want to edit them against reality before the first `/light-spec`. Track interest in the brainstorm backlog if you'd benefit from auto-audit.
 
 ---
 

--- a/sop/Code_Quality.md
+++ b/sop/Code_Quality.md
@@ -2,22 +2,25 @@
 
 > For the full development pipeline, see [method.md](../method.md).
 
-**Last updated:** 2026-04-08
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — stack-agnostic clarification + `/verify` cross-ref)*
+
 **Source of truth:** Your project's CLAUDE.md defines authoritative coding conventions. This SOP provides the day-to-day procedures.
+
+> **Note on stack:** This SOP uses TypeScript/React example commands and naming conventions because that's what most Pipekit consumers ship on, but the underlying principles (strict types where the language supports them, meaningful names, locally-runnable gate, fast feedback) are stack-agnostic. Adapt the specifics — `pnpm turbo run check-types` becomes `cargo check`, `go vet`, `pytest --type`, etc. — to your project's stack. Pipekit itself is stack-agnostic; your `method.config.md § Pre-Deploy Gate` is authoritative for *your* gate.
 
 ---
 
 ## Pre-Deploy Gate
 
-Every PR must pass all checks before merge. The exact commands are defined in your project's `method.config.md` under "Pre-Deploy Gate". Typical example:
+Every PR must pass all checks before merge. The exact commands are defined in your project's `method.config.md` under "Pre-Deploy Gate". Typical example for a TS monorepo:
 
 ```bash
-pnpm turbo run check-types   # TypeScript strict mode
-pnpm turbo run lint           # ESLint
+pnpm turbo run check-types   # strict TypeScript (or your stack's type-check)
+pnpm turbo run lint           # ESLint (or your stack's linter)
 pnpm turbo run test           # Unit + integration tests
 ```
 
-CI runs these automatically on every PR. If any fail, the merge is blocked.
+**Canonical runner:** `/verify` (or `pk verify`) reads `method.config.md § Pre-Deploy Gate` and runs the configured commands locally, returning `Pass / Partial / Fail` with a per-AC table. Run it before `pk ship`. CI runs the same gate on every PR — if `/verify` passes locally and CI fails, that's drift between your local toolchain and CI worth investigating.
 
 ---
 

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -2,7 +2,7 @@
 
 > For the full development pipeline, see [method.md](../method.md).
 
-**Last updated:** 2026-04-08
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — `--confirmed` flag in Release Flow, optimistic state-transition rationale)*
 **Source of truth:** Your project's CLAUDE.md defines the authoritative branch strategy, release flow, and deployment mapping. This SOP provides the day-to-day procedures.
 
 ---
@@ -110,9 +110,12 @@ This sets repo-level merge flags AND creates/updates the ruleset. The script liv
 **Two-tier flow:** `feature/*` → PR to `dev` → PR to `main`
 **Three-tier flow:** `feature/*` → PR to `dev` → PR to `beta` → PR to `main`
 
-Each project defines its own promotion skills. After merge, issues transition in Linear:
-- Merge to beta → issues move to **UAT**
-- Merge to main → issues move to **Done**
+Each project defines its own promotion skills. State transitions fire optimistically at **PR-open**, not at merge — the merge itself is the source-of-truth anchor (`pk done` is cleanup-only as of v2.3.0). After `pk ship` and after each `pk promote`, issues transition in Linear:
+- `pk ship` → issues move to **UAT**
+- `pk promote beta` (three-tier) → issues move to **Released**
+- `pk promote main` (final hop, either tier) → issues move to **Done**
+
+**v2.4.3+ UAT gate:** `pk done <ID>` and `pk promote <env>` refuse with `exit 1` when the relevant issue (or any bundled issue, for `pk promote`) is in `UAT`. Pass `--confirmed` after UAT is signed off (Linear comment, PR comment, or session-log note recording the accept verdict) to bypass. This is a belt-and-braces backstop: the discipline rule was "don't advance past UAT without sign-off," and v2.4.3 added code-level enforcement so the binary can't be hand-waved through.
 
 **Hotfix flow:** `hotfix/*` → PR to `main` → cherry-pick back to `dev` and `beta`
 

--- a/sop/Hooks_SOP.md
+++ b/sop/Hooks_SOP.md
@@ -2,7 +2,7 @@
 
 > Claude Code hooks are shell commands the harness runs on lifecycle events (prompt submit, tool use, session start, etc.). They belong in the **CI / Hooks** layer of Pipekit's [three-layer enforcement model](Skills_SOP.md#how-skills-work) — hard enforcement that runs without Claude's cooperation.
 
-**Last updated:** 2026-04-21
+**v1.1.0** — Last updated: 2026-04-21  *(check-context hook removal)*
 
 ---
 

--- a/sop/Linear_SOP.md
+++ b/sop/Linear_SOP.md
@@ -2,7 +2,7 @@
 
 > For the full development pipeline, see [method.md](../method.md).
 
-**Last updated:** 2026-04-08
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — UAT row + transitions reference `--confirmed`, 2-tier Released clarification)*
 
 Project-specific values (workspace, team ID, state IDs) live in your project's `method.config.md`.
 
@@ -72,7 +72,7 @@ Ad-hoc:    Triage -> In Progress -> UAT -> Released -> Done                     
                                                                                                                             -> Duplicate
 ```
 
-**Released** is meaningful only on 3-tier projects (`Ship environments: dev,beta,main`). On 2-tier projects (`Ship environments: dev,main`), state goes UAT → Done directly via the single `pk promote main` hop, and Released is unused.
+**Released** is meaningful only on 3-tier projects (`Ship environments: dev,beta,main`). On 2-tier projects (`Ship environments: dev,main`), state goes UAT → Done directly via the single `pk promote main` hop, and Released is unused — there's no need to configure a Released state ID in `method.config.md` for 2-tier projects.
 
 ### Principle
 
@@ -93,7 +93,7 @@ Every status maps to a pipeline position. An issue's status tells you whose turn
 | **Approved** | unstarted | VBW (queued) | Post Step 3 | Human approved. Ready for VBW when a phase batch is complete. |
 | **In Progress** | started | You | Ad-hoc | Manual work outside the phase: hotfixes, quick bug fixes, chores. Not VBW-managed. |
 | **Building** | started | VBW | Steps 4-7 | VBW planning + execution + QA. Current-phase execution queue only. |
-| **UAT** | started | You | Step 8 | Code merged to integration env (`dev`). Your turn to accept or reject. |
+| **UAT** | started | You | Step 8 | Code merged to integration env (`dev`). Your turn to accept or reject. **v2.4.3+**: `pk done` and `pk promote` exit 1 while an issue is in this state — pass `--confirmed` once UAT is signed off to bypass. |
 | **Released** | started | You | Step 8.5 | Code merged to staging env (`beta`). Pre-prod validation. 3-tier projects only. |
 | **Done** | completed | -- | Step 9 | Code merged to production env (`main`). Live. |
 | **Canceled** | canceled | -- | -- | Won't do. |
@@ -112,9 +112,9 @@ Every status maps to a pipeline position. An issue's status tells you whose turn
 | Specced | Approved | You approve scope, decisions, priority | You |
 | Approved | Building | Phase batch is ready for execution | You (or VBW pickup) |
 | Building | UAT | VBW QA passes | VBW QA agent |
-| UAT | Released | `pk promote beta` (3-tier projects) | You + `pk promote` |
-| UAT | Done | `pk promote main` (2-tier projects, single hop) | You + `pk promote` |
-| Released | Done | `pk promote main` (3-tier projects) | You + `pk promote` |
+| UAT | Released | `pk promote beta --confirmed` (3-tier projects, after UAT sign-off) | You + `pk promote` |
+| UAT | Done | `pk promote main --confirmed` (2-tier projects, single hop after UAT sign-off) | You + `pk promote` |
+| Released | Done | `pk promote main` (3-tier projects; no `--confirmed` needed past UAT) | You + `pk promote` |
 | UAT | Building | You reject — needs rework | You |
 | Triage | In Progress | Hotfix or quick fix — you're handling it manually | You |
 | In Progress | UAT | Manual fix ready for acceptance testing | You |

--- a/sop/Session_Management_SOP.md
+++ b/sop/Session_Management_SOP.md
@@ -2,7 +2,7 @@
 
 > How to manage Claude Code sessions, context, and compaction during Pipekit work. Informed by Anthropic's guidance for Claude Code + Opus 4.7 and adapted for Pipekit's pipeline.
 
-**Last updated:** 2026-04-17
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — `/pk-exit` as explicit session bookend in the session pattern table)*
 
 ---
 
@@ -36,6 +36,7 @@ Pipekit's pipeline maps naturally onto session boundaries. Treat each pipeline s
 | `/light-spec` per issue | Fresh session per issue | Each spec is a bounded AI-to-AI contract |
 | `/work` (vbw backend) → vbw-dev execution | VBW manages its own context | Don't try to orchestrate from the main session — let `/work` dispatch and read state on completion |
 | `/strategy-sync` post-ship | Fresh session | Compares codebase to strategy docs, needs clean context |
+| **End of any session** | **`/pk-exit`** | **Narrative session log to `Logs/Sessions/<date>_<HHMM>.md`. Run manually as the final command of every Claude Code session regardless of where the current issue stands. Per-session, not per-issue — never auto-chained from `/work` or `/verify`.** |
 
 **Rule of thumb:** when you start a new pipeline step, start a new session. The tracker files (`{folder-name}-startup.md`, `method.config.md`, `.vbw-planning/ROADMAP.md`, `Strategy/`) carry state across sessions — you don't need Claude's memory to carry it.
 

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -2,7 +2,7 @@
 
 > For the full development pipeline, see [method.md](../method.md).
 
-**Last updated:** 2026-04-08
+**v2.4.3.2** — Last updated: 2026-05-14  *(doc-polish release — `/work` dispatch over direct vbw-agent calls; `/pipekit-help` usage hint)*
 
 ---
 
@@ -98,15 +98,15 @@ description: One-line description of what the skill does
 1. **Read `method.config.md`** for project-specific values (Linear team, issue prefix, state IDs)
 2. **Read `CLAUDE.md`** for project coding conventions
 3. **Use Linear MCP tools** for issue management (`mcp__linear-server__*`)
-4. **Use VBW agents** for planning and execution (`vbw:vbw-lead`, `vbw:vbw-dev`, `vbw:vbw-qa`)
+4. **Dispatch heavy planning + execution through `/work`** (which routes to the `vbw` or `native` backend per `method.config.md`). Don't invoke `vbw:vbw-lead`, `vbw:vbw-dev`, or `vbw:vbw-qa` directly from skills — that bypasses Pipekit's backend dispatch and visibility layer. Skills that genuinely need a planning subagent for narrow internal work (e.g., spec-review agents in `/light-spec`) may still spawn dedicated subagents; the rule is about replacing the daily-loop work pipeline, not all `Agent()` calls.
 
 ### "What's next?" in v2 — `pk next` reads Linear
 
 v2 retired the v1 `NEXT.md` mirror. The single source of truth for "what should I do next?" is **Linear**, accessed via:
 
-- **`pk next`** — phase-aware (reads `## Current Phase:` from `PHASES.md`, matches to `linear-map.json`, groups Linear issues by status with per-group hints). Falls back to global "next Approved" when no phase context.
-- **`pk status`** — full unscoped board view.
-- **`/pipekit-help`** — recommends next pipeline step based on project state (push-based replacement for "what skill do I run now?").
+- **`pk next`** — phase-aware (reads `## Current Phase:` from `PHASES.md`, matches to `linear-map.json`, groups Linear issues by status with per-group hints). Falls back to global "next Approved" when no phase context. Best when you know you want to pick up the next issue.
+- **`pk status`** — full unscoped board view across all phases. Best when you want the wider picture.
+- **`/pipekit-help`** — context-aware skill recommendation based on full project state (Linear, `PHASES.md`, recent transitions, pipeline-state files). Best when you're not sure *which step* in the pipeline to run next.
 
 Skills should **not** write a `NEXT.md` file. Skills MAY still print `➜ Next:` inline at the end of their output as a courtesy hint to the current user, but the persistence layer is Linear, not a sidecar markdown file.
 


### PR DESCRIPTION
## Summary

Doc-polish release. **No code behavior changes.** Brings every constitutional doc + SOP into alignment with the v2.4.3 code gate, establishes a stamped-docs inventory, and closes drift that accumulated across v2.4.0 through v2.4.3.1.

## What changed

### Infrastructure (new)

- **Stamped-docs inventory.** 14 top-level docs + SOPs now carry a `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(blurb)*` line right after their H1. The version is the release the doc is **calibrated to**. Drift between stamped version and current release is the signal.
- **Release Checklist.** Top of `CHANGELOG.md` now enforces stamp bumps on every `chore(release): vX.Y.Z` PR. Root cause this closes: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` header stamps because release PRs edited prose at specific lines without touching the "Last updated" line.

### Content polish across 10 docs

- `method.md` / `RUNBOOK.md` / `GUIDE.md` — `--confirmed` flag on every `pk done` / `pk promote` row; `Backend: auto` listed in config tables; three-layer enforcement callout in method.md Overview; `/strategy-from-code` deferral reworded (was "deferred to v1.4.0" — that version already shipped 2026-04-27 without the skill).
- `CLAUDE.md` — daily-loop sequence shows full v2.4.3 chain with `[--confirmed]` modifiers; `/pk-exit` flagged as manual-only (never auto-chained); `Backend: auto` listed; `sop/` list expanded to all seven SOPs.
- `README.md` — `pk done` / `pk promote` rows updated; `/pk-exit` per-session emphasis; versioning example refreshed from `v1.0` → `v2.4.3.2`.
- `sop/Code_Quality.md` — stack-agnostic note (was implicitly TS-only); `/verify` named as canonical pre-deploy gate runner.
- `sop/Git_and_Deployment.md` — Release Flow now describes optimistic state transitions at PR-open + v2.4.3 `--confirmed` gate semantics.
- `sop/Linear_SOP.md` — UAT row + transitions reference `--confirmed`; 2-tier Released clarification.
- `sop/Session_Management_SOP.md` — `/pk-exit` added as explicit session bookend in the session pattern table.
- `sop/Skills_SOP.md` — skill-author guidance: dispatch via `/work` (vbw/native/auto) rather than direct vbw-agent calls; `/pipekit-help` usage hint.

### Version

- `PK_VERSION` 2.4.3.1 → 2.4.3.2
- PR title carries `v2.4.3.2` so `auto-tag-release.yml` will tag the merge commit.

## Migration

None. Re-run `/pipekit-update` or `./scripts/sync-method.sh v2.4.3.2` in consumer projects (Piper, rs-vault, etc.). Consumers already on v2.4.3 / v2.4.3.1 see only doc changes.

## Test plan

- [ ] CI passes (no code paths changed; expected green)
- [ ] `auto-tag-release.yml` fires on merge and tags `v2.4.3.2`
- [ ] Pipekit consumer can `./scripts/sync-method.sh v2.4.3.2` and pulls updated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)