### PR TITLE
chore(release): v2.7.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
+**`pk branch` now symlinks nested per-app env files into the worktree** (`bin/pk`, `scripts/test-pk-env-links.sh`)
+- `pk branch` symlinked only a hardcoded **root-level** env list (`.env .env.local .envrc …`). In a monorepo, the browser client reads `apps/web/.env.local` — which is gitignored, so a fresh worktree never had it and fell back to the `*.example` placeholder (`NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co`), leaving the app with no real backend to talk to.
+- Extracted the linking into a testable `pk_link_env_files` helper and added pass (2): auto-discover every real nested env file (`.env` / `.env.local` / `.env.dev` / `.env.prod`) in the parent and symlink it at the same relative path. Exact-name match (never `*.example`), pruning `node_modules` / `.git` / `.worktrees`. Idempotent; never clobbers a real file already in the worktree.
+- **Auto-discover, not config:** a `method.config.md` env-link list was considered and rejected — the failure was that the need was *implicit* and nobody enumerated it; a config list reintroduces the same "forgot to configure it" footgun. Discovery mirrors parent reality with zero setup, so new monorepo apps are picked up automatically.
+- **Recovery for existing worktrees:** the worktree-exists path in `pk branch` falls through to the symlink step, so re-running `pk branch <ID>` (idempotent) backfills the missing links into a worktree created before this fix.
+- New `scripts/test-pk-env-links.sh` exercises the real helper (sources `bin/pk`): real-value link, `.example` exclusion, nested depth, `node_modules` prune, idempotency, no-clobber.
+
 **`/strategy-sync` fresh-chat → stage-isolation framing** (`skills/10-strategy-sync/skill.md`)
 - Aligned the fresh-chat requirement with v2.7.0-rc2's `method.md` stage-isolation reframe: clarified it's *deliberate isolation* (an agent that watched the build can't independently diff shipped-reality vs. the docs), **not** a context-window workaround — a 1M window doesn't relax it because the risk is contaminated judgment, not lost memory. Wording only, no behavior change. Surfaced by the Opus 4.8 rollout review.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
+**`/verify` migration flag now carries a verdict, not a bare pointer** (`skills/verify/skill.md`)
+- Step 6 Flag check A previously detected migration files in the diff and surfaced a bare `FLAG: … review for irreversibility, RLS, search_path` — handing the user a raw `git show` to review themselves, the exact analysis the skill exists to perform. It now spawns a review subagent (`pr-review-toolkit:code-reviewer`, fallback `general-purpose`) that applies `/pr-security-review`'s migration rubric (M1–M8, plus the RLS / SECURITY DEFINER / GRANT rubrics when the diff body contains those patterns), writes `migration-review.md`, and the flag carries the resulting **Hold/Approve verdict**. `reality-check.md` gained a `## Migration review` section that inlines it.
+- Runs on **every tier** (migrations are high-stakes regardless of tier) and is complementary to Step 5's generic antagonistic pass — that lens finds "what's wrong"; this one returns a structured verdict against named rubric IDs.
+- A `Hold` verdict pauses auto-ship via the flag but does **not** auto-downgrade `/verify` status to NEEDS WORK — consistent with how antagonistic findings and every other flag behave; classification stays the user's RECONCILE step. The human gate is unchanged in spirit (migrations always pause for a human eye), changed in substance: the user now approves `Hold: M3 missing backfill` or `Approve — no findings` instead of a `git show` they were never positioned to act on.
+
 **`/strategy-sync` fresh-chat → stage-isolation framing** (`skills/10-strategy-sync/skill.md`)
 - Aligned the fresh-chat requirement with v2.7.0-rc2's `method.md` stage-isolation reframe: clarified it's *deliberate isolation* (an agent that watched the build can't independently diff shipped-reality vs. the docs), **not** a context-window workaround — a 1M window doesn't relax it because the risk is contaminated judgment, not lost memory. Wording only, no behavior change. Surfaced by the Opus 4.8 rollout review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**v2.7.0-rc3** — Last updated: 2026-05-31 19:01  *(`/pr-fix` gains two dependency-free historical finders — git-blame regression detection + prior-PR-comment reapplication — running alongside the pr-review-toolkit specialists, with a historical-corroboration confidence boost; `pr-review-toolkit` promoted to a user-scope managed dependency via new `/pipekit-update` Phase P. Carries forward rc2: pluggable `/pr-fix` engine + two-axis severity×confidence triage + Opus 4.8 framing audit; rc1: discipline substrate, source-authority hierarchy, evidence-gated `/verify`, `pk ship` hard-fail on missing `verify-complete.md`)*
+**v2.7.0-rc4** — Last updated: 2026-06-02 19:40  *(`/verify` migration flag now self-reviews — spawns the `/pr-security-review` migration rubric in a subagent and carries a Hold/Approve verdict instead of punting a raw `git show` to the human; `pk branch` auto-discovers and symlinks nested per-app env files into the worktree (monorepo `apps/web/.env.local`) so fresh worktrees stop coming up on the `*.example` placeholder. Carries forward rc3: `/pr-fix` historical finders + `pr-review-toolkit` managed dependency; rc2: pluggable `/pr-fix` engine + two-axis severity×confidence triage + Opus 4.8 framing audit; rc1: discipline substrate, source-authority hierarchy, evidence-gated `/verify`, `pk ship` hard-fail on missing `verify-complete.md`)*
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v2.7.0-rc3** — Last updated: 2026-05-31 19:01  *(no daily-flow changes; `/pr-fix` gained git-blame + prior-PR-comment historical finders, `/pipekit-update` gained plugin-dependency Phase P — see GUIDE.md; sync-method.sh example bumped to v2.7.0-rc3)*
+**v2.7.0-rc4** — Last updated: 2026-06-02 19:40  *(no daily-flow changes; `/verify` migration flag self-reviews via subagent + `pk branch` links nested per-app env files — see GUIDE.md / CHANGELOG; sync-method.sh example bumped to v2.7.0-rc4)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -11,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v2.7.0-rc3             (or latest tag)
+1. ./scripts/sync-method.sh v2.7.0-rc4             (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: backend, integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)

--- a/bin/pk
+++ b/bin/pk
@@ -556,6 +556,35 @@ pk_worktree_path() {
   echo "$root/.worktrees/${id}"
 }
 
+# Symlink parent env files into a worktree (idempotent). Two passes:
+#   (1) Root-level config + env files — the historical set.
+#   (2) Nested per-app env files (monorepo: apps/web/.env.local, packages/*/.env).
+# A fresh worktree checks out tracked files only; gitignored env files live in
+# the parent and never appear here, so the app falls back to its *.example
+# placeholder (e.g. NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co) and the
+# browser client has no real backend to talk to. Pass (2) mirrors every real
+# nested env file at the same relative path. Exact-name match (never *.example),
+# pruning node_modules/.git/.worktrees so we never recurse into a dependency
+# tree or a sibling worktree.
+pk_link_env_files() {
+  local root="$1" wt_path="$2" envf abs rel
+  for envf in .env .env.local .env.dev .env.prod .envrc .mcp.json .sentryclirc; do
+    if [ -f "$root/$envf" ] && [ ! -e "$wt_path/$envf" ]; then
+      ln -sf "$root/$envf" "$wt_path/$envf"
+    fi
+  done
+  while IFS= read -r abs; do
+    [ -n "$abs" ] || continue
+    rel="${abs#"$root"/}"
+    case "$rel" in */*) ;; *) continue ;; esac   # root-level handled above
+    if [ ! -e "$wt_path/$rel" ]; then
+      mkdir -p "$wt_path/$(dirname "$rel")"
+      ln -sf "$abs" "$wt_path/$rel"
+    fi
+  done < <(find "$root" \( -name node_modules -o -name .git -o -name .worktrees \) -prune \
+             -o -type f \( -name .env -o -name .env.local -o -name .env.dev -o -name .env.prod \) -print 2>/dev/null)
+}
+
 # Slugify issue title — lowercase, replace non-alnum with -, collapse, trim,
 # keep first 3 words. Short slugs keep status bars and worktree paths sane.
 # Stop words removed up-front (and, the, of, for, in, on, to, with) so the
@@ -981,12 +1010,8 @@ cmd_branch() {
     fi
   fi
 
-  # Symlink env files (idempotent)
-  for envf in .env .env.local .env.dev .env.prod .envrc .mcp.json .sentryclirc; do
-    if [ -f "$root/$envf" ] && [ ! -e "$wt_path/$envf" ]; then
-      ln -sf "$root/$envf" "$wt_path/$envf"
-    fi
-  done
+  # Symlink env files from the parent (root-level + nested per-app). Idempotent.
+  pk_link_env_files "$root" "$wt_path"
 
   # Auto-allow direnv when .envrc was symlinked (v2.6.0.1). Direnv treats
   # the worktree path as a new .envrc and blocks it until allowed — but

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.7.0-rc3"
+PK_VERSION="2.7.0-rc4"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/scripts/test-pk-env-links.sh
+++ b/scripts/test-pk-env-links.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# test-pk-env-links.sh — regression test for pk_link_env_files (pk branch).
+#
+# Guards the worktree-env-linking contract that `pk branch` relies on:
+#   - root-level env/config files are symlinked into the worktree (historical)
+#   - NESTED per-app env files (monorepo apps/web/.env.local, packages/*/.env)
+#     are symlinked too — the gap that left fresh worktrees reading the
+#     *.example placeholder (NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co)
+#     so the browser client had no backend to talk to
+#   - *.example placeholders are NEVER linked (exact-name match)
+#   - node_modules / .git / .worktrees are pruned (no dep-tree or sibling-worktree recursion)
+#   - the operation is idempotent (re-run is a no-op, never errors)
+#
+# Exercises the REAL helper by sourcing bin/pk — not a re-implemented copy, so
+# the test fails if the shipped logic drifts.
+#
+# Run: bash scripts/test-pk-env-links.sh   (exit 0 on pass, 1 on any failure)
+
+set -uo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+fail=0
+pass=0
+ok()   { pass=$((pass + 1)); printf '  ok  %s\n' "$1"; }
+nope() { fail=$((fail + 1)); printf '  FAIL %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; }
+
+# bin/pk skips main() when sourced (BASH_SOURCE guard at its tail), so sourcing
+# exposes its helpers without dispatching a subcommand. It does run
+# `set -euo pipefail` at top level, which flips errexit on in this harness —
+# clear it afterward so our intended `set -uo pipefail` (no -e) mode holds.
+# shellcheck disable=SC1091
+source "$repo_root/bin/pk"
+set +e
+
+if ! command -v pk_link_env_files >/dev/null 2>&1; then
+  echo "FAIL: pk_link_env_files not defined after sourcing bin/pk" >&2
+  exit 1
+fi
+
+echo "pk_link_env_files: root + nested env symlinking into a fresh worktree"
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+root="$stage/repo"
+wt="$root/.worktrees/RS-1-x"
+
+# Parent repo: real (gitignored) env files, placeholders, and noise.
+mkdir -p "$root/apps/web" "$root/packages/db" "$root/node_modules/pkg" "$root/.git"
+printf 'NEXT_PUBLIC_SUPABASE_URL=https://real.supabase.co\n' > "$root/apps/web/.env.local"
+printf 'NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co\n'  > "$root/apps/web/.env.local.example"
+printf 'DB=postgres://real\n'                                 > "$root/packages/db/.env"
+printf 'SHOULD_NOT_LINK=1\n'                                  > "$root/node_modules/pkg/.env"
+printf 'ROOT=1\n'                                             > "$root/.env.local"
+
+# Fresh worktree: tracked dirs only, no gitignored env files present.
+mkdir -p "$wt/apps/web" "$wt/packages/db"
+
+pk_link_env_files "$root" "$wt"
+
+# Nested real env file linked to the REAL value (the core regression).
+if [ -L "$wt/apps/web/.env.local" ] && \
+   [ "$(cat "$wt/apps/web/.env.local")" = "NEXT_PUBLIC_SUPABASE_URL=https://real.supabase.co" ]; then
+  ok "nested apps/web/.env.local linked to real value"
+else
+  nope "nested apps/web/.env.local linked to real value" "got: $(readlink "$wt/apps/web/.env.local" 2>/dev/null || echo MISSING)"
+fi
+
+# Arbitrary nested depth.
+[ -L "$wt/packages/db/.env" ] && ok "nested packages/db/.env linked" || nope "nested packages/db/.env linked"
+
+# *.example must never be linked.
+[ ! -e "$wt/apps/web/.env.local.example" ] && ok ".example placeholder not linked" || nope ".example placeholder not linked"
+
+# node_modules pruned.
+[ ! -e "$wt/node_modules/pkg/.env" ] && ok "node_modules pruned" || nope "node_modules pruned"
+
+# Root-level file handled by pass (1).
+[ -L "$wt/.env.local" ] && ok "root .env.local linked" || nope "root .env.local linked"
+
+# Idempotency: a second run must not error and must not change anything.
+before=$(cd "$wt" && find . -name '.env*' | sort)
+if pk_link_env_files "$root" "$wt" 2>/dev/null; then
+  after=$(cd "$wt" && find . -name '.env*' | sort)
+  [ "$before" = "$after" ] && ok "idempotent re-run (no change, no error)" || nope "idempotent re-run" "set changed"
+else
+  nope "idempotent re-run" "second invocation returned nonzero"
+fi
+
+# Does NOT clobber a real file already present in the worktree, even when the
+# parent holds a (different) file at the same relative path.
+mkdir -p "$wt/apps/api" "$root/apps/api"
+printf 'PREEXISTING=1\n' > "$wt/apps/api/.env.local"
+printf 'PARENT=1\n'      > "$root/apps/api/.env.local"
+pk_link_env_files "$root" "$wt"
+if [ ! -L "$wt/apps/api/.env.local" ] && [ "$(cat "$wt/apps/api/.env.local")" = "PREEXISTING=1" ]; then
+  ok "pre-existing worktree env file not clobbered"
+else
+  nope "pre-existing worktree env file not clobbered" "got: $(cat "$wt/apps/api/.env.local" 2>/dev/null)"
+fi
+
+echo ""
+printf 'passed: %d   failed: %d\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/skills/verify/skill.md
+++ b/skills/verify/skill.md
@@ -383,20 +383,82 @@ After the gate, QA, and antagonistic review (if run), enumerate any **human-deci
 
 Run these checks in order. Surface every match. For `TIER != quick`, also append each surfaced flag as a `FLAG: ...` line to `$VERIFY_DIR/evidence.txt`.
 
-### Flag check A — Migration files in diff
+### Flag check A — Migration files in diff (auto-reviewed)
 
 ```bash
 MIGRATION_DIR=$(pk config "Migration dir" "")
+MIGRATION_FILES=""
 if [ -n "$MIGRATION_DIR" ]; then
   MIGRATION_FILES=$(git diff --name-only "origin/$INTEGRATION...HEAD" -- "$MIGRATION_DIR" 2>/dev/null)
-  if [ -n "$MIGRATION_FILES" ]; then
-    echo "FLAG: migration files in diff — review for irreversibility, RLS, search_path"
-    [ "$TIER" != "quick" ] && printf 'FLAG: migration files in diff: %s\n' "$(echo "$MIGRATION_FILES" | tr '\n' ' ')" >> "$VERIFY_DIR/evidence.txt"
-  fi
 fi
 ```
 
-Migrations are high-stakes and always warrant a human eye, regardless of QA verdict. Even a "trivial column add" can ship a destructive default backfill or a missing `search_path` on a `SECURITY DEFINER` function.
+If `MIGRATION_FILES` is non-empty, **never surface a bare pointer.** Migrations are high-stakes and always warrant a human eye regardless of QA verdict — but the human's job is to *approve a verdict*, not to perform the review. A "trivial column add" can ship a destructive default backfill or a missing `search_path` on a `SECURITY DEFINER` function, and handing the user a raw `git show` asks them to catch exactly the class of issue this skill exists to catch. So when migration files are present, spawn a review subagent and attach its verdict to the flag.
+
+#### Spawn the migration-review subagent
+
+Fires whenever `MIGRATION_FILES` is non-empty, on **every tier** (migrations are high-stakes regardless of tier). Complementary to Step 5's antagonistic review — that pass is a generic "find what's wrong" lens; this one applies the structured migration rubric and returns a Hold/Approve verdict against named rubric IDs.
+
+Backend-pluggable:
+- prefer `subagent_type: "pr-review-toolkit:code-reviewer"` (the same specialist `/pr-security-review` uses)
+- fall back to `general-purpose` if the toolkit isn't installed (warn, mirroring the QA fallback in the Failure model)
+
+Configure `allowed-tools: Read, Bash, Write`, `model: opus`. Use the Task tool with:
+
+- `description: "Migration review of <ISSUE-ID>"`
+- Prompt:
+  ```
+  Write target: <VERIFY_DIR>/migration-review.md
+    (if $VERIFY_DIR is unset — tier:quick — skip the file and return the verdict block inline).
+    Return only a one-line confirmation: "Migration review written: <verdict>".
+
+  Apply the migration rubric from the /pr-security-review skill. Read it first — it lives at
+  `.claude/skills/pr-security-review/skill.md` (consuming projects) or
+  `skills/pr-security-review/skill.md` (Pipekit itself) — read § "Migration rubric (M1–M8)"
+  and apply every item. ALSO apply, only when the diff body contains the triggering pattern:
+    - RLS rubric (R1–R6)            — diff contains CREATE POLICY / ALTER POLICY / ENABLE ROW LEVEL SECURITY
+    - SECURITY DEFINER rubric (S1–S8) — diff contains SECURITY DEFINER
+    - GRANT/REVOKE rubric (G1–G3)   — diff contains GRANT / REVOKE
+  If you cannot read the skill file, fall back to checking these categories directly:
+  idempotency; destructive DDL without a data-migration plan; NOT NULL columns without
+  default/backfill; FK ON DELETE behavior; RLS enablement + at least one policy;
+  search_path on SECURITY DEFINER functions; type regeneration present in the diff;
+  timestamp ordering of the migration filename.
+
+  Anchor-emit discipline: cite every finding as `<file>:<line>`. No vague refs.
+
+  Write exactly this shape:
+
+  ## Migration review — <ISSUE>
+
+  **Verdict:** Hold | Approve with notes | Approve
+  **Files:** <migration files reviewed>
+  **Findings:** N Critical · N High · N Medium · N Low · N Nit
+
+  | # | Sev | Rubric | File:line | Finding | Remediation |
+  |---|---|---|---|---|---|
+  | 1 | High | M3 | `<file>:<line>` | <issue> | <action> |
+
+  (or, if clean: "No issues found after thorough examination — Verdict: Approve.")
+
+  Verdict rule: any Critical or High finding → Hold. Medium/Low/Nit only → Approve with notes.
+  No findings → Approve.
+
+  ARTIFACT:
+  <output of: git diff "origin/$INTEGRATION...HEAD" -- "$MIGRATION_DIR">
+
+  CONTRACT:
+  <full Linear issue description — the AC list>
+  ```
+
+After the subagent returns, read `<VERIFY_DIR>/migration-review.md` (or the inline block on tier:quick), grep the **Verdict:** line into `MIGRATION_VERDICT`, then surface the flag carrying the verdict — never a bare pointer:
+
+```bash
+echo "FLAG: migration review — ${MIGRATION_VERDICT} — see migration-review.md ($(echo "$MIGRATION_FILES" | tr '\n' ' '))"
+[ "$TIER" != "quick" ] && printf 'FLAG: migration review: %s — files: %s\n' "$MIGRATION_VERDICT" "$(echo "$MIGRATION_FILES" | tr '\n' ' ')" >> "$VERIFY_DIR/evidence.txt"
+```
+
+The verdict — `Hold` included — is surfaced for the user to RECONCILE; it does **not** auto-downgrade the `/verify` status, consistent with how antagonistic findings and every other flag behave (Step 8). The migration flag still pauses auto-ship (Step 9). The only thing that changed: the user now approves `Hold: M3 missing backfill on line 14` or `Approve — no findings`, instead of a `git show` they were never positioned to act on.
 
 ### Flag check B — QA Pass with non-empty sub-sections
 
@@ -490,6 +552,10 @@ For `TIER != quick`, render `$VERIFY_DIR/reality-check.md` with this structure:
 ## Antagonistic review
 
 <inline contents of `$VERIFY_DIR/adversarial.md`, or "Not run (tier:<TIER>, no --review).">
+
+## Migration review
+
+<inline contents of `$VERIFY_DIR/migration-review.md`, or "No migration files in diff.">
 
 ## Flags surfaced
 


### PR DESCRIPTION
## v2.7.0-rc4

Two gates that were punting work back to the human now do the work and present a verdict.

### What changed

**`/verify` migration flag now carries a verdict, not a bare pointer** (`skills/verify/skill.md`)
- Flag check A used to surface a bare `FLAG: migration files in diff — review …`, handing the user a raw `git show`. It now spawns a review subagent (`pr-review-toolkit:code-reviewer`, fallback `general-purpose`) that applies `/pr-security-review`'s migration rubric (M1–M8 + RLS/SECURITY DEFINER/GRANT when present), writes `migration-review.md`, and the flag carries a **Hold/Approve verdict**. `reality-check.md` gained a `## Migration review` section.
- Runs on every tier. A `Hold` pauses auto-ship but does not auto-downgrade `/verify` status — classification stays the user's RECONCILE step.

**`pk branch` now symlinks nested per-app env files into the worktree** (`bin/pk`, `scripts/test-pk-env-links.sh`)
- Only root-level env files were linked, so monorepo worktrees came up reading `apps/web/.env.local.example` (`NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co`) with no real backend.
- New testable `pk_link_env_files` helper auto-discovers and links every real nested env file at the same relative path — exact-name (never `*.example`), pruning `node_modules`/`.git`/`.worktrees`, idempotent, no-clobber. Auto-discover over config so the implicit need can't go unconfigured again.
- Re-running `pk branch <ID>` backfills links into worktrees created before this fix.

### Release bookkeeping
- `PK_VERSION` → `2.7.0-rc4`; CHANGELOG `Unreleased` rolled into the `v2.7.0-rc4` section; `CLAUDE.md` + `RUNBOOK.md` stamps and the `sync-method.sh` example bumped.

### Tests
- All pk suites green: `test-pk-env-links` (7), `test-pk-config` (14), `test-pk-v2.4.3` (9), `test-pk-promote` (27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)