### PR TITLE
feat(skill): portable /financial-review (framework + checks file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
+- **New portable skill `/financial-review`** — periodic financial-accuracy review for finance/calculation-heavy projects: cross-layer parity audit (DB view ↔ server/client calc ↔ UI footer; delta > tolerance = finding), baseline tests, parallel sub-agent audit, regression scan, severity-ranked report, and a recurring-WIT Linear lifecycle (In Progress → In Review → Done, transitions by **state name** via `pk` — no hardcoded UUIDs). Generalized from SiteLine's project-specific version using the **framework + checks-file** split: the skill ships the discipline + report shape; each project supplies its concrete checks (test cmd, calc files, DB-integrity SQL, parity formulas) in `resources/financial-review-checks.md`, scaffolded from `templates/financial-review-checks.template.md`. No-op on projects without a checks file. New `method.config.md` keys: `Financial review WIT` (blank disables the Linear lifecycle) + `Financial review checks` (path). Indexed in `Skills_SOP.md`.
 - **`sync-method.sh` now gitignores `pipekit/.sync-changelog.md`** (idempotent self-heal). The sync changelog is regenerated on every run, so committing it was pure history noise — it had been landing in consuming-project sync commits. The sync now appends the ignore line to `.gitignore` if missing; the method content itself stays committed (worktrees check out tracked files only, so skills/rules/templates must be tracked — only this transient artifact is ignored).
 
 ---

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -160,6 +160,8 @@ Keys consumed by `bin/pk` and the `/work` + `/verify` skills. All have sensible 
 | **Spec approved state** | Linear state name | `Approved` | `pk spec-cycle` (transitions issue to this state on a Pass verdict) |
 | **Self-reference check** | `enabled` \| `disabled` | `disabled` | `pk verify` — runs `scripts/check-no-self-references.sh`; fails if current branch's source still references its own ticket ID (e.g. `RS-29`) in any file the branch did not edit. Catches predecessor-placeholder integration misses (RS-29 rs-vault, 2026-05-05). Bypass on a per-run basis with `AGREED_PLACEHOLDER=1 pk verify` after surfacing matches in the hand-off summary. |
 | **Source root** | path | `src/` | `scripts/check-no-self-references.sh` (where to grep) |
+| **Financial review WIT** | Linear issue id, or blank | (blank) | `/financial-review` — recurring WIT moved In Progress → In Review → Done each cycle; **blank disables the Linear lifecycle** (run + report only). Finance/calculation-heavy projects only. |
+| **Financial review checks** | path | `resources/financial-review-checks.md` | `/financial-review` — project checks file (test cmd, calc files, DB-integrity SQL, parity formulas). Scaffold from `pipekit/templates/financial-review-checks.template.md`. |
 
 ### Example (rs-vault)
 

--- a/skills/financial-review/skill.md
+++ b/skills/financial-review/skill.md
@@ -1,0 +1,150 @@
+---
+name: financial-review
+description: Periodic financial-accuracy review for finance/calculation-heavy projects — cross-layer parity audit (DB view ↔ server calc ↔ UI), severity-ranked report, recurring-WIT lifecycle. Portable framework; concrete checks live in a per-project checks file. Different from /security-review (security) and /pr-security-review (PR-scoped).
+---
+
+# Financial Review
+
+You are a senior finance engineer conducting a periodic **financial-accuracy review**: verifying that the same monetary figure agrees across every layer that computes it (database view, server/client calculation, UI footer), that the calculation tests pass, and that recent changes haven't introduced silent drift.
+
+This is the **portable framework**. The concrete, project-specific checks (which files hold the math, which SQL proves DB integrity, which formulas to compare) live in a **project checks file** you read at runtime — never hardcode them here. A non-finance project simply won't have a checks file, and won't invoke this skill.
+
+Different from `/security-review` (repo-wide security audit) and `/pr-security-review` (PR-scoped security). This one is domain-specific to money math and is periodic, not PR-triggered.
+
+## Triggers
+
+- `/financial-review`
+- "run financial review", "financial accuracy check"
+
+## Config (read from `method.config.md`)
+
+| Key | Purpose | Default |
+|-----|---------|---------|
+| **Project display name** | Used in the report header + comments | (project name) |
+| **Financial review WIT** | Recurring Linear issue id for the review (e.g. `WIT-101`). **Blank → skip the Linear lifecycle entirely** (just run + report). | (blank) |
+| **Financial review checks** | Path to the project checks file | `resources/financial-review-checks.md` |
+| **Reports path** | Where to write the review report | `Reports/` |
+| **Spec ready state** / state names | Linear state names for transitions (see below) | per board |
+
+**Linear transitions are by state NAME via `pk`**, never hardcoded UUIDs: use `pk_linear_set_state "<WIT>" "<State>"` (or the project's Linear MCP with a name lookup). The three states this skill moves through are **In Progress**, **In Review**, **Done** — they must exist in the team's workflow.
+
+## Step 0 — Load the checks file (gate)
+
+Read the checks file at `Financial review checks` (default `resources/financial-review-checks.md`).
+
+- **If it doesn't exist**, STOP and tell the user:
+  > No financial-review checks file found at `<path>`. This skill is the framework; the project supplies the checks. Scaffold one from `pipekit/templates/financial-review-checks.template.md` (copy it to `<path>` and fill in your test command, calculation files, DB-integrity queries, and parity formulas), then re-run.
+  Offer to scaffold it from the template.
+
+The checks file defines, for this project: the **test command**, the **calculation source files**, the **DB-integrity queries**, the **client↔server parity formulas**, the **margin/footer checks**, and the **regression-watch paths**. Everything below executes *that project's* checks — this skill provides the discipline and the report shape, the checks file provides the substance.
+
+## Step 1 — Open the review (Linear lifecycle)
+
+If `Financial review WIT` is set:
+- Move it to **In Progress**: `pk_linear_set_state "<WIT>" "In Progress"`
+- Post a comment: `"Starting financial accuracy review — {YYYY-MM-DD}"`
+
+If blank, skip — proceed straight to the audit and just produce the report.
+
+> Recurring-WIT note: for a recurring Linear issue, **Done** means "this cycle's review is complete"; Linear's recurrence re-opens it next cycle.
+
+## Step 2 — Read current state + baseline tests
+
+- Read the calculation source files named in the checks file (the source of truth for the math).
+- Find the previous report: `ls -t <Reports path>/Financial_Review_*.md 2>/dev/null | head -1` (for trend comparison).
+- Run the checks file's **test command**. If tests fail → **Critical** finding, surfaced immediately.
+
+## Step 3 — Cross-layer parity audit (parallel sub-agents)
+
+Run the checks file's audit groups as parallel read-only sub-agents. The canonical groups (each project's checks file fills in the specifics):
+
+1. **DB integrity** — run the checks file's SQL against the configured DB (via the project's DB MCP / `execute_sql`). Any row returned where a stored/view total disagrees with the recomputed total by more than the tolerance (default `> 0.01`) is a **Critical** discrepancy.
+2. **Client↔server parity** — compare the server/DB formulas (e.g. `GENERATED ALWAYS AS` columns, RPCs) against the client calculation implementation named in the checks file. A formula mismatch is **High** (UI shows a different number than the source of truth).
+3. **Margin / footer / derived metrics** — verify inline/derived calculations (margins, fees, contingency) per the checks file, including divide-by-zero guards and rounding accumulation.
+4. **Snapshot / version integrity** (if applicable) — verify version-comparison math and sign conventions per the checks file.
+
+Spawn these as independent sub-agents (they return findings; they do not fix). Each finding carries `file:line` or a query result as evidence.
+
+## Step 4 — Regression scan
+
+Run the checks file's regression-watch over recent history:
+```bash
+git log --oneline --since="7 days ago" -- <financial paths from checks file>
+```
+Flag any change touching financial logic for manual review.
+
+## Step 5 — Update Linear by findings
+
+If `Financial review WIT` is set:
+- **Critical or High findings:** move to **In Review**, post a comment summarizing findings + proposed fixes. Work each fix, posting a comment per fix with evidence. After all fixes verified, move to **Done**.
+- **Only Medium/Low, or clean:** proceed to the report; move to **Done** after it's written.
+
+If blank, skip transitions.
+
+## Step 6 — Generate the report
+
+Write `<Reports path>/Financial_Review_{YYYY-MM-DD}.md`:
+
+```markdown
+# Financial Accuracy Review — {YYYY-MM-DD}  ·  {Project display name}
+
+## Summary
+- **Status**: PASS / FAIL / WARNINGS
+- **Previous Review**: {date or "First review"}
+- **Tests Passed**: {X}/{Y}
+- **DB Integrity Checks**: {PASS/FAIL per check}
+
+## Unit Test Results
+{test output summary}
+
+## Database Integrity
+{per-check results — "PASS: no discrepancies" or the mismatching rows}
+
+## Client↔Server Parity
+{findings}
+
+## Margin / Footer / Derived
+{findings}
+
+## Snapshot / Version Integrity
+{findings, or "n/a"}
+
+## Recent Changes (Last 7 Days)
+{git log of financial-related changes}
+
+## Findings
+### Critical
+{list or "None"}
+### High
+{list or "None"}
+### Medium
+{list or "None"}
+### Low / Recommendations
+{list or "None"}
+
+## Known Gaps
+{carried from the checks file's known-gaps section + anything new}
+
+## Next Review Actions
+{specific items to check next cycle}
+```
+
+## Step 7 — Close + summarize
+
+- If `Financial review WIT` set: move to **Done**, post `"Review complete — {STATUS}. Report: <path>"`.
+- Present the user: overall status, discrepancy count, top findings by severity, comparison to the previous review, recommended actions.
+
+## Severity rubric
+
+- **Critical** — a stored/view figure disagrees with the recomputed aggregation: users see a wrong number.
+- **High** — client↔server formula mismatch: one surface shows a different total than the source of truth.
+- **Medium** — unhandled edge case (divide-by-zero, null markup, excluded items).
+- **Low** — code quality, missing test coverage, doc gaps.
+
+## Key principles
+
+1. **Numbers must match** — the same figure from the DB view, the calculation code, and the UI must agree; any delta beyond tolerance is a finding.
+2. **Evidence-based** — every finding cites a query result or `file:line`.
+3. **Regression-aware** — always check what changed recently.
+4. **Consistent** — run the same checks-file checklist every cycle so trends are comparable.
+5. **Framework here, checks in the project** — never hardcode a project's schema, paths, or WIT in this skill; they live in the checks file and `method.config.md`.

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -65,6 +65,7 @@ These skills work across any project that follows the method. They read `method.
 | `/pipekit-help` | Read project state, recommend next pipeline step | Anytime |
 | `/spec-validator` | Validate spec completeness | Stage 1: Spec |
 | `/security-review` | Periodic repo security audit (different from `/pr-security-review`) | Anytime |
+| `/financial-review` | Periodic financial-accuracy review for finance/calculation-heavy projects — cross-layer parity audit (DB view ↔ calc ↔ UI), severity-ranked report, recurring-WIT lifecycle. Portable **framework**; concrete checks live in a per-project checks file (`resources/financial-review-checks.md`, scaffolded from `templates/financial-review-checks.template.md`). No-op on projects without a checks file. | Anytime (domain: finance) |
 | `/skill-index` | Sync skill index after changes | Anytime |
 | `/task-processor` | Process Linear tasks systematically | Stage 2: Plan + Build |
 | `/pipekit-update` | Pull latest Pipekit from GitHub into project | Anytime |

--- a/templates/financial-review-checks.template.md
+++ b/templates/financial-review-checks.template.md
@@ -1,0 +1,108 @@
+# Financial Review Checks — {PROJECT}
+
+Project-specific checks consumed by the portable `/financial-review` skill. Copy this
+file to your project (default path `resources/financial-review-checks.md`, or set
+`Financial review checks` in `method.config.md`) and fill in every section for your
+schema and code. The skill supplies the discipline + report shape; this file supplies
+the substance. Keep it committed — it's project-owned, never overwritten by sync.
+
+> Examples below are drawn from a real finance platform (budgets → sections →
+> subsections → line items, with client + DB calculation layers). Replace them with
+> your own; delete what doesn't apply.
+
+---
+
+## Test command
+
+The calculation test suite that establishes the baseline. A non-zero exit is a **Critical** finding.
+
+```bash
+# EXAMPLE — replace:
+cd "$(git rev-parse --show-toplevel)" && npx jest tests/calculations.test.js --verbose
+```
+
+## Calculation source files
+
+The files the skill reads to understand the math (the source of truth + where it's recomputed).
+
+```
+# EXAMPLE — replace:
+src/app/js/utils/calculations.js     # client-side line-item math
+supabase/migrations/                 # GENERATED ALWAYS AS columns / RPCs (DB-side math)
+src/app/js/pages/budget-edit-main.js # inline margin / footer calculations
+tests/TEST_COVERAGE.md               # documented integrity checks + known issues
+```
+
+## DB integrity queries
+
+Run against the configured DB (your project's DB MCP / `execute_sql`). Each query should
+return **zero rows** on a healthy system; any returned row is a **Critical** discrepancy.
+Tolerance for float comparisons: `> 0.01` unless noted.
+
+```sql
+-- EXAMPLE Check 1 — stored/view total matches recomputed line-item sum
+-- (replace tables/columns with yours)
+SELECT p.id, p.name, pt.total_sum AS view_total, COALESCE(s.computed_total,0) AS computed_total
+FROM projects p
+JOIN project_totals pt ON pt.id = p.id
+LEFT JOIN LATERAL (
+  SELECT SUM(li.total) AS computed_total FROM line_items li WHERE li.project_id = p.id
+) s ON true
+WHERE ABS(COALESCE(pt.total_sum,0) - COALESCE(s.computed_total,0)) > 0.01;
+```
+
+```sql
+-- EXAMPLE Check 2 — child-level total matches its line items
+-- EXAMPLE Check 3 — derived rate (fee/tax/markup) drawn from the right source
+```
+
+## Client ↔ server parity
+
+The formulas to compare between the client implementation and the DB/server definition.
+A mismatch is **High**.
+
+```
+# EXAMPLE — replace with your formulas:
+subtotal = qty * unit_cost * multiplier
+tax      = subtotal * tax_pct
+total    = subtotal + tax
+# markup formats the client must match the DB on: 20%, -10%, +50, -200, =800, null
+```
+
+## Margin / footer / derived metrics
+
+Inline/derived calculations to verify (guards, rounding, base correctness). **Medium** unless
+they produce a user-visible wrong number (then **High**).
+
+```
+# EXAMPLE:
+margin = (out_total - in_total) / out_total * 100   # guard divide-by-zero
+fee base respects per-section include flags
+contingency applied to both internal and client-facing totals
+```
+
+## Snapshot / version integrity (optional)
+
+If the project has versioned snapshots / a version-comparison RPC, the math + sign
+conventions to verify. Delete this section if not applicable.
+
+## Regression-watch paths
+
+Paths the skill greps for changes in the last 7 days (any change here → manual review flag).
+
+```
+# EXAMPLE — replace:
+supabase/migrations/
+src/app/js/utils/calculations.js
+src/app/js/pages/budget-edit-main.js
+```
+
+## Known gaps
+
+Carried into every report's "Known Gaps" section so they're tracked, not rediscovered.
+
+```
+# EXAMPLE:
+- GP%/NP% computed inline in the footer, not as testable functions
+- No cash-flow model yet
+```


### PR DESCRIPTION
Imports SiteLine's `/financial-review` into Pipekit as a **portable** skill so it works on Piper and for other finance/calculation-heavy projects.

## Approach: framework + checks file
- **The skill** (`skills/financial-review/skill.md`) ships the *discipline*: cross-layer parity audit (DB view ↔ server/client calc ↔ UI footer; delta > tolerance = finding), baseline tests, parallel sub-agent audit, regression scan, severity-ranked report, and a recurring-WIT Linear lifecycle (In Progress → In Review → Done) — transitioned **by state name via `pk`**, not the hardcoded UUIDs the SiteLine original used.
- **Each project** supplies its concrete checks (test cmd, calc files, DB-integrity SQL, parity formulas) in `resources/financial-review-checks.md`, scaffolded from `templates/financial-review-checks.template.md`. No checks file → the skill is a no-op (clean for the many non-finance projects that sync Pipekit).
- New `method.config.md` keys: `Financial review WIT` (blank disables the Linear lifecycle) + `Financial review checks` (path). Indexed in `Skills_SOP.md`.

## Why portable, not hardcoded
SiteLine's original hardcoded its schema, file paths, WIT-101 + state UUIDs, and SQL — none portable. Pipekit is a general methodology repo, so the schema-specific substance moves to a project-owned checks file; the methodology is what ships.

## Follow-up (not in this PR)
- Wire SiteLine onto the framework (extract its real queries into a checks file; decide its WIT — the original's `WIT-101` + state UUIDs look cross-workspace, needs confirming).
- Author a Piper checks file against Piper's schema (Piper has a related `budget-review` to reconcile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)