### PR TITLE
docs: reframe README + GUIDE for 3.0 native-default executor

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**v2.8.0-rc3** — Last updated: 2026-06-07 16:00  *(no instruction-manual change — `/security-review` finding-stage coverage + adversarial verification pass (generalized from a downstream override). Carries v2.8.0-rc2 CI reviewer-trigger hardening + `/pk-bug` guard, rc1 `/financial-review`, and the v2.7.0 final content pass: `/pk-express`; `/pr-fix` pluggable engine + historical finders; `/verify` migration self-review verdict; `pk branch` nested env symlinks; `pk doctor` false-ship cross-check; `pk done` rc5 finish; `/pipekit-update` Phase P; `/light-spec` configured `Spec ready state`)*
+**v3.0.0-rc2** — Last updated: 2026-06-09  *(Pipekit 3.0: reframes the VBW Integration section + the `/vbw:init`, Building-state, and enforcement-layer descriptions around native-on-Workflow as the default executor with VBW as an optional backend; drops the misleading "VBW QA" row (the `vbw` backend only spawns `vbw-dev`). Carries the v2.8.x substrate + the v2.7.0 content pass)*
 
 ---
 
@@ -342,7 +342,7 @@ This is where you set up the actual infrastructure. The `/startup` orchestrator 
 **Input:** —
 **Output:** `.vbw-planning/` directory scaffold
 
