### PR TITLE
docs(linear-guidance): backend-agnostic planner framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
+- **Linear Agent Guidance → backend-agnostic (v5.2).** `templates/linear_guidance.md` (injected ahead of the Spec Review Agent) no longer names VBW as the execution engine. "VBW is the execution engine" → "Claude Code (`/work`) is the planning + execution engine, native default / vbw optional"; pipeline `… → VBW Plan → Execution` → `… → Plan → Execution` with an inline-planning note; "If VBW would guess → Revise" → "If the planner would guess → Revise". Review philosophy and gates unchanged.
 - **Spec Review Agent → backend-agnostic (v5.2).** `templates/spec_review_skill.md` no longer names VBW as the planning engine. The reviewer sits **upstream of backend dispatch** — the spec is reviewed before `/work` runs, and `/work` plans inline regardless of executor (`native` default, `vbw` optional) — so the executor is irrelevant to the review. Replaced every "VBW will/would …" with "the planner …" and added an explicit upstream-of-dispatch note. Gate logic (Problem/Scope/AC, Authority Rule, Decomposition Readiness) unchanged; native's task-DAG + atomic-commit-per-task model only sharpens the existing decomposition/testable-AC bar.
 
 ---

--- a/templates/linear_guidance.md
+++ b/templates/linear_guidance.md
@@ -1,4 +1,4 @@
-# Linear Agent Guidance (v5)
+# Linear Agent Guidance (v5.2)
 
 ## Purpose
 
@@ -9,7 +9,7 @@ It is used to:
 - enforce quality before planning
 - provide audit trail for decisions
 
-VBW is the execution engine.
+Claude Code (`/work`) is the planning + execution engine — `native` on the Workflow primitive by default, `vbw` optional. This review is **upstream of backend dispatch** and executor-agnostic: review for planning safety, not for any one executor.
 
 ---
 
@@ -52,7 +52,9 @@ Do NOT over-optimise for completeness or prose polish.
 
 Pipeline:
 
-Feature → Spec → Review → VBW Plan → Execution
+Feature → Spec → Review → Plan → Execution
+
+(`/work` plans inline before executing, regardless of backend.)
 
 Specs are planning contracts, not execution plans.
 
@@ -92,4 +94,4 @@ Outputs must be:
 
 Bad specs should fail loudly.
 
-If VBW would guess -> Revise
+If the planner would guess -> Revise


### PR DESCRIPTION
## What

Decouples the Linear Agent Guidance template (`templates/linear_guidance.md`, injected into Linear ahead of the Spec Review Agent) from VBW.

- `VBW is the execution engine.` → `Claude Code (/work) is the planning + execution engine` (native default on the Workflow primitive, vbw optional) + an upstream-of-dispatch / executor-agnostic note.
- Pipeline `Feature → Spec → Review → VBW Plan → Execution` → `… → Plan → Execution`, with a note that `/work` plans inline regardless of backend.
- `If VBW would guess → Revise` → `If the planner would guess → Revise`.

## Why

The guidance runs upstream of backend dispatch. `/work` plans inline and executes per the configured backend, so naming VBW was stale even pre-3.0. Companion to #109 (the Spec Review Agent itself). Version bumped v5 → v5.2 to match.

## What does NOT change

Core Philosophy, Light Spec Context, Financial Sensitivity, Source of Truth, Agent Readability, and the fail-loud Review Principle are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)