### PR TITLE
chore(sync): gitignore transient .sync-changelog.md by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
-_Nothing yet._
+- **`sync-method.sh` now gitignores `pipekit/.sync-changelog.md`** (idempotent self-heal). The sync changelog is regenerated on every run, so committing it was pure history noise — it had been landing in consuming-project sync commits. The sync now appends the ignore line to `.gitignore` if missing; the method content itself stays committed (worktrees check out tracked files only, so skills/rules/templates must be tracked — only this transient artifact is ignored).
 
 ---
 

--- a/scripts/sync-method.sh
+++ b/scripts/sync-method.sh
@@ -625,6 +625,15 @@ CHLOG
 
   echo ""
   echo "Changelog written to: pipekit/.sync-changelog.md"
+
+  # Self-heal: ensure the transient changelog is gitignored. It's regenerated
+  # on every sync, so committing it is pure history noise (the method content
+  # itself stays committed — worktrees + reproducibility depend on that).
+  GITIGNORE="$PROJECT_ROOT/.gitignore"
+  if [ -f "$GITIGNORE" ] && ! grep -qxF 'pipekit/.sync-changelog.md' "$GITIGNORE"; then
+    printf '\n# Pipekit sync changelog (regenerated each sync; not version-controlled)\npipekit/.sync-changelog.md\n' >> "$GITIGNORE"
+    echo "Added pipekit/.sync-changelog.md to .gitignore"
+  fi
 fi
 
 # Clean up snapshot


### PR DESCRIPTION
Makes `sync-method.sh` stop committing `pipekit/.sync-changelog.md` in every consuming project.

The sync changelog is regenerated on each run, so committing it is pure history noise — it had been landing in sync commits (incl. the v2.7.1 syncs into Piper + SiteLine, since fixed manually). The sync now self-heals: it appends `pipekit/.sync-changelog.md` to `.gitignore` if missing (idempotent).

Deliberately narrow — only the transient artifact is ignored. The method content (`pipekit/`, `.claude/skills/`, `.claude/rules/`) stays committed because `pk branch` worktrees check out tracked files only, and skills read `pipekit/templates/` at runtime; gitignoring those would break every worktree.

No version bump — rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)