### PR TITLE
chore(release): v2.8.0-rc2 — CI reviewer-trigger hardening + /pk-bug guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ _Nothing yet._
 
 ---
 
+## v2.8.0-rc2 — 2026-06-07
+
+> **Reviewer-trigger hardening + `/pk-bug` branch guard.** CI review templates now re-run on every push (self-healing) and carry a loud warning about the workflow-validation 401 that masquerades as a secrets failure; `/pk-bug` refuses to run its main-anchored phases from the wrong checkout. All fixes/docs — no new capability. Continues the rc cycle.
+
+- **`claude-review.yml` + `semgrep.yml` now trigger on `synchronize`** (every push to a Ready PR) in addition to `opened` + `ready_for_review`. A failed review — transient, or the workflow-validation 401 below — now self-heals on the next push instead of forcing a Draft → Ready re-flip to re-trigger. Per-push cost on `claude-review.yml` stays bounded: Draft PRs are exempt (the `triage` job's `draft == false` guard) and the **skip-on-trivial `triage` job** filters doc-only / <5-LOC pushes before the paid review runs. Semgrep is free (Community Rules), so it re-runs unconditionally on non-Draft pushes. Reverses the original `synchronize` omission (Piper WIT-463, 23-commit branch) now that the triage guard absorbs the cheap-push noise — and without it, a one-line workflow-file mistake (SiteLine POC-87) had no automatic recovery path.
+- **`claude-review.yml` hardened against the app-token-exchange 401.** `anthropics/claude-code-action` requires the workflow file on a PR to be byte-identical to the version on the default branch — a deliberate guard so a PR can't alter the reviewer that runs with the OAuth secret. Editing the file on a feature branch (even deleting a comment) fails the exchange with `401 Unauthorized - Workflow validation failed`. Added a prominent warning to the template header **and** `templates/ci/README.md`, including the load-bearing detail that `ANTHROPIC_API_KEY: empty` in the log is **normal under OAuth auth and not the cause** — scan for the 401 — plus the one-line restore fix (`git checkout origin/<default-branch> -- .github/workflows/<file>`). Anchor: SiteLine POC-87, 2026-06-07 (first misdiagnosed as a 1Password secret-load failure; the OAuth token had loaded fine).
+- **`/pk-bug` checkout guard.** Phases 1–4 are main-anchored: intake → reproduce → diagnose → the *failing regression test* are authored on the integration checkout, uncommitted, before Phase 4's `pk branch` cuts the worktree (off `origin/<integration>`). A test written on any other branch is orphaned by that handoff. Added a preflight guard that **STOPs with a redirect** when the skill is invoked from a feature branch or an existing worktree, with the escape hatch that resuming a past-Phase-4 bug by `<ISSUE-ID>` skips the guard. Phases 5–8 (post-worktree) are unaffected.
+
+---
+
 ## v2.8.0-rc1 — 2026-06-06
 
 > **New capability: portable `/financial-review`.** A finance/calculation-accuracy review skill, generalized from SiteLine's project-specific version so any finance project (Piper, SiteLine, other users) gets it via the framework + checks-file split. Plus a sync-noise self-heal. Minor bump for the new skill; cut as a release candidate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**v2.8.0-rc1** — Last updated: 2026-06-06 10:00  *(new portable `/financial-review` skill — finance/calculation-accuracy review via the framework + checks-file split, generalized from SiteLine; new config keys `Financial review WIT` + `Financial review checks`. Plus `sync-method.sh` self-heal gitignoring the transient `pipekit/.sync-changelog.md`. Carries v2.7.1: `templates/ci/linear-transition.yml` merge-driven Linear transition; and v2.7.0: enforcement-substrate hardening, `/pk-express`, `/pr-fix` pluggable engine + historical finders, `pk branch` nested env symlinks, `pk doctor` false-ship check, `/light-spec` configured `Spec ready state`)*
+**v2.8.0-rc2** — Last updated: 2026-06-07 14:30  *(CI reviewer-trigger hardening — `claude-review.yml`/`semgrep.yml` add the `synchronize` event (failed reviews self-heal on next push), and `claude-review.yml` + `templates/ci/README.md` warn that editing the workflow file on a feature branch 401s the app-token exchange (`ANTHROPIC_API_KEY: empty` is a red herring). Plus a `/pk-bug` checkout guard refusing main-anchored phases from the wrong branch. Carries v2.8.0-rc1 `/financial-review` + `.sync-changelog.md` self-heal; v2.7.1 `templates/ci/linear-transition.yml`; v2.7.0 enforcement-substrate hardening, `/pk-express`, `/pr-fix` pluggable engine + historical finders, `pk branch` nested env symlinks, `pk doctor` false-ship check, `/light-spec` configured `Spec ready state`)*
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**v2.8.0-rc1** — Last updated: 2026-06-06 10:00  *(adds portable `/financial-review` to the skill quick reference — finance/calculation-accuracy review, framework + checks-file. Carries v2.7.1 `templates/ci/linear-transition.yml` and the v2.7.0 final content pass: `/pk-express`; `/pr-fix` pluggable engine + historical finders; `/verify` migration self-review verdict; `pk branch` nested env symlinks; `pk doctor` false-ship cross-check; `pk done` rc5 finish; `/pipekit-update` Phase P; `/light-spec` configured `Spec ready state`)*
+**v2.8.0-rc2** — Last updated: 2026-06-07 14:30  *(no instruction-manual change — CI reviewer-trigger hardening (`synchronize` self-heal + workflow-validation 401 warning) and a `/pk-bug` checkout guard, both fixes/docs. Carries v2.8.0-rc1 `/financial-review` and the v2.7.0 final content pass: `/pk-express`; `/pr-fix` pluggable engine + historical finders; `/verify` migration self-review verdict; `pk branch` nested env symlinks; `pk doctor` false-ship cross-check; `pk done` rc5 finish; `/pipekit-update` Phase P; `/light-spec` configured `Spec ready state`)*
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v2.8.0-rc1** — Last updated: 2026-06-06 10:00  *(new portable `/financial-review` skill (finance projects; framework + checks-file) + `sync-method.sh` gitignore self-heal for the transient `.sync-changelog.md`. No daily-flow change. Carries v2.7.1 `templates/ci/linear-transition.yml` and the v2.7.0 substrate — see CHANGELOG; sync-method.sh example bumped to v2.8.0-rc1)*
+**v2.8.0-rc2** — Last updated: 2026-06-07 14:30  *(CI reviewer-trigger hardening — `claude-review.yml`/`semgrep.yml` add `synchronize` (self-healing reviews), `claude-review.yml` warns about the workflow-validation 401 — plus a `/pk-bug` checkout guard. No daily-flow change. Carries v2.8.0-rc1 `/financial-review` and the v2.7.x substrate — see CHANGELOG; sync-method.sh example bumped to v2.8.0-rc2)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -11,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v2.8.0-rc1             (or latest tag)
+1. ./scripts/sync-method.sh v2.8.0-rc2             (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: backend, integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="2.8.0-rc1"
+PK_VERSION="2.8.0-rc2"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.md
+++ b/method.md
@@ -1,6 +1,6 @@
 # Pipekit
 
-**v2.8.0-rc1** — Last updated: 2026-06-06 10:00  *(adds portable `/financial-review` to the tooling table — finance/calculation-accuracy review, framework + checks-file. Carries v2.7.1 `templates/ci/linear-transition.yml` and the v2.7.0 content pass: `/pk-express`, `/pr-fix` pluggable engine + historical finders, `/verify` migration self-review verdict, `pk done` rc5 finish, `/pipekit-update` Phase P, `pk doctor` false-ship check, `/light-spec` configured `Spec ready state`; rc2's stage-isolation reframe of Fresh-Chat Discipline)*
+**v2.8.0-rc2** — Last updated: 2026-06-07 14:30  *(no methodology change — CI reviewer-trigger hardening (`synchronize` self-heal + workflow-validation 401 warning on `claude-review.yml`/`semgrep.yml`) and a `/pk-bug` checkout guard, both fixes/docs. Carries v2.8.0-rc1 `/financial-review` and the v2.7.x content pass: `/pk-express`, `/pr-fix` pluggable engine + historical finders, `/verify` migration self-review verdict, `pk done` rc5 finish, `/pipekit-update` Phase P, `pk doctor` false-ship check, `/light-spec` configured `Spec ready state`)*
 
 > **v2.4.3.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >

--- a/skills/pk-bug/skill.md
+++ b/skills/pk-bug/skill.md
@@ -36,11 +36,28 @@ Read `method.config.md` for:
 - Pre-deploy gate commands
 - Backend (`vbw` or `native`) — passed through to `/work`
 
+## Preflight — checkout guard  *(applies to Phases 1–4 only)*
+
+Phases 1–4 are **main-anchored**: intake, reproduce, diagnose, and the failing regression test are authored on the integration-branch checkout (`main` or the configured integration branch), with the test left *uncommitted* until `pk branch` cuts the worktree in Phase 4. Phase 4's `pk branch <ID>` always cuts the worktree off `origin/<integration>` (see `bin/pk`) — so a test written on **any other branch is orphaned**, not carried into the new worktree. Running these phases from a feature branch or an existing `pk branch` worktree silently breaks the handoff.
+
+Before entering Phase 1 (new bug), or any resume that routes to Phases 2–4, check the current checkout:
+
+```bash
+current=$(git rev-parse --abbrev-ref HEAD)
+# integration = `Integration branch` from method.config.md (pk falls back to origin/dev, else origin/HEAD)
+```
+
+- `current` is the integration branch (and you're in the repo-root checkout, not a worktree) → **proceed.**
+- `current` is any other branch, or you are inside a `pk branch` worktree → **STOP.** Do not write the test here; it will not survive the Phase 4 handoff. Tell the user:
+  > `/pk-bug` Phases 1–4 must run from the `<integration>` checkout. You're on `<current>`. Return to the repo-root checkout (`cd <repo-root>` && `git switch <integration>`) and re-invoke, or finish/park the current branch first. (To resume a bug already past Phase 4, pass its `<ISSUE-ID>` — that routes straight into the worktree phases and skips this guard.)
+
+This guard does **not** apply to resume routing into Phases 5–8 — by then the worktree exists and running from inside it (`statusType=started`) is the correct location.
+
 ## Resume routing
 
 When invoked with an existing `<ISSUE-ID>`, query Linear and enter the phase below:
 
-Routing keys off Linear's `statusType` (not display name) so projects with custom statuses like `Parked` route correctly.
+Routing keys off Linear's `statusType` (not display name) so projects with custom statuses like `Parked` route correctly. **If the resolved phase is 1–4, run the Preflight checkout guard above first;** phases 5–8 skip it (the worktree already exists).
 
 | Linear state                                                            | Enter phase |
 |------------------------------------------------------------------------|-------------|
@@ -225,6 +242,7 @@ After main deploys, Linear should auto-transition to `Done` (per the existing au
 
 | Rule | Enforcement |
 |------|-------------|
+| Phases 1–4 run only from the integration checkout | Preflight guard; STOP + redirect on any other branch/worktree |
 | No fix code before failing test exists | Phase 3 gate; Phase 4 commits test first |
 | Cannot repro → STOP | Phase 2 gate; mark `needs-info`, exit |
 | Linear is the source of truth | Resume always re-reads Linear, never local state |

--- a/templates/ci/README.md
+++ b/templates/ci/README.md
@@ -39,19 +39,46 @@ The list should mirror `method.config.md`'s `Ship environments` minus the first 
 
 `claude-review.yml` also requires the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (Settings → Secrets and variables → Actions → New repository secret). Get the token via the Claude Code Action setup flow.
 
-## Trigger model — why `opened` + `ready_for_review` only
+## ⚠️ Never edit `claude-review.yml` on a feature branch
 
-Both templates trigger on:
+`anthropics/claude-code-action` performs a privileged app-token exchange that **requires the workflow file to be byte-identical to the version on the default branch.** Any change to it on a PR branch — including deleting a comment line — fails the exchange and the review job dies with:
+
+```
+App token exchange failed: 401 Unauthorized - Workflow validation failed.
+The workflow file must exist and have identical content to the version on
+the repository's default branch.
+```
+
+This is a deliberate security guard: a PR must not be able to alter the reviewer that runs with the OAuth secret, then have that altered version execute.
+
+**The log is misleading.** It prints `ANTHROPIC_API_KEY: empty` (normal under OAuth auth) just above the real 401. Don't chase it as a secrets/1Password failure — scan for `App token exchange failed`.
+
+**To change the workflow:** land the edit on the default branch first (its own PR), then rebase feature branches on top.
+
+**To fix an already-broken branch** (restore the file to match the default branch):
+
+```bash
+git checkout origin/<default-branch> -- .github/workflows/claude-code-review.yml
+git commit -m "ci: restore claude-review workflow to match default branch (fixes 401 app-token validation)"
+```
+
+Anchor: SiteLine POC-87, 2026-06-07 — a feature branch stripped the file's header comment; the review 401'd and was first misdiagnosed as a 1Password secret-load failure. The OAuth token had loaded fine.
+
+## Trigger model — `opened` + `ready_for_review` + `synchronize`
+
+`claude-review.yml` triggers on:
 
 ```yaml
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
 ```
 
-**No `synchronize`.** Every push to a Ready PR would otherwise fire the reviewer — wasteful on heavy-iteration PRs (Piper's WIT-463 was a 23-commit feature branch; 23 reviews × per-call cost = the problem). `synchronize` is exactly the wrong event to gate "outside review" on.
+**`opened` + `ready_for_review` are the merge-moment signals.** Combined with Pipekit's Draft-PR lifecycle below, the reviewer fires once at PR-open (if not Draft) and once when the user flips Draft → Ready (the "I'm done iterating, review it now" gesture). Draft PRs never fire — the `triage` job's `draft == false` guard keeps Draft iteration free.
 
-**`ready_for_review` is the merge-moment signal.** Combined with Pipekit's Draft-PR lifecycle below, the reviewer fires once at PR-open (if not Draft) and once when the user flips Draft → Ready (the "I'm done iterating, review it now" gesture).
+**`synchronize` (every push to a Ready PR) is included so failed reviews self-heal.** When a review fails — a transient error, or the 401 workflow-validation guard (see the warning above) — the next push re-runs it automatically, instead of forcing a Draft → Ready re-flip to re-trigger. The cost of every-push reviews is capped two ways: Draft PRs are exempt (iterate as a Draft, push freely, no reviews), and the **skip-on-trivial `triage` job** filters doc-only and <5-LOC pushes before the paid review runs.
+
+> **History:** `synchronize` was originally *omitted* (≤ v2.8.0) to avoid per-push credit burn — Piper's WIT-463 was a 23-commit branch where 23 reviews would have fired. It was added back once two facts converged: (1) the `triage` skip-on-trivial guard already absorbs the cheap-push noise, and (2) without `synchronize`, a failed review has no automatic re-trigger, which turned a one-line workflow-file mistake (SiteLine POC-87) into a Draft-dance to recover. The cost is genuinely modest for small teams; raise the `triage` LOC floor (5 → 50) if your push volume makes it add up.
 
 ## Draft-PR lifecycle (v2.6.0 #6)
 

--- a/templates/ci/claude-review.yml
+++ b/templates/ci/claude-review.yml
@@ -1,15 +1,38 @@
 # Claude PR Review — semantic outside reviewer on release-class PRs.
 #
+# ⚠️  DO NOT EDIT THIS WORKFLOW FILE ON A FEATURE BRANCH.
+#     anthropics/claude-code-action does a privileged app-token exchange that
+#     requires this file to be byte-identical to the version on the default
+#     branch. ANY change on a PR branch — even deleting a comment — makes the
+#     exchange fail with:
+#         "App token exchange failed: 401 Unauthorized - Workflow validation
+#          failed. The workflow file must exist and have identical content to
+#          the version on the repository's default branch."
+#     and the review job fails. (Note: `ANTHROPIC_API_KEY: empty` in the log is
+#     NORMAL under OAuth auth and is NOT the cause — look for the 401 above it.)
+#     This is a deliberate security guard: a PR must not be able to alter the
+#     reviewer that runs with the OAuth secret. To change this workflow, land
+#     the edit on the default branch first (its own PR), then rebase.
+#     Fix for an already-broken branch:
+#         git checkout origin/<default-branch> -- .github/workflows/<this-file>
+#     (Anchor: SiteLine POC-87, 2026-06-07 — a stripped header comment 401'd the
+#     review; first misread as a 1Password/secret failure.)
+#
 # Part of Pipekit's Path 3 reviewer model (v2.6.0): Claude is the
 # semantic outside reviewer; semgrep.yml is the deterministic one.
 # Empirically caught 2 must-fix bugs on Piper PR #331 (2026-05-18)
 # that Semgrep and Gemini both missed.
 #
-# Triggers: `opened` and `ready_for_review` only. Match the Pipekit
-# Draft-PR lifecycle (open as Draft via `pk ship` default, iterate
-# freely without firing reviews, `pk ready <ID>` flips to Ready at
-# the actual merge moment). Drops `synchronize` to avoid per-push
-# credit burn on iteration.
+# Triggers: `opened`, `ready_for_review`, and `synchronize`. The first
+# two match the Pipekit Draft-PR lifecycle (open as Draft via `pk ship`
+# default, iterate freely as a Draft without firing reviews, `pk ready
+# <ID>` flips to Ready at the merge moment). `synchronize` (every push to
+# a Ready PR) is included so a failed review — transient, or the 401
+# workflow-validation guard above — self-heals on the next push instead
+# of needing a Draft→Ready re-flip. Per-push credit burn is capped by the
+# `triage` skip-on-trivial job below (doc-only and <5-LOC pushes skip the
+# paid review). Draft PRs never fire regardless of event (the `draft ==
+# false` guard on `triage`), so Draft iteration stays free.
 #
 # Path filtering: ALL paths reviewed by default (PR #331 evidence
 # showed claude-review caught bugs in non-high-leverage paths that
@@ -20,7 +43,7 @@ name: Claude PR Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
     # Release-class branches only — match method.config.md `Ship environments`.
     branches:
       - main

--- a/templates/ci/semgrep.yml
+++ b/templates/ci/semgrep.yml
@@ -4,9 +4,13 @@
 # deterministic outside reviewer; claude-review.yml is the semantic one.
 # Free Community Rules, no SEMGREP_APP_TOKEN required.
 #
-# Triggers: `opened` and `ready_for_review` only — matches Pipekit's
-# Draft-PR lifecycle (open as Draft, iterate freely, `pk ready <ID>`
-# to flip when shipping). Avoids the per-push credit burn of `synchronize`.
+# Triggers: `opened`, `ready_for_review`, and `synchronize`. The first
+# two match Pipekit's Draft-PR lifecycle (open as Draft, iterate freely,
+# `pk ready <ID>` to flip when shipping). `synchronize` (every push to a
+# Ready PR) is included so analysis re-runs on each push and failed runs
+# self-heal — and unlike claude-review, Semgrep is free (Community Rules),
+# so there is no per-push credit to conserve. Draft PRs still skip via the
+# job guard below.
 #
 # Tune the `branches` list to your project's release-class branches
 # (the ones that hit deploy gates). 2-tier: typically `main`. 3-tier:
@@ -17,7 +21,7 @@ name: Semgrep
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
     # Release-class branches only — match method.config.md `Ship environments`.
     branches:
       - main


### PR DESCRIPTION
## v2.8.0-rc2

Fixes/docs release continuing the rc cycle. No new capability.

### Changes
- **`claude-review.yml` + `semgrep.yml` add the `synchronize` trigger** — a failed review (transient, or the workflow-validation 401 below) self-heals on the next push instead of needing a Draft→Ready re-flip. Per-push cost on the paid Claude reviewer stays bounded by the existing Draft exemption + skip-on-trivial `triage` job; Semgrep is free.
- **`claude-review.yml` hardened against the app-token-exchange 401** — `anthropics/claude-code-action` requires the workflow file to be byte-identical to the default-branch version (a guard so a PR can't alter the reviewer that runs with the OAuth secret). Editing it on a feature branch 401s. Warning added to the template header + `templates/ci/README.md`, including that `ANTHROPIC_API_KEY: empty` is a red herring under OAuth auth, plus the one-line restore fix. Anchor: SiteLine POC-87, 2026-06-07.
- **`/pk-bug` checkout guard** — Phases 1–4 are main-anchored (the failing regression test is authored on the integration checkout before `pk branch` cuts the worktree). Added a preflight guard that STOPs with a redirect when invoked from a feature branch/worktree; resuming a past-Phase-4 bug by `<ISSUE-ID>` skips the guard.

### Release checklist
- [x] `PK_VERSION` bumped in `bin/pk` → `2.8.0-rc2`
- [x] `CHANGELOG.md` — new `## v2.8.0-rc2 — 2026-06-07` section
- [x] Constitutional stamps bumped (`method.md`, `RUNBOOK.md`, `GUIDE.md`) + `CLAUDE.md` banner
- [x] `RUNBOOK.md` line 14 sync example → `v2.8.0-rc2`
- [x] PR title contains `v2.8.0-rc2` for `auto-tag-release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)