### PR TITLE
docs(strategy-sync): reframe fresh-chat as stage isolation (4.8 clarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ---
 
+## Unreleased
+
+**`/strategy-sync` fresh-chat → stage-isolation framing** (`skills/10-strategy-sync/skill.md`)
+- Aligned the fresh-chat requirement with v2.7.0-rc2's `method.md` stage-isolation reframe: clarified it's *deliberate isolation* (an agent that watched the build can't independently diff shipped-reality vs. the docs), **not** a context-window workaround — a 1M window doesn't relax it because the risk is contaminated judgment, not lost memory. Wording only, no behavior change. Surfaced by the Opus 4.8 rollout review.
+
+---
+
 ## v2.7.0-rc2 — 2026-05-31
 
 > **Opus 4.8 framing audit — docs reframed, one handoff slimmed, nothing lost.** An impact audit of Pipekit's artifacts against Opus 4.8 (1M context window + harness-persistent memory) found that the persistence layer those capabilities would obsolete was *already pruned in the 4.7 cycle* (`NEXT.md` retired v2.1.0, bash Stop hook retired, `Session_Management_SOP.md` already 1M-aware). No artifact was REDUNDANT-delete. The real finding was framing rot: a few docs still justified discipline as a small-window workaround. These edits correct the *why* without changing the rule, refresh the external prompt-engineering snapshot to 4.8, codify a durable-vs-ephemeral split for handoff docs (git history holds any removed runbook), and harden `pr-fix` against 4.8 recall loss (the one enforcement skill that suppressed findings at the find stage).

--- a/skills/10-strategy-sync/skill.md
+++ b/skills/10-strategy-sync/skill.md
@@ -5,7 +5,7 @@ description: Update Strategy docs to reflect what actually shipped. Use after a 
 
 # Strategy Sync Skill
 
-> **Fresh-chat check.** Strategy sync compares shipped reality to docs. Start a new conversation — recall of build decisions contaminates the diff. See `method.md` § Fresh-Chat Discipline.
+> **Stage-isolation check.** Strategy sync diffs *shipped reality* against the docs, so it must read both as documents — an agent that watched the build can't independently judge its own assumptions. Start a fresh conversation; recall of build decisions contaminates the diff. This is deliberate isolation, **not** a context-window workaround — a 1M window doesn't relax it, because the risk is contaminated judgment, not lost memory. See `method.md` § Fresh-Chat Discipline.
 
 You are a documentation synchronizer. Your job is to update Strategy docs to reflect what was actually built. Read `method.config.md` for project context. You close the documentation loop so that anyone reading the Strategy docs understands the product as it exists today — not just as it was originally envisioned.
 


### PR DESCRIPTION
Optional polish surfaced by the Opus 4.8 rollout review of `/strategy-sync`.

Reframes the skill's fresh-chat requirement as **deliberate stage isolation** rather than a context-window workaround: an agent that watched the build can't independently diff shipped-reality vs. the docs, so a 1M window does not relax it (the risk is contaminated judgment, not lost memory). Aligns with the v2.7.0-rc2 `method.md` reframe.

**Wording only — no behavior change.** Lands as `## Unreleased`, folds into the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)