-VBW (Vibe-Based Workflow) is the planning and execution engine. `/vbw:init` creates the directory structure that VBW uses to track roadmap, state, plans, and execution.
+VBW is an optional execution backend — as of 3.0 the default executor is native-on-Workflow — but `/vbw:init` still scaffolds the `.vbw-planning/` directory Pipekit uses to track the roadmap and state (and, when the `vbw` backend runs, its plans and execution). The directory is created here regardless of which backend you execute with, because the roadmap lives in it.
 
 This step is simple — run `/vbw:init` and it scaffolds:
 ```
@@ -887,7 +887,7 @@ Both `/strategy-create` and `/strategy-sync` read this table. Add or remove rows
 
 ## The Linear Model
 
-Linear is the view layer. VBW is the planning engine. They share data but serve different purposes.
+Linear is the view layer. The executor (`/work`, native by default) plans and builds. They share data but serve different purposes.
 
 ### Hierarchy
 
@@ -914,7 +914,7 @@ Terminal:
 `[In <Env> →]*` is one state per non-final env in `Ship environments`. For 3-tier (`dev,beta,main`): `In Dev → In Beta → Done`. For 2-tier (`dev,main`): `In Dev → Done`. State maps 1:1 to environment: `UAT` = PR open on preview branch; `In Dev` = merged to dev; `In Beta` = promoted to beta; `Done` = on the final env.
 
 **Key distinction:**
-- **Building** = VBW owns it. Phase-batched, planned work.
+- **Building** = automated execution owns it (`/work`, native or vbw backend). Phase-batched, planned work.
 - **In Progress** = You're doing it manually. Ad-hoc, outside the phase.
 
 ### Phase Management via Status
@@ -953,19 +953,18 @@ Terminal:
 
 ---
 
-## VBW Integration
+## VBW Integration (optional backend)
 
-VBW (Vibe-Based Workflow) is the planning and execution engine. Here's where its tools appear in the pipeline:
+As of 3.0 the default executor is **native-on-Workflow** — `/work` plans the issue inline and executes on Claude Code's Workflow primitive. VBW is an **optional backend** you opt into with `Backend: vbw`. The `.vbw-planning/` scaffold and the roadmap are used regardless of backend; the rest only appears when you actually run the `vbw` backend.
 
-| Pipeline Stage | VBW Tool | Purpose |
-|---------------|----------|---------|
-| Stage 0.5 | `/vbw:init` | Scaffold `.vbw-planning/` |
-| Stage 0.6 | `/roadmap-create` writes to `.vbw-planning/ROADMAP.md` | Populate roadmap |
-| Stage 0.7 (optional) | `/vbw:discuss` | Discuss first phase before speccing |
-| Stage 2 | VBW Lead Agent | Generate PLAN.md from spec |
-| Stage 3 | VBW Dev Agent | Execute tasks with atomic commits |
-| Stage 3 | VBW QA Agent | Verify against acceptance criteria |
-| Anytime | `/vbw:status` | Project progress dashboard |
+| Pipeline Stage | Tool | Used when | Purpose |
+|---------------|------|-----------|---------|
+| Stage 0.5 | `/vbw:init` | Always | Scaffold `.vbw-planning/` |
+| Stage 0.6 | `/roadmap-create` writes to `.vbw-planning/ROADMAP.md` | Always | Populate roadmap |
+| Stage 0.7 (optional) | `/vbw:discuss` | Optional | Discuss first phase before speccing |
+| Stage 2 (planning) | `/work` inline planning | Always | Generate the plan from the spec — **native and vbw both plan here; `/work` has no separate "VBW Lead" step** |
+| Stage 3 (execute) | `vbw-dev` agent | `Backend: vbw` only | Execute tasks with atomic commits (native executes on the Workflow primitive instead) |
+| Anytime | `/vbw:status` | If VBW installed | Project progress dashboard |
 
 ### VBW Agent Roster
 
@@ -979,6 +978,8 @@ VBW (Vibe-Based Workflow) is the planning and execution engine. Here's where its
 | Docs | Documentation generation |
 | Scout | Research and codebase scanning |
 
+> **In Pipekit, `/work` with `Backend: vbw` only dispatches the Dev agent.** Lead, QA, Architect, and the rest run only under direct `/vbw:*` invocation — which Pipekit advises against (it bypasses the visibility layer). In every backend, planning is `/work`'s inline step and verification is the `/verify` gate plus the antagonistic review gates, not a VBW QA pass.
+
 ### Keeping VBW Updated
 
 When `/work` runs with `Backend: native` (plan + execute in-context; task DAG and run trail land in gitignored `.pk-work/`, not `.vbw-planning/`), `.vbw-planning/STATE.md` must still be updated to reflect progress. The method tracks all work — not just VBW-planned work.
@@ -991,11 +992,11 @@ The method uses three layers to enforce conventions. Each layer serves a differe
 
 | Layer | Purpose | Who Reads It | When |
 |-------|---------|-------------|------|
-| **CLAUDE.md** | Documents conventions | VBW agents during execution | Every agent session |
+| **CLAUDE.md** | Documents conventions | The executor (native or VBW) during execution | Every agent session |
 | **CI / Hooks** | Hard enforcement — blocks merges | Everyone (agents and humans) | Every PR |
 | **Skills** | Interactive shortcuts | You, in hands-on sessions | When you invoke them |
 
-**Skills are convenience wrappers.** They automate the same conventions documented in CLAUDE.md. VBW agents don't call skills — they read CLAUDE.md and write code directly.
+**Skills are convenience wrappers.** They automate the same conventions documented in CLAUDE.md. Executor agents (native or VBW) don't call skills — they read CLAUDE.md and write code directly.
 
 **CLAUDE.md is the single document** that agents read to understand the project. Build it up as the project grows:
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,30 @@
 # Pipekit
 
-**v2.7.0** — Last updated: 2026-06-05  *(v2.7.0 sync: adds the `/pk-express` express lane, names the `/pr-fix` and `/pr-security-review` enforcement gates, refreshes the versioning example)*
+**v3.0.0-rc2** — Last updated: 2026-06-09  *(Pipekit 3.0: native-on-Workflow is the default executor, VBW reframed as an optional backend. Rewrites the "wraps VBW" thesis + ownership split, fixes the VBW repo link, reframes the install step. Carries the v2.8.x substrate)*
 
-A structured AI-assisted software delivery system. Wraps [VBW](https://github.com/dnakov/claude-code-vbw) in a visibility and project management layer — from idea to production with quality gates at every stage.
+A structured AI-assisted software delivery system — from idea to production with quality gates at every stage. The default executor is **native-on-Workflow** (Claude Code's first-party orchestration primitive); [VBW](https://github.com/yidakee/vibe-better-with-claude-code-vbw) remains an optional backend.
 
 ## What This Is (and Isn't)
 
-Pipekit **does not replace VBW**. VBW handles planning, execution, and QA. Pipekit adds structure around it:
+Pipekit is the **structure around an executor** — spec creation, independent review, human sign-off, quality gates, Linear visibility, and promotion. It is **not** itself a planner or code executor: it dispatches the build step to a configured backend and owns everything around it.
 
-| Layer | What Pipekit does | What VBW does |
-|-------|-------------------|---------------|
-| **Before** (steps 1-4) | Spec creation, agent review, human sign-off, gate checks | — |
-| **During** (steps 5-8) | — | **Plan, execute, QA — all VBW** |
-| **After** (steps 9-11) | UAT tracking, shipping, doc sync | — |
-| **Around** | Linear integration for cross-issue visibility | Tracks one phase at a time |
-| **Stage 0** | Project bootstrap (idea → roadmap) | Starts at "I have a task" |
+As of **3.0**, the default backend is **native-on-Workflow** — `/work` plans the issue inline (parallel codebase grounding), then executes on Claude Code's first-party Workflow primitive: a task DAG, an atomic commit per task, verify-before-integrate. [VBW](https://github.com/yidakee/vibe-better-with-claude-code-vbw) is now an **optional** backend, not a dependency — set `Backend: vbw` to dispatch the `vbw-dev` executor instead. Either way `/work` does the planning; the backend only changes who executes.
 
-VBW doesn't need the full project plan — it's designed for bounded scope. Pipekit makes sure the input going into VBW is clean and unambiguous, and tracks what comes out.
+| Stage | What Pipekit handles |
+|-------|----------------------|
+| **Stage 0** | Project bootstrap — idea → roadmap |
+| **Before** (steps 1–4) | Spec creation, agent review, human sign-off, gate checks |
+| **During** (steps 5–8) | `/work` (plan inline + execute) and `/verify` (pre-deploy gate) |
+| **After** (steps 9–13) | UAT tracking, shipping, promotion, doc sync |
+| **Around** | Linear for cross-issue visibility (VBW tracks one phase at a time) |
+
+The deep-analysis safety net is the **gate layer** — `/financial-review`, `/pr-security-review`, antagonistic PR review — which runs regardless of backend. The executor is not where correctness is enforced; the gates are. (Validated head-to-head on hard financial work: native matched VBW-the-full-system on first-pass correctness at a fraction of the wall-clock and tokens — see `CHANGELOG.md` v3.0.0-rc1.)
 
 ### Ownership split
 
 To avoid drift between the two systems, the boundaries are explicit:
 
-- **VBW owns the planning layer** — `.vbw-planning/ROADMAP.md`, `PLAN.md` files, and execution state. Pipekit reads these but does not overwrite them.
+- **VBW owns the `.vbw-planning/` directory** — `ROADMAP.md` (the roadmap, written at Stage 0) plus the `PLAN.md`/execution-state files the `vbw` backend produces. The native backend writes its per-issue plan to `.pk-work/<ID>-PLAN.md` instead. Pipekit reads these but does not overwrite them.
 - **Pipekit owns the visibility layer** — Linear issues, `linear-map.json`, `PHASES.md`, strategy docs, and `method.config.md`. VBW does not touch these. "What's next?" is read live from Linear via `pk next` (phase-aware as of v2.1.0); v2 retired the old `NEXT.md` mirror file.
 - **The merge happens once**, at `/roadmap-create`. Strategy-derived requirements are added **into** VBW's phase structure; VBW's phases, goals, and success criteria are preserved.
 - **Don't invoke VBW agents directly.** Use `/work`, not `/vbw:lead` or `/vbw:dev`. `/work` dispatches to the configured backend (`vbw` or `native` per `method.config.md`) and keeps Linear and the `pk *` state machine in sync. Direct VBW invocation bypasses the visibility layer.
@@ -66,7 +68,7 @@ A bigger context window changes how much an agent can hold. It does not change w
 | 3 | Human Review | (Linear UI) | You sign off in Linear |
 | 4 | Find next | `pk next` | Phase-aware: groups by status from Linear + `PHASES.md` |
 | 5 | Branch | `pk branch <ID>` | Worktree + branch + Linear → In Progress |
-| 6 | **Work** | **`/work <ID>`** | **Plan + execute. Dispatches to `vbw` or `native` backend per `method.config.md`.** |
+| 6 | **Work** | **`/work <ID>`** | **Plan inline + execute. Default backend is `native` (Workflow primitive); `vbw` optional per `method.config.md`.** |
 | 7 | **Verify** | **`/verify`** | **Pre-deploy gate (types + lint + test).** |
 | 8 | Ship | `pk ship [--review] [--ready]` | Push, open PR as **Draft** (v2.6.0+; `--ready` opts to Ready), Linear → UAT. `--review` triggers antagonistic review. |
 | 8a | Flip to Ready | `pk ready [<ID>]` | (v2.6.0+) Flip Draft → Ready; fires outside reviewers (Semgrep + claude-review per `templates/ci/`). |
@@ -142,7 +144,7 @@ The sync script creates a `method.config.md` file in your project — this is wh
 
 Open Claude Code **in your project directory** and install the dependencies:
 
-**VBW** — the planning/execution engine that Pipekit wraps. Run these as two separate commands (don't paste them together):
+**VBW** — an optional execution backend. Pipekit's default executor is native-on-Workflow (built into Claude Code, nothing to install), but Stage 0's `/vbw:init` still uses VBW to scaffold the `.vbw-planning/` roadmap directory, and `Backend: vbw` stays available as a per-issue executor — so install it once during setup. Run these as two separate commands (don't paste them together):
 
 ```
 /plugin marketplace add yidakee/vibe-better-with-claude-code-vbw
