### PR TITLE
docs(spec-review): backend-agnostic planner framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
-_Nothing yet._
+- **Spec Review Agent → backend-agnostic (v5.2).** `templates/spec_review_skill.md` no longer names VBW as the planning engine. The reviewer sits **upstream of backend dispatch** — the spec is reviewed before `/work` runs, and `/work` plans inline regardless of executor (`native` default, `vbw` optional) — so the executor is irrelevant to the review. Replaced every "VBW will/would …" with "the planner …" and added an explicit upstream-of-dispatch note. Gate logic (Problem/Scope/AC, Authority Rule, Decomposition Readiness) unchanged; native's task-DAG + atomic-commit-per-task model only sharpens the existing decomposition/testable-AC bar.
 
 ---
 

--- a/templates/spec_review_skill.md
+++ b/templates/spec_review_skill.md
@@ -1,16 +1,18 @@
-# Linear Agent Skill: Spec Review Agent (v5)
+# Linear Agent Skill: Spec Review Agent (v5.2)
 
 ## Context
 
 You are operating inside {PROJECT_NAME}'s review layer for AI-assisted planning.
 
 Linear = review/control layer  
-VBW = planning + execution engine
+Claude Code (`/work`) = planning + execution engine
 
-Your job is to determine if a spec is safe and ready for VBW planning.
+Your job is to determine if a spec is safe and ready for planning.
 
 You are not reviewing for writing quality.
-You are identifying where VBW will fail or make incorrect assumptions.
+You are identifying where the planner will fail or make incorrect assumptions.
+
+> You sit **upstream of backend dispatch**. The spec is reviewed before `/work` runs, and `/work` plans inline regardless of executor (`native` on the Workflow primitive by default; `vbw` optional). The executor is irrelevant to this review — you review for **planning safety**, full stop.
 
 ---
 
@@ -45,7 +47,7 @@ Do NOT fail a spec for:
 
 DO fail a spec if:
 - concision hides ambiguity
-- [TBD] forces VBW to guess
+- [TBD] forces the planner to guess
 - core decisions are missing
 
 ---
@@ -58,14 +60,14 @@ A spec is NOT ready if any of the following are weak AND block planning:
 - Scope (unclear boundaries)
 - Acceptance Criteria (not testable)
 
-A spec is only **Pass** if VBW can plan without guessing.
+A spec is only **Pass** if the planner can plan without guessing.
 
 ---
 
 ## Severity Classification
 
 **Blocking**
-- VBW would need to guess core logic
+- the planner would need to guess core logic
 - source of truth unclear
 - financial correctness risk
 - contradictory or undefined behaviour
@@ -101,7 +103,7 @@ A decision is valid if:
 OR
 - explicitly deferred as [TBD] AND does not block planning
 
-If VBW would need to guess -> Blocking
+If the planner would need to guess -> Blocking
 
 ---
 


### PR DESCRIPTION
## What

Decouples the Spec Review Agent template (`templates/spec_review_skill.md`) from VBW. It now names **the planner** rather than VBW as the planning engine, and adds an explicit note that the reviewer sits **upstream of backend dispatch**.

## Why

The reviewer runs *before* `/work` is invoked, and `/work` plans inline regardless of executor (`native` default on the Workflow primitive; `vbw` optional). The executor is therefore irrelevant to the review — it reviews for **planning safety**. Naming VBW was a category error even pre-3.0; 3.0 makes it visibly wrong.

## What does NOT change

Gate logic is untouched — Problem/Scope/AC, Authority Rule, Decomposition Readiness all stand. If anything native's task-DAG + atomic-commit-per-task model *sharpens* the decomposition / testable-AC bar, so the existing gate is correct.

Bumped the template's internal version v5 → v5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)