### PR TITLE
chore(release): v2.4.3.3 — canary-driven (F6 flag gate + 5 doc-polish fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ archive/scratch/
 
 # personal notepad — replaces v1 NEXT.md; free-form, never committed
 notepad.md
+
+# /work → /verify cross-skill flag markers (consumed by /verify Step 3.5)
+.pk-work/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,57 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ---
 
+## v2.4.3.3 — 2026-05-14
+
+> **Canary-driven release.** One load-bearing skill behavior change (F6 — `/verify` pauses auto-ship when human-decision flags surface) plus a five-finding doc-polish bundle. All six items surfaced by a live v2.4.3.2 canary against Piper WIT-456 the same day. The canary itself validated v2.4.3.2's headline UAT-gate feature end-to-end (P1, P12, P13) and v2.3.3's skip-backward-transition guard in production (P15). Twelve passing signals total. Full canary log: `Logs/Sessions/2026-05-14_0838.md`.
+
+### What changed
+
+**`/verify` auto-ship now gates on `Pass AND zero flags AND --auto-ship` (F6 — load-bearing).** New Step 3.5 enumerates human-decision flags before the rollover decision:
+- Migration files in diff (always pause regardless of QA — migrations are high-stakes and warrant a human eye for irreversibility, RLS, `search_path` review).
+- QA verdict Pass with non-"none" Omissions / Scope-creep / Bugs-noticed sub-sections (the subagent classified the work as shippable in aggregate but still flagged items worth surfacing — treat each as a flag).
+- User invoked `/verify --qa` (forcing QA signals "I want eyes on it"; auto-ship would contradict the explicit flag).
+- `/work` advisory marker file (`.pk-work/<ID>.flags`) present (cross-skill signal — see below).
+
+When `FLAG_COUNT > 0`, auto-ship is forbidden even with `--auto-ship`. The skill surfaces the flag list + three resolution paths (address, accept-and-amend, `/work --resume`), then stops. The auto-chain itself stays — it is a feature when nothing is surfaced. F6 anchor: 2026-05-14 canary verbatim feedback from the user: *"the F6 — /work → /verify → pk ship auto-chain is a feature. The programming should pause on verify if there is ANY Flag for human decision making."*
+
+**`/work` Step 6.5 writes `.pk-work/<ISSUE-ID>.flags` when advisories surface (F6 cross-skill signal).** Triggers: self-reference grep #1/#2/#3 returns a match outside the file just edited, behavioral self-check finds a gap and the work ships anyway with the gap documented, or a documented Risk-fallback was invoked during execution. Marker file is one line per flag, gitignored at `.pk-work/`, consumed by `/verify` Step 3.5, cleaned up automatically when `pk done` removes the worktree. Re-runs of `/work --resume` overwrite the marker rather than appending. Empty markers are forbidden — file existence is the signal.
+
+**`bin/pk pk_config` → `pk config` in `/work` skill (F1).** Replaced 6 invocations in `skills/work/skill.md` (lines 65, 68-71, 79, 504). `pk_config` is an internal shell function inside `bin/pk` reachable only when the binary is *sourced*; the subcommand exposed for skill bodies is `pk config <key> [default]`. The skill body's wrong form crashed the first config read of every `/work` invocation; workers self-recovered by retrying with the correct form, but each crash + retry burned a Bash tool call + LLM cycles. Doc-only fix; no binary change needed.
+
+**`/work` Step 5 gains a "Test command discipline" preamble (F7).** One paragraph instructing executors to use the AC-stated test command verbatim before improvising. Surfaced by 3 retries on WIT-456: `pnpm --filter=@piper/web vitest run <abs-path>` (no such script) → `cd apps/web && pnpm test <abs-path>` (wrong relative path) → finally the AC's literal `pnpm turbo run test --filter=@piper/web`. Each ad-hoc invocation costs ~30s of retry; the AC string is pre-tested.
+
+**`pk branch` emits a fresh-worktree dependency-install hint (F8).** When the new worktree has `package.json` but no `node_modules/`, `pk branch` now ends with:
+```
+⚠️  Fresh worktree — install deps before first test:
+     (cd <wt-path> && <pkg-manager> install)
+```
+Lockfile detection picks `pnpm install` / `yarn install` / `npm install`. Worktrees inherit tracked files but not gitignored ones; the first test invocation otherwise triggered a multi-minute `pnpm install` while the worker session tried to figure out what was wrong. Surfaced on canary WIT-456 worker session.
+
+**`/pr-fix` Phase 6.6 pre-documents the expected external-action security warning (F10).** Posting a Linear comment from inside `/pr-fix` triggers a generic "external action" security warning because Linear is an external write. The action is sanctioned by the skill (Phase 6.6 is an explicit step), but the harness can't know that — so workers improvised transparency notes per-run. The new preamble in `skills/pr-fix/skill.md` § 6.6 gives the worker the exact line to surface, removing the need to improvise.
+
+**`pk done` + `/pk-exit` ordering hints (F11).** Two non-load-bearing additions:
+- `bin/pk done --help` row now appends *"Run from parent repo (not worktree); run /pk-exit inside the worktree session first."*
+- `skills/pk-exit/skill.md` frontmatter description now appends *"For worker sessions in a worktree, run /pk-exit before pk done (pk done cleans up the worktree this session lives in, so the log must be written first)."*
+
+The canonical sequence was already documented in RUNBOOK step [7]→[8] and the refuse-table line 435 (`pk done` from worktree → refuses with hint). But experienced users still paused mid-canary to ask "do I run /pk-exit first?" — the join between the two skills was implicit in the flowchart. These hints surface the dependency at each command's own help text.
+
+**`PK_VERSION`** 2.4.3.2 → 2.4.3.3. **`RUNBOOK.md`** sync-example line bumped to `v2.4.3.3`.
+
+### Why
+
+The 2026-05-14 canary against Piper WIT-456 ran the full v2 daily loop end-to-end against the v2.4.3.2 release and validated the headline UAT-gate features in production (PR #276 shipped, `pk done --confirmed` honored UAT bypass, `pk promote beta` refused without `--confirmed` then ran clean with it). In the process, six findings surfaced. F6 is the only behavior change — it was an explicit user methodology decision to keep the auto-chain but make `/verify` itself smarter about pausing. F1/F7/F8/F10/F11 are doc-tier polish that the v2.4.3.2 stamped-docs inventory and drift-check.sh wouldn't have caught (they check stamps and removed-skill references, not command examples vs `bin/pk`'s actual subcommand surface, and not user-friction patterns that show up only mid-loop).
+
+The canary pattern paid off: zero methodology rework, six fixes ready the same day, all anchored to concrete observed behavior rather than speculative cleanup. The canary log is the substantive artifact — read `Logs/Sessions/2026-05-14_0838.md` for the structured P/F findings tally + the moment-by-moment observations.
+
+### Migration
+
+None for consumers already on v2.4.3.2 — F1/F7/F8/F10/F11 are doc-only or hint-only. F6 changes `/verify`'s auto-ship gate: it is strictly *more conservative* (paused chains are easier to recover than over-eager shipping), and the new pause path is the documented expected behavior when a flag is present. Re-run `/pipekit-update v2.4.3.3` or `./scripts/sync-method.sh v2.4.3.3` in consumer projects.
+
+If your project already uses `.pk-work/` for something else, the F6 marker scheme will collide — but `.pk-work/` is a new directory in Pipekit's vocabulary and is unlikely to be in use already. (Pipekit's own `.gitignore` adds the entry.)
+
+---
+
 ## v2.4.3.2 — 2026-05-14
 
 > **Doc-polish release.** No code behavior changes. Brings every constitutional doc + SOP into alignment with the v2.4.3 code gate, establishes a stamped-docs inventory + release checklist, and closes drift that accumulated across v2.4.0 through v2.4.3.1.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**v2.4.3.2** — Last updated: 2026-05-14 04:23  *(doc-polish release — `/strategy-from-code` deferral wording)*
+**v2.4.3.3** — Last updated: 2026-05-14 09:27  *(canary-driven release — `/verify` Step 3.5 flag gate (F6); content unchanged this release)*
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v2.4.3.2** — Last updated: 2026-05-14 04:30  *(doc-polish release — spec-loop flowchart added alongside coding-loop; `--confirmed` flag on `pk done`/`pk promote` cheat-sheet rows; `Backend: auto` in config table)*
+**v2.4.3.3** — Last updated: 2026-05-14 09:27  *(canary-driven release — `/verify` Step 3.5 flag gate (F6) + sync-example bump to v2.4.3.3)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -11,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v2.4.3.2               (or latest tag)
+1. ./scripts/sync-method.sh v2.4.3.3               (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: backend, integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)

--- a/bin/pk
+++ b/bin/pk
@@ -753,7 +753,31 @@ cmd_branch() {
   pk_linear_set_state "$id" "In Progress" || true
 
   echo ""
-  echo "Done. To enter:"
+  echo "Done."
+
+  # Fresh-worktree dependency hint (F8 — surfaced 2026-05-14 canary against
+  # Piper WIT-456). Worktrees inherit tracked files but not gitignored ones
+  # like node_modules/. First test invocation otherwise triggers a multi-
+  # minute pnpm install while the worker session tries to figure out what's
+  # wrong. Hint here so the human installs deps before running /work.
+  if [ -f "$wt_path/package.json" ] && [ ! -d "$wt_path/node_modules" ]; then
+    local pkg_install=""
+    if [ -f "$wt_path/pnpm-lock.yaml" ]; then
+      pkg_install="pnpm install"
+    elif [ -f "$wt_path/yarn.lock" ]; then
+      pkg_install="yarn install"
+    elif [ -f "$wt_path/package-lock.json" ]; then
+      pkg_install="npm install"
+    fi
+    if [ -n "$pkg_install" ]; then
+      echo ""
+      echo "⚠️  Fresh worktree — install deps before first test:"
+      echo "     (cd $wt_path && $pkg_install)"
+    fi
+  fi
+
+  echo ""
+  echo "To enter:"
   echo "  cd $wt_path && claude --dangerously-skip-permissions"
 }
 
@@ -1731,7 +1755,7 @@ Subcommands:
   pk status                       Quick triage of the Linear board + worktrees
   pk branch <ISSUE-ID>            Create worktree+branch, Linear → In Progress
   pk ship [--env=<env>] [--review]  Push, gh pr create, Linear → UAT (optional antagonistic review)
-  pk done [<ID>] [--confirmed]    Verify PR merged, cleanup worktree+branch (no Linear state change). Refuses if issue is in UAT — pass --confirmed once UAT is signed off.
+  pk done [<ID>] [--confirmed]    Verify PR merged, cleanup worktree+branch (no Linear state change). Refuses if issue is in UAT — pass --confirmed once UAT is signed off. Run from parent repo (not worktree); run /pk-exit inside the worktree session first.
   pk verify                       Run the project's pre-deploy gate
   pk config [<key> [<default>]]   Read a V2 key from method.config.md; no args = dump all known keys
   pk promote <env> [--stash|--take-remote] [--confirmed]  Walk one hop in Ship environments; transitions issues → Released (intermediate) or Done (final). Conflict flags resolve local edits vs incoming source. Refuses if any bundled issue is in UAT — pass --confirmed to override.

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.4.3.2"
+PK_VERSION="2.4.3.3"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.md
+++ b/method.md
@@ -1,6 +1,6 @@
 # Pipekit
 
-**v2.4.3.2** — Last updated: 2026-05-14 04:23  *(doc-polish release — methodology alignment + stamped-docs inventory + release checklist)*
+**v2.4.3.3** — Last updated: 2026-05-14 09:27  *(canary-driven release — `/verify` Step 3.5 flag gate (F6); content unchanged this release)*
 
 > **v2.4.3.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >

--- a/skills/pk-exit/skill.md
+++ b/skills/pk-exit/skill.md
@@ -1,6 +1,6 @@
 ---
 name: pk-exit
-description: Write the session log to Logs/Sessions/<date>_<HHMM>.md before /exit. Captures narrative — what shipped, decisions, lessons, outstanding work. Run as the last command of every Claude session in a Pipekit project.
+description: Write the session log to Logs/Sessions/<date>_<HHMM>.md before /exit. Captures narrative — what shipped, decisions, lessons, outstanding work. Run as the last command of every Claude session in a Pipekit project. For worker sessions in a worktree, run /pk-exit before `pk done` (pk done cleans up the worktree this session lives in, so the log must be written first).
 ---
 
 # /pk-exit Skill

--- a/skills/pr-fix/skill.md
+++ b/skills/pr-fix/skill.md
@@ -333,6 +333,8 @@ git push
 
 After fixes are pushed, post a Linear comment on the PR's linked issue summarizing the triage. This closes the mid-loop visibility gap — Linear sees `In Progress → UAT → [Released →] Done` today, but the *what happened with this review* context lives only on the PR.
 
+> **Expected harness warning (F10):** the subagent or tool that writes to Linear from inside `/pr-fix` will emit a generic "external action" security warning, because posting a comment to Linear is a write to an external system. This is expected — Phase 6.6 is an explicit, sanctioned action of this skill. Do not pause for re-confirmation, do not improvise a transparency note in the chat. Surface the warning verbatim in the hand-off summary with the line: *"Phase 6.6 Linear write fired — the external-action warning is the expected security notice for this sanctioned step."* Surfaced 2026-05-14 canary; documented v2.4.3.3.
+
 Identify the Linear issue from:
 - The PR title's `<TEAM>-<N>:` prefix (e.g. `RS-73: …`), OR
 - The PR body's `Closes <TEAM>-<N>` line, OR

--- a/skills/verify/skill.md
+++ b/skills/verify/skill.md
@@ -163,34 +163,129 @@ Use Task tool with:
 
 Wait for the subagent to return. Print its verdict block verbatim — no editorializing.
 
+## Step 3.5 — Human-decision flag enumeration
+
+After the gate (and QA, if run), enumerate any **human-decision flags** present. A flag is anything that should pause the auto-ship chain even when the headline verdict is Pass. The principle: the auto-chain is a feature, but it must not bypass a human eye when there is any signal worth a human eye.
+
+Run these checks in order. Surface every match.
+
+### Flag check A — Migration files in diff
+
+```bash
+MIGRATION_DIR=$(pk config "Migration dir" "")
+if [ -n "$MIGRATION_DIR" ]; then
+  MIGRATION_FILES=$(git diff --name-only "origin/$INTEGRATION...HEAD" -- "$MIGRATION_DIR" 2>/dev/null)
+  [ -n "$MIGRATION_FILES" ] && echo "FLAG: migration files in diff — review for irreversibility, RLS, search_path"
+fi
+```
+
+Migrations are high-stakes and always warrant a human eye, regardless of QA verdict. Even a "trivial column add" can ship a destructive default backfill or a missing `search_path` on a `SECURITY DEFINER` function.
+
+### Flag check B — QA Pass with non-empty sub-sections
+
+When QA ran and returned **Pass**, also parse the verdict block for non-"none" content in:
+
+- **Omissions** line: anything other than `none` (case-insensitive)
+- **Scope creep** line: anything other than `none`
+- **Bugs noticed** line: anything other than `none observed` / `none`
+
+A Pass with non-empty sub-sections means the subagent classified the work as shippable in aggregate but still flagged items worth surfacing. Treat each non-empty sub-section as one flag.
+
+### Flag check C — `--qa` was forced by user
+
+If the user invoked `/verify --qa` (regardless of `Require QA review` config), they signaled they want eyes on it. The Pass verdict from QA is necessary but not sufficient — auto-ship would short-circuit the intent of the explicit flag.
+
+Surface as: `FLAG: --qa forced — user explicitly requested QA, do not auto-ship without confirm`
+
+### Flag check D — `/work` cross-skill marker
+
+`/work`'s Step 6.5 writes `.pk-work/<ISSUE-ID>.flags` (one line per flag) when self-reference grep surfaces matches, behavioral self-check finds gaps, or a documented Risk-fallback was invoked during execution. Read it here.
+
+```bash
+MARKER=".pk-work/${ISSUE}.flags"
+if [ -f "$MARKER" ]; then
+  echo "FLAGS from /work (Step 6.5):"
+  sed 's/^/  FLAG: /' "$MARKER"
+fi
+```
+
+The marker is `.pk-work/` per repo convention; gitignored.
+
+### Tally
+
+After all four checks, count flags:
+
+```bash
+FLAG_COUNT=<sum of flags surfaced above>
+```
+
+If `FLAG_COUNT > 0`, the verdict is treated as **Pass-with-flags** in Step 4's auto-ship decision, even if the QA verdict block says Pass. This is the load-bearing rule for F6.
+
+Print one summary line:
+
+```
+Flags: <count>  ·  Auto-ship: <will-fire | paused>
+```
+
 ## Step 4 — Hand off (with auto-ship for the /work rollover path)
 
-Based on verdict, print the next-action:
+Based on verdict + flag tally, print the next-action:
 
-| Verdict | Next |
-|---|---|
-| Pass (gate only) | `pk ship` (auto-shipped if invoked with `--auto-ship`; otherwise hint only) |
-| Pass (gate + QA) | `pk ship` (auto-shipped if invoked with `--auto-ship`; otherwise hint only) |
-| Partial | Read the per-AC table. Decide: amend with `/work` (if gap is real), or ship anyway with `git commit --amend` documenting the gap. Then `pk ship`. |
-| Fail (gate) | Fix the failing command, then re-run `/verify` (idempotent). |
-| Fail (QA) | Stop. Either: expand `/work <ID>` to address Unmet ACs; OR `pk delegate <ID> "the spec needs <X>"` to refine spec; OR override consciously with documented decision. |
+| Verdict | Flags | Next |
+|---|---|---|
+| Pass (gate only) | 0 | `pk ship` (auto-shipped if invoked with `--auto-ship`; otherwise hint only) |
+| Pass (gate + QA) | 0 | `pk ship` (auto-shipped if invoked with `--auto-ship`; otherwise hint only) |
+| **Pass** | **≥1** | **Pause. List flags. Auto-ship is forbidden. User runs `pk ship` manually after reviewing — or `/work --resume` to address a flag, or amends the commit to document the accept decision.** |
+| Partial | any | Read the per-AC table. Decide: amend with `/work` (if gap is real), or ship anyway with `git commit --amend` documenting the gap. Then `pk ship`. |
+| Fail (gate) | any | Fix the failing command, then re-run `/verify` (idempotent). |
+| Fail (QA) | any | Stop. Either: expand `/work <ID>` to address Unmet ACs; OR `pk delegate <ID> "the spec needs <X>"` to refine spec; OR override consciously with documented decision. |
 
-### Auto-ship rollover (Pass only, only when invoked with --auto-ship)
+### Auto-ship rollover (Pass + zero flags only, only when invoked with --auto-ship)
 
-If the verdict is **Pass** AND this skill was invoked with the `--auto-ship` argument (which `/work`'s Step 7 rollover passes via the Skill tool's `args` parameter), auto-invoke `pk ship`:
+Auto-ship fires when **all three** conditions hold:
 
-1. Print: `✓ /verify Pass — auto-running pk ship`
+1. The verdict is **Pass** (gate green; QA Pass if QA ran).
+2. The flag tally from Step 3.5 is **zero** (no migration files, no QA Pass-with-non-empty sub-sections, no `--qa` force, no `/work` advisory marker).
+3. This skill was invoked with the `--auto-ship` argument (passed via the Skill tool's `args` parameter by `/work`'s Step 7 rollover).
+
+Behavior:
+
+1. Print: `✓ /verify Pass + 0 flags — auto-running pk ship`
 2. Run `pk ship` via bash. Use no flags — `pk ship` reads `Integration branch` from `method.config.md` to pick the destination, which gives `dev` for Piper-style multi-env projects and `main` for single-env projects (correct in both cases).
 3. If `pk ship` succeeds: print its output (PR URL + Linear transition) and exit.
 4. If `pk ship` fails (push rejected, gh CLI error, branch protection): surface the error verbatim and STOP. Do NOT auto-retry — push failures usually mean branch protection, lockfile drift, or remote conflicts that need human eyes.
 
 `--review` (antagonistic review) stays opt-in; the user runs `pk ship --review` separately if they want it.
 
-If `--auto-ship` is **not** in this skill's args (standalone `/verify` invocation), do NOT auto-ship on Pass. Print the hint and let the user pace.
+### Pass-with-flags pause (the F6 gate — load-bearing)
+
+When the verdict is Pass but `FLAG_COUNT > 0`, **do not auto-ship under any circumstance**, even with `--auto-ship`. Print:
+
+```
+✓ Pass with <N> flag(s) — auto-ship paused for human decision.
+
+Flags surfaced:
+  <flag 1>
+  <flag 2>
+  ...
+
+To proceed:
+  • Address the flag(s), then re-run /verify.
+  • OR accept the flag(s): document the accept decision in the commit
+    (git commit --amend --no-edit -m '<existing>\n\nAccepted flags: <reason>')
+    and run `pk ship` manually.
+  • OR /work --resume <ISSUE-ID> if execution gaps remain.
+```
+
+Then **stop**. The chain does not advance to `pk ship` without explicit human action. This rule is non-negotiable — it is the entire reason Step 3.5 exists. Skipping it on agent judgment reintroduces the F6 failure mode the canary 2026-05-14 surfaced.
+
+### Standalone /verify (no --auto-ship)
+
+If `--auto-ship` is **not** in this skill's args (standalone `/verify` invocation), do NOT auto-ship regardless of verdict or flag count. Print the hint and let the user pace. The flag list still gets surfaced — it just informs the user's manual `pk ship` decision instead of gating it.
 
 **Why an arg, not an env var:** env vars set in one Bash tool call don't propagate to subsequent Bash calls — each invocation is a fresh subshell. The only reliable cross-skill signal is the Skill tool's `args` parameter.
 
-**Partial / Fail with `--auto-ship`:** still no auto-ship. Auto-ship is gated on Pass, not on the arg alone. The arg only authorizes the *Pass branch* to ship; failures always pause for human attention.
+**Partial / Fail with `--auto-ship`:** still no auto-ship. Auto-ship is gated on Pass + zero flags, not on the arg alone. The arg only authorizes the *clean Pass branch* to ship; flags or failures always pause for human attention.
 
 ## Failure model
 

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -62,13 +62,13 @@ ISSUE=${ISSUE:-$(echo "$CURRENT" | grep -oE '[A-Z]+-[0-9]+' | head -1)}
 
 ## Step 1 — Read configuration
 
-Read these values from `method.config.md` using the `bin/pk pk_config` binary — do not grep the file directly, as the markdown table format (bold keys, backtick values) is unreliable to parse inline:
+Read these values from `method.config.md` using `pk config <key> [default]` — do not grep the file directly, as the markdown table format (bold keys, backtick values) is unreliable to parse inline. (`pk_config` is the internal shell function inside `bin/pk`; the subcommand exposed to skill bodies is `pk config`. Using `bin/pk pk_config` would exit 1 with "Unknown subcommand: pk_config" — surfaced 2026-05-14 canary, fixed v2.4.3.3.)
 
 ```bash
-BACKEND=$(bin/pk pk_config "Backend" "vbw")
-DEEP_FLAG=$(bin/pk pk_config "Default deep flag" "false")
-QA_REVIEW=$(bin/pk pk_config "Require QA review" "false")
-STRATEGY_PATH=$(bin/pk pk_config "Strategy docs path" "Strategy/")
+BACKEND=$(pk config "Backend" "vbw")
+DEEP_FLAG=$(pk config "Default deep flag" "false")
+QA_REVIEW=$(pk config "Require QA review" "false")
+STRATEGY_PATH=$(pk config "Strategy docs path" "Strategy/")
 ```
 
 Resolve the effective `--deep` (CLI flag OR `Default deep flag: true`).
@@ -76,7 +76,7 @@ Resolve the effective `--deep` (CLI flag OR `Default deep flag: true`).
 Resolve the effective backend in this order (first match wins):
 
 1. `--backend=vbw`, `--backend=native`, or `--backend=auto` passed on the invocation
-2. `Backend` row in `method.config.md` (read via `bin/pk pk_config` above)
+2. `Backend` row in `method.config.md` (read via `pk config` above)
 3. Default: `vbw`
 
 If `--backend=` is passed with any value other than `vbw`, `native`, or `auto`, refuse: `Unknown backend '<value>'. Valid: vbw, native, auto.`
@@ -266,6 +266,12 @@ Recommendation: pk delegate <ISSUE-ID> "the plan keeps revising on <area>. Refin
 ```
 
 ## Step 5 — Execute
+
+### Test command discipline (applies to every execute path)
+
+If the spec's Acceptance Criteria names a specific test command verbatim — e.g., `pnpm turbo run test --filter=@piper/web` — **use that command verbatim before improvising.** Spec-stated commands are pre-tested and known to work; ad-hoc invocations (`pnpm vitest run <path>`, `pnpm <pkg> test <abs-path>`, etc.) routinely cost two-to-three retries while you re-discover package-script naming, monorepo path conventions, and filter syntax. Surfaced 2026-05-14 canary (F7); fixed v2.4.3.3.
+
+If the AC doesn't name a test command, fall back to the project's § Pre-Deploy Gate in `method.config.md`.
 
 ### vbw backend
 
@@ -501,7 +507,7 @@ Before printing the hand-off, ask yourself: "Did the last shell command exit 0?"
 | Spec missing required sections, with `--deep` | Refuse. Recommend `/light-spec` or `pk delegate`. |
 | Plan revised >3 times | Refuse. Recommend `pk delegate`. |
 | `--backend=` with unknown value | Refuse: `Unknown backend '<value>'. Valid: vbw, native, auto.` |
-| `bin/pk pk_config` binary absent | Warn: `bin/pk not found — cannot read Backend from config. Defaulting to vbw. Run /pipekit-update to fix.` |
+| `pk` (or `bin/pk`) binary absent | Warn: `pk not found — cannot read Backend from config. Defaulting to vbw. Run /pipekit-update to fix.` |
 | Subagent returns permission denial | Stop. Print the denial. Do not retry. |
 | Subagent returns ambiguous failure | Print full output. Ask user how to proceed. |
 | Tests fail post-execute | Surface. Don't auto-fix — that's `/verify`. |

--- a/skills/work/skill.md
+++ b/skills/work/skill.md
@@ -409,6 +409,32 @@ Why mandatory: WIT-451 canary 2026-05-13 shipped via the R4 documented fallback 
 
 If something fails this self-check, **surface it in the hand-off summary** — don't paper over. The user paces; they decide whether to ship-with-known-gap or revise.
 
+### Cross-skill flag marker (F6 — load-bearing for /verify Step 3.5)
+
+When this Step 6.5 surfaces *any* of the following, you MUST also write a flag marker file so `/verify` can pause the auto-ship chain:
+
+- Self-reference grep #1, #2, or #3 returned a match outside the file you just edited
+- Behavioral self-check found a UI/integration gap and you're shipping anyway with the gap documented
+- A documented Risk-fallback was invoked during this run (the same trigger as the mandatory follow-up WIT)
+
+Write the marker as `.pk-work/<ISSUE-ID>.flags`, one human-readable line per flag:
+
+```bash
+mkdir -p .pk-work
+{
+  # one line per surfaced flag — examples:
+  echo "self-ref match: <FILE:LINE> contains '<ISSUE-ID>' outside edited file"
+  echo "behavioral gap: <component> renders but <affordance> not wired (shipping with gap)"
+  echo "risk-fallback R<N> invoked: <deferred scope> — follow-up WIT <NEW-WIT-ID>"
+} > .pk-work/${ISSUE_ID}.flags
+```
+
+`.pk-work/` is gitignored at the repo root (see `.gitignore`). Marker is per-issue so concurrent worktrees on different issues don't collide. `/verify` reads this file in its Step 3.5 flag enumeration and pauses auto-ship if any line is present.
+
+**Do not write an empty marker** — `/verify` treats file existence as "flags present." If Step 6.5 found nothing surface-worthy, do not create the file.
+
+**Marker lifecycle:** the file is consumed by `/verify` (read-only) and cleaned up by `pk done` when the worktree is removed. If you re-run `/work --resume <ISSUE-ID>`, overwrite the marker — don't append to a stale one.
+
 ### Anti-rationalization guard
 
 If the user asks during execution about visible state — *"is this correct?"*, *"why does it look like this?"*, *"shouldn't there be X here?"* — and provides a screenshot or describes what they see:


### PR DESCRIPTION
## Summary

**Canary-driven release.** One load-bearing skill behavior change (F6 — `/verify` pauses auto-ship when human-decision flags surface) plus a five-finding doc-polish bundle. All six items surfaced by a live v2.4.3.2 canary against Piper WIT-456 the same day.

The canary itself validated v2.4.3.2's headline UAT-gate feature end-to-end (P1, P12, P13) and v2.3.3's skip-backward-transition guard in production (P15). **12 passing signals, 6 fixes, 0 methodology rework.**

Full canary log: [`Logs/Sessions/2026-05-14_0838.md`](./Logs/Sessions/2026-05-14_0838.md) — structured P/F findings tally + moment-by-moment observations.

## Commits

- `b247cff` — `feat(verify): pause auto-ship when human-decision flags present (F6)` — load-bearing
- `16e69ac` — `fix(skills): canary doc-polish bundle (F1, F7, F8, F10, F11)` — doc-tier
- `1dca9ee` — `chore(release): v2.4.3.3` — PK_VERSION + CHANGELOG + constitutional stamps

## What changed (one-liners — see CHANGELOG.md for full rationale)

**F6 — `/verify` Step 3.5 flag enumeration (skill behavior).** Auto-ship now requires Pass **AND** zero flags **AND** `--auto-ship`. Flags: migration files in diff · QA Pass with non-empty omissions/scope-creep/bugs · `--qa` forced by user · `/work` advisory marker (`.pk-work/<ID>.flags`). Auto-chain stays a feature when nothing is surfaced.

**F1 — `bin/pk pk_config` → `pk config`** in `/work` skill (the actual subcommand exposed by `bin/pk`; `pk_config` is an internal shell function only reachable when sourced).

**F7 — Test command discipline preamble** in `/work` Step 5 — prefer AC-stated test command verbatim before improvising.

**F8 — `pk branch` fresh-worktree dep-install hint** when `package.json` exists but `node_modules/` doesn't. Lockfile detection picks pnpm | yarn | npm.

**F10 — `/pr-fix` Phase 6.6** pre-documents the expected external-action security warning so workers don't improvise transparency notes.

**F11 — `pk done` + `/pk-exit` ordering hints** — `pk done` help says "run from parent; /pk-exit first"; /pk-exit description says "run before pk done".

## Stamps bumped (Release Checklist compliance)

- [x] `PK_VERSION` 2.4.3.2 → 2.4.3.3 in `bin/pk:32`
- [x] `RUNBOOK.md` sync-example line bumped to `v2.4.3.3`
- [x] Constitutional doc stamps (method.md, RUNBOOK.md, GUIDE.md) → v2.4.3.3 with today's timestamp
- [x] CHANGELOG.md v2.4.3.3 section added at top
- [x] PR title contains `v2.4.3.3` → auto-tag-release workflow will tag the merge commit

## Test plan

- [ ] Merge via "Create a merge commit" (squash disabled repo-wide per v2.2.0+ policy)
- [ ] Verify auto-tag-release workflow fires; tag `v2.4.3.3` appears on merge commit
- [ ] In Piper (next session): `./scripts/sync-method.sh v2.4.3.3` — pulls the new docs + skills
- [ ] In Piper: verify `pk branch <ID>` emits the F8 fresh-worktree install hint
- [ ] In Piper: verify `/work` no longer crashes on the F1 `bin/pk pk_config` call (will use `pk config` now)
- [ ] First Piper feature with a migration in scope: verify F6 flag gate pauses `/verify` correctly

## Out of scope (deferred to v2.4.3.4)

**F12** — `pk next` should honor `blockedBy` edges. Surfaced this session during Piper IMPLEMENTATION-PLAN ↔ pk next sync orchestration (where 9 Wave 8S Approved WITs had to be state-choreographed to On Deck because `pk next` couldn't see the blockedBy edges). Operationally fixed Piper-side today; proper Pipekit feature fix in next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)