@@ -285,7 +287,7 @@ pipekit/
 Tag releases when stable. Projects can pin to a specific version:
 
 ```bash
-./scripts/sync-method.sh v2.7.0   # or any tag listed in CHANGELOG.md
+./scripts/sync-method.sh v3.0.0-rc2   # or any tag listed in CHANGELOG.md
 ```
 
 Versioning is semver-ish — minor bumps for new capability, patch for fixes/docs only. Tags are created automatically on merge to `main` via `.github/workflows/auto-tag-release.yml` when the PR title contains a `vX.Y.Z` token.


### PR DESCRIPTION
Brings the two front-end docs in line with the 3.0 positioning (CLAUDE.md / method.md / CHANGELOG already reflect it). No version token in the title — this is a docs follow-up to the already-tagged `v3.0.0-rc2`, not a new release.

## README
- **Thesis rewrite.** "Wraps VBW; VBW handles planning, execution, and QA" → "Pipekit is the structure around an executor; default executor is native-on-Workflow; VBW is an optional backend." `/work` plans inline regardless of backend; the gate layer (not the executor) is where correctness is enforced.
- **Fixed the broken VBW link** — `dnakov/claude-code-vbw` → `yidakee/vibe-better-with-claude-code-vbw` (the repo the install step already uses).
- Reframed the "What This Is" table, the ownership bullet (native plans live in `.pk-work/`), the pipeline `/work` row, and the Step 4 install copy. Stamp → v3.0.0-rc2.

## GUIDE
- Reframed `/vbw:init`, the Building-state distinction, "The Linear Model", and the enforcement-layer table around native-default + optional-VBW.
- **VBW Integration section** now scoped as "optional backend" with a *used-when* column; **dropped the misleading "VBW QA" row** — `/work --backend=vbw` only spawns `vbw-dev`. Added a roster note clarifying Lead/QA/Architect run only under direct `/vbw:*`.
- Stamp → v3.0.0-rc2.

## Untouched
method.md (already rc1; residual deep-ownership lines are a tracked later-rc pass), STARTUP/RUNBOOK (no executor-engine framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)