### PR TITLE
docs: scrub stale /work→vbw-lead drift + commit POC-57 verdict

### DIFF
--- a/Logs/Sessions/2026-06-07_1210.md
+++ b/Logs/Sessions/2026-06-07_1210.md
@@ -1,0 +1,54 @@
+# Session Log — 2026-06-07 (afternoon)
+
+**Branch flow:** `main` → `chore/release-v2.8.0-rc2` → `chore/release-v2.8.0-rc3` → `main` (plus isolated SiteLine worktrees)
+**Session topic:** Started from "`/pk-bug` doesn't work on a branch?" — cascaded into CI reviewer hardening, two pipekit RC releases, a VBW hook fix, and propagating it all to SiteLine
+**Duration:** ~3h
+
+## Summary
+
+What began as a `/pk-bug` observation turned into a full hardening pass on the claude-review reviewer model. Shipped pipekit **v2.8.0-rc2** (`/pk-bug` checkout guard + claude-review 401 hardening + `synchronize` self-heal trigger on both review templates) and **v2.8.0-rc3** (`/security-review` finding-stage discipline, generalized from a SiteLine override). Diagnosed and correctly attributed a recurring claude-review CI failure to the `anthropics/claude-code-action` workflow-validation 401 — *not* the 1Password/secrets failure a prior session had assumed. Tightened the third-party VBW commit-format hook through three iterations. Propagated everything to SiteLine (synced rc2 then rc3, inoculated the live workflow, retired a drifted override). All work landed via PRs; SiteLine ended on rc3 with zero override drift.
+
+## Commits shipped
+
+pipekit (this repo):
+- `d9465e4` fix(templates): harden CI review triggers — add synchronize self-heal + workflow-validation 401 warning
+- `1dd6d2b` fix(skill): pk-bug checkout guard for main-anchored phases 1–4
+- `fabe33d` chore(release): v2.8.0-rc2 — CI reviewer-trigger hardening + pk-bug guard
+- `02ad853` feat(skill): security-review finding-stage coverage + adversarial verification pass
+- `52d66b9` chore(release): v2.8.0-rc3 — security-review finding-stage discipline
+
+SiteLine (separate repo, via PRs #240 / #242): rc2 sync; live-workflow inoculation; rc3 sync + override retirement.
+
+Out-of-repo: VBW plugin cache `validate-commit.sh` patched (ephemeral — overwritten on next VBW update, per user's explicit choice).
+
+## Decisions / findings (worth remembering)
+
+1. **The claude-review CI failure was misdiagnosed by a prior session.** `ANTHROPIC_API_KEY: empty` in the action log is **normal under OAuth auth** and is a red herring. The real failure is `App token exchange failed: 401 Unauthorized - Workflow validation failed` — `anthropics/claude-code-action` requires the workflow file on a PR to be **byte-identical to the default branch**, a deliberate guard so a PR can't alter the reviewer that runs with the OAuth secret. POC-87 had stripped a header comment → 401. Documented in both the template and the live SiteLine workflow.
+2. **`synchronize` does NOT fix the 401** — it only adds recovery ergonomics (failed reviews self-heal on next push instead of needing a Draft→Ready re-flip). It was originally omitted (Piper WIT-463 cost concern) but re-added once the triage skip-on-trivial guard was confirmed to absorb the cheap-push noise. Semgrep got it too (free, no credit concern).
+3. **`/pk-bug` is main-anchored by design** (phases 1–4 author the failing test on the integration checkout before `pk branch` cuts the worktree off `origin/<integration>`). Running from a feature branch orphans the test at the Phase 4 handoff. Fix was a guard (STOP + redirect), not making it branch-aware — chosen to preserve the invariant.
+4. **The VBW commit-format hook has a real bug** (false-positives on multi-line bodies, two-`-m` subject+body, chained commits, and unrelated `gh pr create` heredocs). It's a third-party plugin (`yidakee/vibe-better-with-claude-code-vbw`), so the cache patch is ephemeral. Correct model: validate only the **first `-m` subject per `git commit`**, stop at first newline. It's also non-blocking (advisory only).
+5. **`ci` and `build` are NOT in the VBW hook's allowed commit types** (`feat|fix|test|refactor|perf|docs|style|chore`). Used `chore(ci)` instead. Standard Conventional Commits types `ci`/`build` would need an upstream VBW change to allow.
+6. **SiteLine's `security-review` override was a half-adapted Piper copy** — still said "Piper platform", included a `../piper-marketing/` security-page step meaningless for SiteLine, yet also had SiteLine URLs. A latent bug. Resolved by upstreaming its good parts (finding-stage coverage, adversarial verification pass) into pipekit rc3 and deleting the override — driftless, and all projects benefit.
+7. **Override reconciliation requires a release in the loop.** Consuming projects sync from tags, so "upstream the good parts, drop the override" needs the guidance in a tag (hence rc3) before the project can adopt it driftlessly.
+
+## Outstanding / next session
+
+- **Cut pipekit `v2.8.0` final** out of the rc2/rc3 line when ready (no blockers; ship by readiness).
+- **VBW hook**: decide whether to allow `ci`/`build` commit types (upstream VBW change or local config) — the patch is ephemeral and will revert on next VBW plugin update.
+- **SiteLine** `docs/session-log-2026-06-07` branch still has its own uncommitted work (untouched this session — all SiteLine work ran in isolated worktrees).
+- Consider upstreaming the workflow-validation-401 warning into `pipekit/templates/ci/` was done; existing consuming projects (Piper) with diverged live `claude-code-review.yml` won't get the in-file warning via sync — only new installs do. Inoculate Piper's live workflow separately if desired.
+
+## QA / verification trail
+
+| Round | Outcome | Notes |
+|---|---|---|
+| claude-review 401 diagnosis | Confirmed via run log | Read actual failed run; found 401 above the red-herring `ANTHROPIC_API_KEY: empty` |
+| Format hook v1 | Fixed multi-line + chained, missed heredoc | 7 test cases |
+| Format hook v2 | Fixed gh-pr heredoc, missed two-`-m` body | exposed by real amend commit |
+| Format hook v3 | All 4 false-positive classes pass; genuine violations still flag | 8+ test cases, first-`-m`-per-commit model |
+| SiteLine override retire | Verified byte-identical to upstream rc3 | `diff -q` MATCH; 0 Piper-cruft markers |
+| rc2 / rc3 / #240 / #242 | All merged green | `tests-required` gated SiteLine; auto-tag-release tagged pipekit |
+
+## Linear updates
+
+— (pipekit-the-repo has no Linear; SiteLine PRs were infra/sync, not WIT-driven)

--- a/experiments/poc-57-backend-ab/RUNCARD-native.md
+++ b/experiments/poc-57-backend-ab/RUNCARD-native.md
@@ -1,0 +1,38 @@
+# RUNCARD — Arm native-1 (pilot)
+
+**Worktree:** `~/Projects/SiteLine/.worktrees/POC-57-native-1` (branch `exp/POC-57-native-1`)
+**Base:** `exp/POC-57-base` (`0c52fcaa`) = SiteLine `origin/main` `2fb49a14` + native-best skill installed.
+
+## Start
+
+Open a **fresh** Claude Code session in the worktree (fresh = no context bleed from other arms):
+
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-native-1 && claude
+```
+
+Then run exactly:
+
+```
+/work POC-57 --backend=native --no-rollover
+```
+
+## Controls (enforce if the session drifts)
+
+- **Backend = native.** Confirm it runs the rebuilt Step 5n path: writes `.pk-work/POC-57-PLAN.md` (task DAG), executes with verify-before-integrate. If it falls back to a single blob subagent, the wrong skill is installed — stop.
+- **No Linear writes.** No status transitions, no comments. (`--no-rollover` + manual worktree means it shouldn't touch Linear; verify it doesn't.)
+- **No shared DB.** Never `supabase db push` to a shared env; never `mcp.apply_migration`. Migration file on disk only; local/branch DB at most.
+- **Spec source:** POC-57 is Approved in Linear and frozen-by-agreement during the experiment (== `SPEC.frozen.md`). Don't edit POC-57 in Linear until the experiment is done.
+- **Stop after execution.** `--no-rollover` blocks the auto `/verify`+`pk ship`. Do not run `pk ship`/`pk done`/`pk promote`.
+
+## Capture when done (paste back to the master session)
+
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-native-1
+git log --oneline exp/POC-57-base..HEAD
+git diff --stat exp/POC-57-base..HEAD
+cat .pk-work/POC-57-PLAN.md
+cat .pk-work/POC-57-SUMMARY.md
+```
+
+Plus, from your observation: wall-clock, # of times you had to intervene, any blockers it surfaced.

--- a/experiments/poc-57-backend-ab/RUNCARD-vbw.md
+++ b/experiments/poc-57-backend-ab/RUNCARD-vbw.md
@@ -1,0 +1,38 @@
+# RUNCARD — Arm vbw-1 (pilot)
+
+**Worktree:** `~/Projects/SiteLine/.worktrees/POC-57-vbw-1` (branch `exp/POC-57-vbw-1`)
+**Base:** `exp/POC-57-base` (`0c52fcaa`) = SiteLine `origin/main` `2fb49a14` + native-best skill installed (VBW path is unchanged by the rebuild, so this base is identical-input for both arms).
+
+## Start
+
+Open a **fresh** Claude Code session in the worktree:
+
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-vbw-1 && claude
+```
+
+Then run exactly:
+
+```
+/work POC-57 --backend=vbw --no-rollover
+```
+
+## Controls (enforce if the session drifts)
+
+- **Backend = vbw.** Confirm it actually spawns the real pipeline: `vbw:vbw-lead` (plan → `.vbw-planning/.../PLAN.md`) then `vbw:vbw-dev` (execute). If it just runs in-context, it's not VBW — stop.
+- **No Linear writes.** No status transitions, no comments.
+- **No shared DB.** Never `supabase db push` to a shared env; never `mcp.apply_migration`. Migration file on disk only; local/branch DB at most.
+- **Spec source:** POC-57 is Approved in Linear and frozen-by-agreement during the experiment (== `SPEC.frozen.md`). Don't edit POC-57 in Linear until the experiment is done.
+- **Stop after execution.** `--no-rollover` blocks the auto `/verify`+`pk ship`. Do not run `pk ship`/`pk done`/`pk promote`.
+
+## Capture when done (paste back to the master session)
+
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-vbw-1
+git log --oneline exp/POC-57-base..HEAD
+git diff --stat exp/POC-57-base..HEAD
+find .vbw-planning -newer .git -name '*POC-57*' -o -name '*-PLAN.md' -newer .git 2>/dev/null | head
+# the vbw PLAN it generated (path printed by vbw-lead), plus any SUMMARY/VERIFICATION
+```
+
+Plus, from your observation: wall-clock, # of times you had to intervene, any blockers it surfaced.

--- a/experiments/poc-57-backend-ab/RUNCARD-vbwfull.md
+++ b/experiments/poc-57-backend-ab/RUNCARD-vbwfull.md
@@ -1,0 +1,41 @@
+# RUNCARD — Arm vbwfull-1 (real full VBW pipeline)
+
+**Worktree:** `~/Projects/SiteLine/.worktrees/POC-57-vbwfull-1` (branch `exp/POC-57-vbwfull-1`)
+**Pane:** `surface:61` (workspace:18), cd'd and ready.
+**Base:** `exp/POC-57-base` (`0c52fcaa`). This arm does NOT use Pipekit `/work`, so the native-best skill in the base is irrelevant to it — diff vs base still isolates this arm's work.
+
+**Purpose:** the real `vbw-lead`→`vbw-dev`→`vbw-qa` pipeline — the thing Pipekit's `/work` vbw backend never invokes. This is "VBW the system," not "vbw-dev the executor."
+
+## Start
+
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-vbwfull-1 && claude
+```
+
+Then drive VBW's real entry (you know its flow better than a guessed incantation — `/vbw:vibe` is "the one command": plan→execute→verify):
+
+```
+/vbw:vibe   (scope POC-57 from the frozen spec, then --plan --execute --verify)
+```
+
+## The one wrinkle to navigate
+
+VBW works off its **own `.vbw-planning` model**, and this worktree's `.vbw-planning/` carries SiteLine's existing milestones/ROADMAP. So **scope it to POC-57 explicitly** — add POC-57 as the requirement (paste the frozen spec from `experiments/poc-57-backend-ab/SPEC.frozen.md`), don't let `vibe` resume pre-existing SiteLine work. Let it run the full pipeline: `vbw-lead` plans → `vbw-dev` executes → `vbw-qa` verifies. **Do not** `--skip-qa` / `--yolo` — the QA gate is the whole point of this arm.
+
+## Controls (same as the other arms)
+
+- No Linear writes. No shared-DB push (`supabase db push`) / no `mcp.apply_migration` — migration on disk + local/branch DB only.
+- Don't edit POC-57 in Linear during the experiment.
+- Stop after the pipeline completes; no `pk ship`/`pk done`/`pk promote`.
+
+## Capture when done
+
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-vbwfull-1
+git log --oneline exp/POC-57-base..HEAD
+git diff --stat exp/POC-57-base..HEAD -- ':(exclude).vbw-planning'   # code only
+find .vbw-planning -name '*PLAN.md' -o -name '*SUMMARY.md' -o -name '*VERIFICATION.md' | xargs ls -t | head
+# the vbw-lead PLAN + vbw-qa VERIFICATION are the artifacts this arm exists to produce
+```
+
+Plus your wall-clock, intervention count, and whether `vbw-lead`/`vbw-qa` actually fired (the fidelity check for this arm).

--- a/experiments/poc-57-backend-ab/SHIP-RUNCARD.md
+++ b/experiments/poc-57-backend-ab/SHIP-RUNCARD.md
@@ -1,0 +1,37 @@
+# SHIP RUNCARD — POC-57 real ship (native finishes the UI)
+
+**This is the real ship, not an experiment arm.** Branch `feature/POC-57-mvp-client-approve`
+(off real `main`, Linear → In Progress). Worktree: `~/Projects/SiteLine/.worktrees/POC-57-mvp-client-approve`.
+
+## Already in place — DO NOT REDO
+
+The **DB layer is cherry-picked and QA-verified** (from the VBW-full pilot arm, 192/192):
+- `supabase/migrations/...20260608120000_add_approval_fields_to_budget_snapshots.sql` — 3 approval fields + `snapshots_approval_update` RLS policy (plain RLS, **no SECURITY DEFINER**, one-time invariant `approved_at IS NULL`).
+- `supabase/migrations/...20260608120100_harden_snapshot_approval_write.sql` — `SECURITY INVOKER` BEFORE-UPDATE trigger: column-immutability + approver-binding (closes the HIGH escalation/forgery finding the pilot caught).
+- `tests/rls/snapshot-approval.rls.test.js` — the authz suite that *proves* the above.
+
+**Read those two migrations first** — they define the write contract (a plain `UPDATE` of the 3 approval columns; the trigger binds the approver to `auth.uid()` and rejects any other column change / re-approval).
+
+## Native's job — finish the consuming UI only (Phases 2 + 3)
+
+Start a fresh session:
+```bash
+cd ~/Projects/SiteLine/.worktrees/POC-57-mvp-client-approve && claude --dangerously-skip-permissions
+```
+Then run `/work` **scoped to the delta** (tell it up front: *"the DB layer + RLS test are already present and verified — plan and execute ONLY the client UI below"*):
+
+- `src/app/js/database/snapshots.js` — `approveSnapshot(snapshotId, note)` doing the plain RLS-guarded `UPDATE`; add the 3 approval columns to the snapshot selects.
+- `src/app/project_detail.html` — gated Approve button (authenticated contact w/ access · `is_snapshot` · `approved_at == null`); on click → `approveSnapshot` → optimistic re-render to approved state (no full reload).
+- `src/app/js/utils/versions.js` `formatVersionLabel()` + `src/app/js/pages/budget-edit-main.js` — "Approved (date)" stamp sourced from `approved_at` (never `description`).
+
+## Non-negotiable discipline (the pilot's lessons, enforced manually)
+
+1. **Author tests for the new UI/data-layer behavior** — at minimum a unit test that `formatVersionLabel` renders the stamp from `approved_at` (and not when null), and the `approveSnapshot` call shape. Don't lean only on the existing suite. (This is the exact gap that cost native the blind panel.)
+2. **`/verify`** — full gate including `npm run test:rls` (DB/RLS touched).
+3. **`/pr-security-review`** — MANDATORY. This feature has a proven escalation footgun; an adversarial pass is required before ship, not optional.
+4. **`pk ship`** — open the PR (Draft), Linear → UAT.
+
+## Notes
+
+- The cherry-picked migrations are dated `20260608` (one day ahead of today). Functionally fine — strictly later than main's tail `20260607170000`, never applied to a shared env. Optional tidy: rename to today's date before merge; re-confirm tail vs `origin/main` right before merge regardless (parallel-branch rule).
+- Don't `supabase db push` to shared envs; migrations deploy via the normal CI path on merge.

--- a/experiments/poc-57-backend-ab/SPEC.frozen.md
+++ b/experiments/poc-57-backend-ab/SPEC.frozen.md
@@ -1,0 +1,87 @@
+# FROZEN SPEC — POC-57 — native-vs-VBW A/B
+
+> **This file is the single frozen contract for all 6 experiment runs.** Verbatim copy of
+> Linear POC-57 (Status: Approved, Readiness 9/10), pasted 2026-06-06. DO NOT EDIT between
+> runs. Both backends, all 3 reps each, receive THIS exact text as the `/work` input.
+> Target repo: SiteLine. Team key: POC.
+
+---
+
+# MVP: client Approve action on a published version (single sign-off)
+
+## Light Spec
+
+**Status:** Approved · **Complexity:** Medium (~6-10h) · **Derived tier:** tier:standard
+**Linear Project:** i1-p2 Client Approval — Published Versions
+
+### Problem
+
+No durable, contract-level record of a client signing off on a budget. Today "client
+approved" is free text in a snapshot's `description` (rendered "📷 Client approved (date)"
+in `versions.js`) — unauditable, unattributable, unenforceable. Formal approval tables
+(`approvals`/`approval_steps`) were scaffolded but never created; their notification
+functions reference nonexistent tables and triggers are commented out as "Phase 3."
+
+### Goal
+
+A logged-in client contact with project access can click **Approve** on a published budget
+version in the client view, producing a durable, attributable sign-off (who + when + which
+snapshot) that the UI reflects and that notifies the internal publisher.
+
+### Scope
+
+**In scope:** persist approval (timestamp + approver contact id + optional note), one per
+published version; Approve action in `project_detail.html`, gated; DB-level authz rejecting
+non-access writes; "Approved (date)" stamp in internal version list + client view; internal
+notification to publisher on approval.
+**Out of scope:** multi-step/multi-approver engine (POC-58, parked); anonymous/link
+approval; un-approve/revoke; dashboard "pending approvals" widget.
+
+### Decisions (all DEFINED)
+
+- Actor = authenticated contact only — from session `getCurrentContact()`, never a link token.
+- Storage = approval fields directly on the `budget_snapshots` row; no approvals/approval_steps table in v1.
+- One sign-off per published version: unapproved → approved-once; no re-approval.
+- Surface = `project_detail.html` client view (`/project?recordId=…`), not a new page, not the producer editor.
+- Notification recipient = version publisher (`snapshot_by`), fallback snapshot `created_by` if null.
+- Write = plain RLS-guarded `UPDATE` on `budget_snapshots`, NO SECURITY DEFINER (avoids POC-87 footgun).
+- Dashboard count = out of scope for v1.
+
+### Requirements
+
+- [ ] Authenticated contact with project access can record an approval on a published version from the client view.
+- [ ] Approval persists who/when/optional-note, scoped to that published version.
+- [ ] Approve action unavailable on working drafts and on already-approved versions.
+- [ ] Write by a contact without project access is rejected at the DB layer.
+- [ ] Recording an approval enqueues a notification to the version publisher.
+- [ ] Approved versions show "Approved (date)" stamp in internal version list + client view, sourced from the approval field (not `description`).
+
+### Acceptance Criteria
+
+- [ ] Given an authenticated contact with project access viewing a published version (`is_snapshot = true`) not yet approved in `project_detail.html`, when they click **Approve**, then `approved_at` + `approved_by_contact_id` persist on that `budget_snapshots` row AND the view re-renders to the approved state without a full reload.
+- [ ] Given an approved version, when the internal version list (`versions.js` `formatVersionLabel`) and the client view (`project_detail.html`) render it, then both show an "Approved (date)" stamp read from the persisted approval field.
+- [ ] Given a contact **without** project access, when an approval `UPDATE` for that version is attempted, then RLS rejects it and no approval field is set.
+- [ ] Given a working-draft (non-published) version, when an authenticated contact with access views it, then no Approve action is offered.
+- [ ] Given an already-approved version, when any user views it, then the Approve action is not offered (no re-approval).
+- [ ] Given an approval is recorded, when the notification queue is processed, then a notification targeting the publisher (`snapshot_by`, fallback `created_by`) is enqueued referencing that project + snapshot.
+
+### Technical Context
+
+- **Existing code:** `src/app/project_detail.html` (client view; inline script, version selector, `getClientSnapshots`, snapshot badge — Approve action lands here); `src/app/js/database/snapshots.js` (publish RPCs `snapshot_for_client`/`snapshot_and_continue`); `src/app/js/database/versions.js` `formatVersionLabel()` (~120-156; renders 📷 from `description`); `src/app/js/pages/budget-edit-main.js` (internal version list + LIVE tag ~7740/7943); `src/app/js/auth.js` `getCurrentContact()` (~936).
+- **Database:** add nullable approval fields to `budget_snapshots` (`approved_at` timestamptz, `approved_by_contact_id` uuid FK→`contacts`, `approval_note` text). Notification: `notifications_queue` table + `enqueue_notification()` RPC (validates project access). Scaffolded `notify_on_approval_*` functions (migration `20260213142825`) reference never-created tables — **do not depend on them**.
+- **Dependencies:** `process-notifications` edge function.
+- **Patterns:** RLS via `user_has_project_access(project_id)`; existing `snapshots_select`/`snapshots_update` policies as exemplar; idempotent migrations + frozen-file invariant. New approval-write authz = an RLS UPDATE policy requiring project access + `is_snapshot = true` + not-yet-approved.
+- **Authority:** the `budget_snapshots` row is the single source of truth for approval state; the version label and client view are *renderers* of that field and must read it (never `description`). Write authz authoritative at DB RLS layer; client JS gating is UX only.
+
+### Notes
+
+tier:standard. Contract-level sign-off — record must be unambiguous and auditable
+(who + when + which snapshot). Touches financial sign-off but not totals math → not
+financial-review-critical. Write path deliberately avoids SECURITY DEFINER per POC-87.
+
+### Spec Review Agent verdict (v5)
+
+Verdict: Pass · Spec: Pass · Readiness 9/10 · Blocking: None · Decomposition Readiness: Yes.
+Non-blocking: (1) define behavior when `snapshot_by` AND `created_by` both null/non-notifiable;
+(2) state whether the optional note is in the MVP click-UI or persisted-field-only;
+(3) make the one-time invariant explicit at the write predicate (`approved_at is null` at UPDATE).

--- a/experiments/poc-57-backend-ab/VERDICT.md
+++ b/experiments/poc-57-backend-ab/VERDICT.md
@@ -1,0 +1,96 @@
+# POC-57 — Verdict (native vs vbw, blind-judged)
+
+> **Status: pilot (1 rep per arm), concluded by the real ship.** Scored blind by a fresh-context
+> judge that never read `judge/KEY.private.txt` and grounded every load-bearing claim against the
+> live SiteLine repo + the team's *actually-shipped* POC-57 migration chain. De-blinded after scoring.
+> This is a **directional** data point, **not** co-equal statistical justification with POC-48
+> round-two — read it as a caution flag, not a coronation.
+
+## What POC-57 was
+
+A head-to-head on a real SiteLine feature (MVP client **Approve** action on a published
+`budget_snapshots` version — durable single sign-off; frozen contract in `SPEC.frozen.md`,
+== `judge/CONTRACT.md`). Three arms off the same base (`exp/POC-57-base`):
+
+| Arm | What it is | In judged pairing? |
+|---|---|---|
+| `native-1` | Pipekit `/work` **native** backend (3.0 default — task DAG on the Workflow primitive) | **yes → impl-A** |
+| `vbw-1` | Pipekit `/work` **vbw** backend (`vbw-dev` executes `/work`'s inline plan) | **yes → impl-B** |
+| `vbwfull-1` | The full `vbw-lead→vbw-dev→vbw-qa` pipeline ("VBW the system", which `/work` never invokes) | no — but **its DB layer is what shipped** |
+
+The blind pairing scored was **native (A) vs vbw (B)** — the two executors `/work` actually offers.
+
+## De-blind key
+
+```
+impl-A = native-1
+impl-B = vbw-1
+```
+
+## Result — the two arms failed in opposite directions
+
+| Criterion | native (A) | vbw (B) |
+|---|---|---|
+| AC1 persist + live re-render | **PARTIAL** — `approved_at` from **client clock** (forgeable, Medium) | **PASS** — `now()` server-side |
+| AC2 stamp from `approved_at`, both surfaces | PASS | PASS |
+| AC3 no-access write rejected at DB | PASS | PASS |
+| AC4 no Approve on draft (UX+DB) | PASS | PASS |
+| AC5 no re-approval (UX+DB) | PASS | PASS |
+| AC6 publisher notification enqueues | **FAIL** — `SECURITY INVOKER` trigger can't call `enqueue_notification` (revoked from `authenticated`); wrapped in `RAISE WARNING` → **silently never fires** | **PARTIAL** — `SECURITY DEFINER` trigger in the *correct* context (works), but **no fail-open wrap** → a publisher who lost access **rolls back the approval** |
+| Write path: **NO SECURITY DEFINER** (spec-DEFINED, POC-87) | **PASS** — plain RLS UPDATE + INVOKER guard (matches what shipped) | **FAIL** — write path is a `SECURITY DEFINER` RPC (violates a DEFINED decision) |
+| Approver-identity forgery blocked | PASS | PASS |
+| Timestamp forgery blocked | **FAIL** | PASS |
+| Tests authored | **FAIL — zero** | **PASS** — RLS authz suite (non-mutation asserts) + `formatVersionLabel` unit tests, test-commit-first |
+| Commit discipline | atomic, not test-first | atomic, test-first ordering |
+
+### Both arms failed AC6 (notification) — the most important finding
+Neither backend shipped a correct notification path. native's is dead-on-arrival (silent
+permission-denied); vbw's works on the happy path but is fail-closed (missing exception wrap).
+The `enqueue_notification` grant reality (revoked from `authenticated`, postgres-only, raises if
+recipient lacks access) is a non-obvious landmine neither fully cleared. The shipped reference
+needed a dedicated, heavily-commented migration (`...120200`) to get **both** halves right
+(SECURITY DEFINER **and** `BEGIN/EXCEPTION` fail-open).
+
+## Blind winner, and the de-blinded reading
+
+**Blind verdict: impl-B (vbw) wins, medium confidence** — it satisfied more of the contract
+(AC1–AC5 outright + AC6's hard part) and shipped a real adversarial test suite, where native
+failed AC6 and left a forgeable timestamp.
+
+**De-blinded, the honest reading is a split, not a vbw win:**
+
+- **native got the architecture right.** Its plain-RLS / no-SECDEF write path matched both the
+  spec's DEFINED POC-87 decision **and** what ultimately shipped. vbw *violated* that DEFINED
+  decision with a SECDEF RPC. On the dimension the spec author cared most about, native was correct.
+- **native got the execution wrong in its known weak spot.** Zero tests + a client-clock timestamp
+  are exactly the failure modes a test suite catches — and "not authoring tests" is the *same* gap
+  the SHIP-RUNCARD flagged as "the exact gap that cost native the blind panel." This is a **repeated**
+  native weakness, not a one-off.
+- **vbw was more thorough but over-reached** — tested, server-bound, working notification context,
+  but bought it with a spec-violating architecture and a fail-closed edge.
+
+If the rubric treats "violated a DEFINED decision" as a disqualifier, **native wins on compliance** —
+at the cost of an untested, partially-broken delivery. That tension is the cleanest takeaway.
+
+## How it actually resolved (the strongest signal)
+
+The team did **not** pick a backend wholesale. The shipped feature is a **hybrid**: the QA'd DB
+layer came from the `vbwfull` arm (plain RLS — native's architecture, vbw-the-system's execution),
+and **native finished the consuming UI** on top of it. Even that composite needed two follow-up
+migrations to close issues *both* judged arms had (`...120500` server-clock; `...120200` fail-open
+notification). The real-world answer was *compose + gate*, not *crown a backend*.
+
+## What this means for Pipekit 3.0
+
+POC-57 does **not** overturn the native-default decision (POC-48 round-two justifies that), and it
+does **not** cleanly confirm "native wins" either. Its load-bearing lesson is narrower and it
+*reinforces* 3.0's design rather than challenging it:
+
+> Native's architectural judgment is sound; its recurring weakness is execution discipline
+> (test-authoring, server-side detail). That is precisely the gap the **gate layer**
+> (`/verify` test-first enforcement, `/pr-security-review`, `/financial-review`) — which **both
+> backends run** — exists to backstop. The safety net is the gate, not the executor.
+
+**Caveats:** single pilot rep per arm (`-1`), so this is directional; the verdict is rubric-dependent
+(compliance vs delivered-quality flip the winner); and the judged pairing excludes `vbwfull`, whose
+DB layer is the one that shipped.

--- a/experiments/poc-57-backend-ab/judge/CONTRACT.md
+++ b/experiments/poc-57-backend-ab/judge/CONTRACT.md
@@ -1,0 +1,87 @@
+# FROZEN SPEC — POC-57 — native-vs-VBW A/B
+
+> **This file is the single frozen contract for all 6 experiment runs.** Verbatim copy of
+> Linear POC-57 (Status: Approved, Readiness 9/10), pasted 2026-06-06. DO NOT EDIT between
+> runs. Both backends, all 3 reps each, receive THIS exact text as the `/work` input.
+> Target repo: SiteLine. Team key: POC.
+
+---
+
+# MVP: client Approve action on a published version (single sign-off)
+
+## Light Spec
+
+**Status:** Approved · **Complexity:** Medium (~6-10h) · **Derived tier:** tier:standard
+**Linear Project:** i1-p2 Client Approval — Published Versions
+
+### Problem
+
+No durable, contract-level record of a client signing off on a budget. Today "client
+approved" is free text in a snapshot's `description` (rendered "📷 Client approved (date)"
+in `versions.js`) — unauditable, unattributable, unenforceable. Formal approval tables
+(`approvals`/`approval_steps`) were scaffolded but never created; their notification
+functions reference nonexistent tables and triggers are commented out as "Phase 3."
+
+### Goal
+
+A logged-in client contact with project access can click **Approve** on a published budget
+version in the client view, producing a durable, attributable sign-off (who + when + which
+snapshot) that the UI reflects and that notifies the internal publisher.
+
+### Scope
+
+**In scope:** persist approval (timestamp + approver contact id + optional note), one per
+published version; Approve action in `project_detail.html`, gated; DB-level authz rejecting
+non-access writes; "Approved (date)" stamp in internal version list + client view; internal
+notification to publisher on approval.
+**Out of scope:** multi-step/multi-approver engine (POC-58, parked); anonymous/link
+approval; un-approve/revoke; dashboard "pending approvals" widget.
+
+### Decisions (all DEFINED)
+
+- Actor = authenticated contact only — from session `getCurrentContact()`, never a link token.
+- Storage = approval fields directly on the `budget_snapshots` row; no approvals/approval_steps table in v1.
+- One sign-off per published version: unapproved → approved-once; no re-approval.
+- Surface = `project_detail.html` client view (`/project?recordId=…`), not a new page, not the producer editor.
+- Notification recipient = version publisher (`snapshot_by`), fallback snapshot `created_by` if null.
+- Write = plain RLS-guarded `UPDATE` on `budget_snapshots`, NO SECURITY DEFINER (avoids POC-87 footgun).
+- Dashboard count = out of scope for v1.
+
+### Requirements
+
+- [ ] Authenticated contact with project access can record an approval on a published version from the client view.
+- [ ] Approval persists who/when/optional-note, scoped to that published version.
+- [ ] Approve action unavailable on working drafts and on already-approved versions.
+- [ ] Write by a contact without project access is rejected at the DB layer.
+- [ ] Recording an approval enqueues a notification to the version publisher.
+- [ ] Approved versions show "Approved (date)" stamp in internal version list + client view, sourced from the approval field (not `description`).
+
+### Acceptance Criteria
+
+- [ ] Given an authenticated contact with project access viewing a published version (`is_snapshot = true`) not yet approved in `project_detail.html`, when they click **Approve**, then `approved_at` + `approved_by_contact_id` persist on that `budget_snapshots` row AND the view re-renders to the approved state without a full reload.
+- [ ] Given an approved version, when the internal version list (`versions.js` `formatVersionLabel`) and the client view (`project_detail.html`) render it, then both show an "Approved (date)" stamp read from the persisted approval field.
+- [ ] Given a contact **without** project access, when an approval `UPDATE` for that version is attempted, then RLS rejects it and no approval field is set.
+- [ ] Given a working-draft (non-published) version, when an authenticated contact with access views it, then no Approve action is offered.
+- [ ] Given an already-approved version, when any user views it, then the Approve action is not offered (no re-approval).
+- [ ] Given an approval is recorded, when the notification queue is processed, then a notification targeting the publisher (`snapshot_by`, fallback `created_by`) is enqueued referencing that project + snapshot.
+
+### Technical Context
+
+- **Existing code:** `src/app/project_detail.html` (client view; inline script, version selector, `getClientSnapshots`, snapshot badge — Approve action lands here); `src/app/js/database/snapshots.js` (publish RPCs `snapshot_for_client`/`snapshot_and_continue`); `src/app/js/database/versions.js` `formatVersionLabel()` (~120-156; renders 📷 from `description`); `src/app/js/pages/budget-edit-main.js` (internal version list + LIVE tag ~7740/7943); `src/app/js/auth.js` `getCurrentContact()` (~936).
+- **Database:** add nullable approval fields to `budget_snapshots` (`approved_at` timestamptz, `approved_by_contact_id` uuid FK→`contacts`, `approval_note` text). Notification: `notifications_queue` table + `enqueue_notification()` RPC (validates project access). Scaffolded `notify_on_approval_*` functions (migration `20260213142825`) reference never-created tables — **do not depend on them**.
+- **Dependencies:** `process-notifications` edge function.
+- **Patterns:** RLS via `user_has_project_access(project_id)`; existing `snapshots_select`/`snapshots_update` policies as exemplar; idempotent migrations + frozen-file invariant. New approval-write authz = an RLS UPDATE policy requiring project access + `is_snapshot = true` + not-yet-approved.
+- **Authority:** the `budget_snapshots` row is the single source of truth for approval state; the version label and client view are *renderers* of that field and must read it (never `description`). Write authz authoritative at DB RLS layer; client JS gating is UX only.
+
+### Notes
+
+tier:standard. Contract-level sign-off — record must be unambiguous and auditable
+(who + when + which snapshot). Touches financial sign-off but not totals math → not
+financial-review-critical. Write path deliberately avoids SECURITY DEFINER per POC-87.
+
+### Spec Review Agent verdict (v5)
+
+Verdict: Pass · Spec: Pass · Readiness 9/10 · Blocking: None · Decomposition Readiness: Yes.
+Non-blocking: (1) define behavior when `snapshot_by` AND `created_by` both null/non-notifiable;
+(2) state whether the optional note is in the MVP click-UI or persisted-field-only;
+(3) make the one-time invariant explicit at the write predicate (`approved_at is null` at UPDATE).

--- a/experiments/poc-57-backend-ab/judge/KEY.private.txt
+++ b/experiments/poc-57-backend-ab/judge/KEY.private.txt
@@ -1,0 +1,2 @@
+A=native-1
+B=vbw-1

--- a/experiments/poc-57-backend-ab/judge/impl-A.commits.txt
+++ b/experiments/poc-57-backend-ab/judge/impl-A.commits.txt
@@ -1,0 +1,5 @@
+feat(approvals): Approved stamp in internal version list
+feat(approvals): Approve action + approved stamp in client view
+feat(approvals): version label reads approval stamp from approved_at
+feat(approvals): approveSnapshot() data-layer call + approval select columns
+feat(approvals): DB contract for client sign-off on published versions

--- a/experiments/poc-57-backend-ab/judge/impl-A.diff
+++ b/experiments/poc-57-backend-ab/judge/impl-A.diff
@@ -1,0 +1,433 @@
+diff --git a/src/app/js/database/snapshots.js b/src/app/js/database/snapshots.js
+index 4fab42ec..9ea37c1e 100644
+--- a/src/app/js/database/snapshots.js
++++ b/src/app/js/database/snapshots.js
+@@ -45,7 +45,7 @@ async function getProjectSnapshots(projectId) {
+     const { data, error } = await supabaseClient
+         .from('budget_snapshots')
+         .select(
+-            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency',
++            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency, approved_at, approved_by_contact_id, approval_note',
+         )
+         .eq('project_id', projectId)
+         .order('created_at', { ascending: false });
+@@ -169,7 +169,7 @@ async function createVersionedSnapshot(projectId, description = null, majorBump
+  */
+ async function getProjectVersions(projectId, includeArchived = false) {
+     const snapshotColumns =
+-        'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency';
++        'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency, approved_at, approved_by_contact_id, approval_note';
+     let query = supabaseClient
+         .from('budget_snapshots')
+         .select(snapshotColumns)
+@@ -447,7 +447,7 @@ async function getClientSnapshots(projectId) {
+     const { data, error } = await supabaseClient
+         .from('budget_snapshots')
+         .select(
+-            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency',
++            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency, approved_at, approved_by_contact_id, approval_note',
+         )
+         .eq('project_id', projectId)
+         .eq('is_snapshot', true)
+@@ -526,6 +526,49 @@ async function updateVersion(snapshotId, updates) {
+     return data;
+ }
+ 
++/**
++ * Record a client sign-off on a published version (POC-57).
++ *
++ * Plain RLS-guarded write: the snapshots_approve_update policy plus the
++ * column-scope guard trigger enforce project access, published-only, write-once,
++ * and approver-is-caller at the DB layer. The client-side filters here are UX
++ * only (a stale/duplicate click resolves to a thrown "no row" rather than a
++ * silent no-op). Approval notification to the publisher fires server-side via
++ * the AFTER-UPDATE trigger.
++ *
++ * @param {string} snapshotId - The published version to approve
++ * @param {string|null} [note] - Optional approval note
++ * @returns {Promise<object>} The updated snapshot row (approval fields populated)
++ * @throws if the write is rejected (no access / already approved / not published)
++ */
++async function approveSnapshot(snapshotId, note = null) {
++    const contact = await getCurrentContact();
++    if (!contact) {
++        throw new Error('You must be signed in to approve a version.');
++    }
++
++    const { data, error } = await supabaseClient
++        .from('budget_snapshots')
++        .update({
++            approved_at: new Date().toISOString(),
++            approved_by_contact_id: contact.id,
++            approval_note: note,
++        })
++        .eq('id', snapshotId)
++        .eq('is_snapshot', true)
++        .is('approved_at', null)
++        .select(
++            'id, project_id, name, created_by, snapshot_by, version_major, version_minor, is_snapshot, approved_at, approved_by_contact_id, approval_note',
++        )
++        .single();
++
++    if (error) {
++        console.error('Error approving version:', error);
++        throw error;
++    }
++    return data;
++}
++
+ // ============================================
+ // EXPORT TO WINDOW (backward compatibility)
+ // ============================================
+@@ -550,3 +593,4 @@ window.getVersionLineItems = getVersionLineItems;
+ window.getVersionData = getVersionData;
+ window.getClientSnapshots = getClientSnapshots;
+ window.updateVersion = updateVersion;
++window.approveSnapshot = approveSnapshot;
+diff --git a/src/app/js/pages/budget-edit-main.js b/src/app/js/pages/budget-edit-main.js
+index 753d00bb..af22c212 100644
+--- a/src/app/js/pages/budget-edit-main.js
++++ b/src/app/js/pages/budget-edit-main.js
+@@ -7943,6 +7943,15 @@ function renderVersionRow(version, liveVersionId) {
+     if (isLive) statusTags += '<span class="status-tag live">LIVE</span>';
+     if (version.is_snapshot) statusTags += '<span class="status-tag snapshot">📸 Published</span>';
+     if (version.is_archived) statusTags += '<span class="status-tag archived">Archived</span>';
++    // POC-57: approval stamp sourced from the persisted field, not description.
++    if (version.approved_at) {
++        const approvedStr = new Date(version.approved_at).toLocaleDateString('en-US', {
++            year: 'numeric',
++            month: 'short',
++            day: 'numeric',
++        });
++        statusTags += `<span class="status-tag" style="background:#2e7d32;color:#fff;">✅ Approved (${approvedStr})</span>`;
++    }
+ 
+     // Build action buttons
+     let actions = '';
+diff --git a/src/app/js/utils/versions.js b/src/app/js/utils/versions.js
+index 61e9d7c2..3d777673 100644
+--- a/src/app/js/utils/versions.js
++++ b/src/app/js/utils/versions.js
+@@ -111,11 +111,11 @@ function isLiveVersion(version, allVersions) {
+  * @param {boolean} [options.isLive=false] - Whether this is the live version
+  * @param {boolean} [options.showDate=true] - Include date in label
+  * @param {boolean} [options.showNote=true] - Include snapshot note in label
+- * @returns {string} Formatted label (e.g., "v1.03 [LIVE] 📷 Client approved (Jan 15, 2026)")
++ * @returns {string} Formatted label (e.g., "v1.03 [LIVE] 📷 ✅ Approved (Jan 15, 2026)")
+  *
+  * @example
+- * formatVersionLabel({ version_major: 1, version_minor: 3, is_snapshot: true, description: 'Client approved', created_at: '2026-01-15' }, { isLive: true })
+- * // Returns: "v1.03 [LIVE] 📷 Client approved (Jan 15, 2026)"
++ * formatVersionLabel({ version_major: 1, version_minor: 3, is_snapshot: true, approved_at: '2026-01-15', created_at: '2026-01-10' }, { isLive: true })
++ * // Returns: "v1.03 [LIVE] 📷 ✅ Approved (Jan 15, 2026) (Jan 10, 2026)"
+  */
+ function formatVersionLabel(version, options = {}) {
+     const { isLive = false, showDate = true, showNote = true } = options;
+@@ -141,6 +141,18 @@ function formatVersionLabel(version, options = {}) {
+         noteStr = ` ${desc}`;
+     }
+ 
++    // Approval stamp — sourced from the persisted approval field (POC-57),
++    // never from `description` free text.
++    let approvalStr = '';
++    if (version.approved_at) {
++        const approvedDate = new Date(version.approved_at);
++        approvalStr = ` ✅ Approved (${approvedDate.toLocaleDateString('en-US', {
++            month: 'short',
++            day: 'numeric',
++            year: 'numeric',
++        })})`;
++    }
++
+     // Format date
+     let dateStr = '';
+     if (showDate && version.created_at) {
+@@ -152,7 +164,7 @@ function formatVersionLabel(version, options = {}) {
+         })})`;
+     }
+ 
+-    return `${versionStr}${liveTag}${snapshotTag}${noteStr}${dateStr}`;
++    return `${versionStr}${liveTag}${snapshotTag}${noteStr}${approvalStr}${dateStr}`;
+ }
+ 
+ /**
+diff --git a/src/app/project_detail.html b/src/app/project_detail.html
+index 498277e4..01756a6f 100644
+--- a/src/app/project_detail.html
++++ b/src/app/project_detail.html
+@@ -312,6 +312,33 @@
+                 font-weight: 600;
+             }
+ 
++            /* POC-57: client approval control */
++            .approve-btn {
++                margin-left: 10px;
++                padding: 4px 14px;
++                border: 1px solid var(--color-success, #2e7d32);
++                background: var(--color-success, #2e7d32);
++                color: #fff;
++                border-radius: 6px;
++                font-size: 12px;
++                font-weight: 600;
++                cursor: pointer;
++            }
++            .approve-btn:hover {
++                opacity: 0.9;
++            }
++            .approve-btn:disabled {
++                opacity: 0.6;
++                cursor: default;
++            }
++            .approval-stamp {
++                display: inline-block;
++                margin-left: 10px;
++                color: var(--color-success, #2e7d32);
++                font-size: 12px;
++                font-weight: 600;
++            }
++
+             /* v0 style export buttons - outline with subtle icon colors */
+             .export-buttons {
+                 display: flex;
+@@ -2202,6 +2229,56 @@
+     `;
+                 }
+ 
++                // POC-57: the currently selected published version object.
++                function getCurrentSnapshot() {
++                    if (!clientSnapshots || clientSnapshots.length === 0) return null;
++                    return (
++                        clientSnapshots.find((s) => s.id === currentSnapshotId) ||
++                        clientSnapshots[0]
++                    );
++                }
++
++                // POC-57: Approve action / "Approved (date)" stamp for the client view.
++                // Visibility is UX only — the DB (RLS + guard trigger) is authoritative.
++                function renderApprovalControl() {
++                    const snap = getCurrentSnapshot();
++                    if (!snap || !snap.is_snapshot) return '';
++
++                    if (snap.approved_at) {
++                        const approvedDate = new Date(
++                            snap.approved_at,
++                        ).toLocaleDateString('en-US', {
++                            month: 'short',
++                            day: 'numeric',
++                            year: 'numeric',
++                        });
++                        return `<span class="approval-stamp">✅ Approved (${approvedDate})</span>`;
++                    }
++
++                    return `<button class="approve-btn" onclick="window.approveVersion('${snap.id}')">Approve</button>`;
++                }
++
++                // POC-57: record the sign-off, then re-render the approved state
++                // (loadBudget re-fetches clientSnapshots with approved_at) — no full reload.
++                window.approveVersion = async function (snapshotId) {
++                    const btn = document.querySelector('.approve-btn');
++                    if (btn) {
++                        btn.disabled = true;
++                        btn.textContent = 'Approving…';
++                    }
++                    try {
++                        await approveSnapshot(snapshotId);
++                        await loadBudget();
++                    } catch (err) {
++                        console.error('Approval failed:', err);
++                        alert('Could not record approval. Please try again.');
++                        if (btn) {
++                            btn.disabled = false;
++                            btn.textContent = 'Approve';
++                        }
++                    }
++                };
++
+                 // Switch to a different snapshot version
+                 window.switchSnapshot = async function (snapshotId, options = {}) {
+                     if (!snapshotId || snapshotId === currentSnapshotId) return;
+@@ -2270,7 +2347,7 @@
+           <div class="header-label">Account Director:</div>
+           <div class="header-value">${escapeHtml(project.director) || '-'}</div>
+           <div class="header-label">Version:</div>
+-          <div class="header-value">${renderVersionSelector()}</div>
++          <div class="header-value">${renderVersionSelector()}${renderApprovalControl()}</div>
+         </div>
+         <div class="header-right">
+           <div class="company-name">${escapeHtml(entity.name)}</div>
+diff --git a/supabase/migrations/20260607180000_client_approval_on_published_version.sql b/supabase/migrations/20260607180000_client_approval_on_published_version.sql
+new file mode 100644
+index 00000000..38ca8e44
+--- /dev/null
++++ b/supabase/migrations/20260607180000_client_approval_on_published_version.sql
+@@ -0,0 +1,170 @@
++-- POC-57: MVP client Approve action on a published version (single sign-off).
++--
++-- Records a durable, attributable client sign-off directly on the published
++-- budget_snapshots row (who + when + optional note), one per published version.
++--
++-- Write authorization is a PLAIN RLS-guarded UPDATE (no SECURITY DEFINER bypass,
++-- deliberately avoiding the POC-87 footgun). Because `authenticated` holds a
++-- table-wide UPDATE grant on budget_snapshots, an RLS policy alone cannot
++-- restrict WHICH columns a client may change -- so a BEFORE-UPDATE guard trigger
++-- confines non-editor (client) writers to the three approval columns, binds the
++-- approver to the caller, and enforces the one-time/published-only invariant.
++--
++-- The scaffolded notify_on_approval_* functions (migration 20260213142825)
++-- reference never-created approvals/approval_steps tables -- this migration does
++-- NOT depend on them; it adds its own AFTER-UPDATE notification trigger.
++--
++-- Idempotent per the frozen-file invariant.
++
++-- 1. Approval columns (nullable; absence = not yet approved) ------------------
++
++ALTER TABLE public.budget_snapshots
++    ADD COLUMN IF NOT EXISTS approved_at timestamptz,
++    ADD COLUMN IF NOT EXISTS approved_by_contact_id uuid,
++    ADD COLUMN IF NOT EXISTS approval_note text;
++
++DO $$
++BEGIN
++    IF NOT EXISTS (
++        SELECT 1 FROM pg_constraint
++        WHERE conname = 'budget_snapshots_approved_by_contact_id_fkey'
++    ) THEN
++        ALTER TABLE public.budget_snapshots
++            ADD CONSTRAINT budget_snapshots_approved_by_contact_id_fkey
++            FOREIGN KEY (approved_by_contact_id) REFERENCES public.contacts(id);
++    END IF;
++END $$;
++
++COMMENT ON COLUMN public.budget_snapshots.approved_at IS
++    'POC-57: client sign-off timestamp on a published version. NULL = not yet approved. One-time (write-once via guard trigger).';
++COMMENT ON COLUMN public.budget_snapshots.approved_by_contact_id IS
++    'POC-57: contact who recorded the approval. Bound to the authenticated caller by the column-scope guard trigger.';
++COMMENT ON COLUMN public.budget_snapshots.approval_note IS
++    'POC-57: optional free-text note captured with the client approval.';
++
++-- 2. RLS: allow a project-access contact to approve an unapproved published ---
++--    version. Permissive, OR'd with snapshots_update (which covers editors).
++
++DROP POLICY IF EXISTS "snapshots_approve_update" ON public.budget_snapshots;
++CREATE POLICY "snapshots_approve_update" ON public.budget_snapshots
++    FOR UPDATE
++    USING (
++        public.user_has_project_access(project_id)
++        AND is_snapshot = true
++        AND approved_at IS NULL
++    )
++    WITH CHECK (
++        public.user_has_project_access(project_id)
++        AND is_snapshot = true
++    );
++
++-- 3. Column-scope guard: confine non-editor writers to the approval columns ---
++--    and enforce the published-only / one-time / approver-is-caller invariants.
++
++CREATE OR REPLACE FUNCTION public.enforce_snapshot_approval_column_scope()
++RETURNS trigger
++LANGUAGE plpgsql
++SECURITY INVOKER
++SET search_path = 'public'
++AS $$
++DECLARE
++    v_caller_contact_id uuid;
++BEGIN
++    -- Service-role / internal (no auth context) and project editors/admins are
++    -- unrestricted -- this guard only tightens the client approval path.
++    IF auth.uid() IS NULL THEN
++        RETURN NEW;
++    END IF;
++    IF public.is_current_user_sitepro_admin()
++       OR public.user_can_edit_project(NEW.project_id) THEN
++        RETURN NEW;
++    END IF;
++
++    -- Client path: only the three approval columns may differ.
++    IF (to_jsonb(OLD) - 'approved_at' - 'approved_by_contact_id' - 'approval_note')
++       IS DISTINCT FROM
++       (to_jsonb(NEW) - 'approved_at' - 'approved_by_contact_id' - 'approval_note') THEN
++        RAISE EXCEPTION 'Only approval fields may be modified on a published version by a client';
++    END IF;
++
++    -- Published-only, write-once sign-off.
++    IF NOT OLD.is_snapshot THEN
++        RAISE EXCEPTION 'Approval is only allowed on a published version';
++    END IF;
++    IF OLD.approved_at IS NOT NULL THEN
++        RAISE EXCEPTION 'This version has already been approved';
++    END IF;
++    IF NEW.approved_at IS NULL THEN
++        RAISE EXCEPTION 'Approval requires approved_at to be set';
++    END IF;
++
++    -- Attributable: the approver must be the authenticated caller's own contact.
++    SELECT id INTO v_caller_contact_id
++    FROM public.contacts
++    WHERE auth_user_id = auth.uid();
++    IF NEW.approved_by_contact_id IS DISTINCT FROM v_caller_contact_id THEN
++        RAISE EXCEPTION 'Approver must be the authenticated contact';
++    END IF;
++
++    RETURN NEW;
++END;
++$$;
++
++DROP TRIGGER IF EXISTS trg_enforce_snapshot_approval_column_scope ON public.budget_snapshots;
++CREATE TRIGGER trg_enforce_snapshot_approval_column_scope
++    BEFORE UPDATE ON public.budget_snapshots
++    FOR EACH ROW
++    EXECUTE FUNCTION public.enforce_snapshot_approval_column_scope();
++
++-- 4. Notify the version publisher on approval (best-effort; never aborts the --
++--    sign-off). Recipient = snapshot_by, falling back to created_by.
++
++CREATE OR REPLACE FUNCTION public.notify_on_version_approval()
++RETURNS trigger
++LANGUAGE plpgsql
++SECURITY INVOKER
++SET search_path = 'public'
++AS $$
++DECLARE
++    v_recipient uuid;
++BEGIN
++    -- Fire only on the transition into the approved state.
++    IF NEW.approved_at IS NOT NULL AND OLD.approved_at IS NULL THEN
++        v_recipient := COALESCE(NEW.snapshot_by, NEW.created_by);
++
++        -- Skip if there is no notifiable publisher, or the approver is the publisher.
++        IF v_recipient IS NOT NULL
++           AND v_recipient IS DISTINCT FROM NEW.approved_by_contact_id THEN
++            BEGIN
++                PERFORM public.enqueue_notification(
++                    v_recipient,
++                    'approval_complete',
++                    'approval',
++                    NEW.id,
++                    NEW.project_id,
++                    jsonb_build_object(
++                        'snapshot_id', NEW.id,
++                        'version_major', NEW.version_major,
++                        'version_minor', NEW.version_minor,
++                        'approved_by_contact_id', NEW.approved_by_contact_id
++                    )
++                );
++            EXCEPTION WHEN OTHERS THEN
++                -- Notification is secondary to the durable sign-off; log loudly
++                -- but do not roll back the approval.
++                RAISE WARNING 'notify_on_version_approval: enqueue failed for snapshot %: %', NEW.id, SQLERRM;
++            END;
++        END IF;
++    END IF;
++    RETURN NEW;
++END;
++$$;
++
++DROP TRIGGER IF EXISTS trg_notify_on_version_approval ON public.budget_snapshots;
++CREATE TRIGGER trg_notify_on_version_approval
++    AFTER UPDATE ON public.budget_snapshots
++    FOR EACH ROW
++    EXECUTE FUNCTION public.notify_on_version_approval();
++
++-- 5. Refresh PostgREST schema cache so the new columns are queryable. ---------
++NOTIFY pgrst, 'reload schema';

--- a/experiments/poc-57-backend-ab/judge/impl-B.commits.txt
+++ b/experiments/poc-57-backend-ab/judge/impl-B.commits.txt
@@ -1,0 +1,6 @@
+test(approval): unit + RLS coverage for client snapshot approval (POC-57)
+feat(client-view): Approve button + approval stamp on published versions (POC-57)
+feat(budget-edit): surface approval columns in internal version lists (POC-57)
+feat(versions): render Approved (date) stamp from approved_at in formatVersionLabel (POC-57)
+feat(snapshots): approveSnapshot client and approval columns in getClientSnapshots (POC-57)
+feat(db): client snapshot approval RPC + notification trigger (POC-57)

--- a/experiments/poc-57-backend-ab/judge/impl-B.diff
+++ b/experiments/poc-57-backend-ab/judge/impl-B.diff
@@ -1,0 +1,645 @@
+diff --git a/src/app/js/database/snapshots.js b/src/app/js/database/snapshots.js
+index 4fab42ec..11411ca1 100644
+--- a/src/app/js/database/snapshots.js
++++ b/src/app/js/database/snapshots.js
+@@ -45,7 +45,7 @@ async function getProjectSnapshots(projectId) {
+     const { data, error } = await supabaseClient
+         .from('budget_snapshots')
+         .select(
+-            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency',
++            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency, approved_at, approved_by_contact_id, approval_note',
+         )
+         .eq('project_id', projectId)
+         .order('created_at', { ascending: false });
+@@ -169,7 +169,7 @@ async function createVersionedSnapshot(projectId, description = null, majorBump
+  */
+ async function getProjectVersions(projectId, includeArchived = false) {
+     const snapshotColumns =
+-        'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency';
++        'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency, approved_at, approved_by_contact_id, approval_note';
+     let query = supabaseClient
+         .from('budget_snapshots')
+         .select(snapshotColumns)
+@@ -447,7 +447,7 @@ async function getClientSnapshots(projectId) {
+     const { data, error } = await supabaseClient
+         .from('budget_snapshots')
+         .select(
+-            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency',
++            'id, project_id, name, description, created_by, created_at, production_fee_pct, production_fee_on_subtotal, contingency_pct, version_major, version_minor, is_locked, is_snapshot, is_archived, currency, approved_at, approved_by_contact_id, approval_note',
+         )
+         .eq('project_id', projectId)
+         .eq('is_snapshot', true)
+@@ -461,6 +461,27 @@ async function getClientSnapshots(projectId) {
+     return data || [];
+ }
+ 
++/**
++ * Record a client sign-off on a published budget version.
++ * Calls the gated approve_snapshot RPC (auth + project-access + one-time invariant
++ * are enforced server-side). UI gating is advisory only.
++ * @param {string} snapshotId - The published version (is_snapshot=true) to approve
++ * @param {string|null} note - Optional approval note
++ * @returns {Promise<object>} The updated budget_snapshots row
++ */
++async function approveSnapshot(snapshotId, note = null) {
++    const { data, error } = await supabaseClient.rpc('approve_snapshot', {
++        p_snapshot_id: snapshotId,
++        p_note: note,
++    });
++
++    if (error) {
++        console.error('Error approving snapshot:', error);
++        throw error;
++    }
++    return data;
++}
++
+ /**
+  * Update a version's settings (fee percentages, etc.)
+  * Only allows updating unlocked versions (working draft)
+@@ -549,4 +570,5 @@ window.unsnapshotVersion = unsnapshotVersion;
+ window.getVersionLineItems = getVersionLineItems;
+ window.getVersionData = getVersionData;
+ window.getClientSnapshots = getClientSnapshots;
++window.approveSnapshot = approveSnapshot;
+ window.updateVersion = updateVersion;
+diff --git a/src/app/js/pages/budget-edit-main.js b/src/app/js/pages/budget-edit-main.js
+index 753d00bb..c8d836ce 100644
+--- a/src/app/js/pages/budget-edit-main.js
++++ b/src/app/js/pages/budget-edit-main.js
+@@ -7942,6 +7942,14 @@ function renderVersionRow(version, liveVersionId) {
+     let statusTags = '';
+     if (isLive) statusTags += '<span class="status-tag live">LIVE</span>';
+     if (version.is_snapshot) statusTags += '<span class="status-tag snapshot">📸 Published</span>';
++    if (version.approved_at) {
++        const approvedDate = new Date(version.approved_at).toLocaleDateString('en-US', {
++            year: 'numeric',
++            month: 'short',
++            day: 'numeric',
++        });
++        statusTags += `<span class="status-tag approved">✓ Approved (${approvedDate})</span>`;
++    }
+     if (version.is_archived) statusTags += '<span class="status-tag archived">Archived</span>';
+ 
+     // Build action buttons
+diff --git a/src/app/js/utils/versions.js b/src/app/js/utils/versions.js
+index 61e9d7c2..af01b376 100644
+--- a/src/app/js/utils/versions.js
++++ b/src/app/js/utils/versions.js
+@@ -111,11 +111,11 @@ function isLiveVersion(version, allVersions) {
+  * @param {boolean} [options.isLive=false] - Whether this is the live version
+  * @param {boolean} [options.showDate=true] - Include date in label
+  * @param {boolean} [options.showNote=true] - Include snapshot note in label
+- * @returns {string} Formatted label (e.g., "v1.03 [LIVE] 📷 Client approved (Jan 15, 2026)")
++ * @returns {string} Formatted label (e.g., "v1.03 [LIVE] 📷 Approved (Jan 15, 2026)")
+  *
+  * @example
+- * formatVersionLabel({ version_major: 1, version_minor: 3, is_snapshot: true, description: 'Client approved', created_at: '2026-01-15' }, { isLive: true })
+- * // Returns: "v1.03 [LIVE] 📷 Client approved (Jan 15, 2026)"
++ * formatVersionLabel({ version_major: 1, version_minor: 3, is_snapshot: true, approved_at: '2026-01-15', created_at: '2026-01-10' }, { isLive: true })
++ * // Returns: "v1.03 [LIVE] 📷 Approved (Jan 15, 2026) (Jan 10, 2026)"
+  */
+ function formatVersionLabel(version, options = {}) {
+     const { isLive = false, showDate = true, showNote = true } = options;
+@@ -127,10 +127,23 @@ function formatVersionLabel(version, options = {}) {
+     const minor = version.version_minor || 0;
+     const versionStr = `v${major}.${String(minor).padStart(2, '0')}`;
+ 
++    const formatDate = (value) =>
++        new Date(value).toLocaleDateString('en-US', {
++            month: 'short',
++            day: 'numeric',
++            year: 'numeric',
++        });
++
+     // Build tags
+     const liveTag = isLive ? ' [LIVE]' : '';
+     const snapshotTag = version.is_snapshot ? ' 📷' : '';
+ 
++    // Approval stamp — sourced ONLY from the persisted approved_at field,
++    // never from description (which carries author notes).
++    const approvedTag = version.approved_at
++        ? ` Approved (${formatDate(version.approved_at)})`
++        : '';
++
+     // Include note/description if present (truncate at 30 chars for dropdown readability)
+     let noteStr = '';
+     if (showNote && version.description) {
+@@ -144,15 +157,10 @@ function formatVersionLabel(version, options = {}) {
+     // Format date
+     let dateStr = '';
+     if (showDate && version.created_at) {
+-        const date = new Date(version.created_at);
+-        dateStr = ` (${date.toLocaleDateString('en-US', {
+-            month: 'short',
+-            day: 'numeric',
+-            year: 'numeric',
+-        })})`;
++        dateStr = ` (${formatDate(version.created_at)})`;
+     }
+ 
+-    return `${versionStr}${liveTag}${snapshotTag}${noteStr}${dateStr}`;
++    return `${versionStr}${liveTag}${snapshotTag}${approvedTag}${noteStr}${dateStr}`;
+ }
+ 
+ /**
+diff --git a/src/app/project_detail.html b/src/app/project_detail.html
+index 498277e4..82a5cef0 100644
+--- a/src/app/project_detail.html
++++ b/src/app/project_detail.html
+@@ -311,6 +311,15 @@
+                 margin-left: 6px;
+                 font-weight: 600;
+             }
++            .approval-stamp {
++                display: inline-block;
++                background: var(--color-success, #2e7d32);
++                color: #fff;
++                padding: 2px 10px;
++                border-radius: 10px;
++                font-size: 11px;
++                font-weight: 600;
++            }
+ 
+             /* v0 style export buttons - outline with subtle icon colors */
+             .export-buttons {
+@@ -2202,6 +2211,70 @@
+     `;
+                 }
+ 
++                // Resolve the snapshot object currently selected in the client view.
++                function getSelectedSnapshot() {
++                    if (!Array.isArray(clientSnapshots) || clientSnapshots.length === 0) {
++                        return null;
++                    }
++                    if (currentSnapshotId) {
++                        return clientSnapshots.find((s) => s.id === currentSnapshotId) || null;
++                    }
++                    return clientSnapshots[0] || null;
++                }
++
++                // Render the Approve control for the selected published version.
++                // UX gating only — the DB is authoritative (approve_snapshot RPC).
++                // Show Approve only when: the selected version is a published snapshot,
++                // not yet approved, and the viewer is an authenticated contact (access
++                // already verified at page load ~L1532). Already-approved versions show
++                // a stamp; working drafts / no selection show nothing.
++                function renderApprovalControl() {
++                    const snap = getSelectedSnapshot();
++                    if (!snap || snap.is_snapshot !== true) return '';
++
++                    if (snap.approved_at) {
++                        const dateStr = formatSnapshotDate(snap.approved_at);
++                        return `<span class="approval-stamp">✓ Approved${dateStr ? ` (${dateStr})` : ''}</span>`;
++                    }
++
++                    if (!window.currentContact) return '';
++
++                    return `<button class="export-btn" onclick="approveCurrentSnapshot()">Approve</button>`;
++                }
++
++                // Record a client sign-off on the currently-selected published version.
++                window.approveCurrentSnapshot = async function () {
++                    const snap = getSelectedSnapshot();
++                    if (!snap || snap.is_snapshot !== true || snap.approved_at) return;
++
++                    const note = window.prompt('Optional note to include with your approval:', '');
++                    // prompt() returns null on Cancel — treat as "no note", still approve.
++                    const approvalNote = note && note.trim() ? note.trim() : null;
++
++                    const control = document.getElementById('approvalControl');
++
++                    try {
++                        const updated = await approveSnapshot(snap.id, approvalNote);
++
++                        // Update in-memory snapshot so re-render reflects approved state
++                        // without a full page reload.
++                        snap.approved_at =
++                            (updated && updated.approved_at) || new Date().toISOString();
++                        snap.approved_by_contact_id =
++                            (updated && updated.approved_by_contact_id) ||
++                            (window.currentContact && window.currentContact.id) ||
++                            null;
++                        snap.approval_note = updated ? updated.approval_note : approvalNote;
++
++                        if (control) control.innerHTML = renderApprovalControl();
++                    } catch (err) {
++                        console.error('Error approving version:', err);
++                        window.alert(
++                            'Could not record approval: ' + (err.message || 'unknown error'),
++                        );
++                    }
++                };
++
+                 // Switch to a different snapshot version
+                 window.switchSnapshot = async function (snapshotId, options = {}) {
+                     if (!snapshotId || snapshotId === currentSnapshotId) return;
+@@ -2271,6 +2344,8 @@
+           <div class="header-value">${escapeHtml(project.director) || '-'}</div>
+           <div class="header-label">Version:</div>
+           <div class="header-value">${renderVersionSelector()}</div>
++          <div class="header-label">Approval:</div>
++          <div class="header-value" id="approvalControl">${renderApprovalControl()}</div>
+         </div>
+         <div class="header-right">
+           <div class="company-name">${escapeHtml(entity.name)}</div>
+diff --git a/supabase/migrations/20260607180000_snapshot_client_approval.sql b/supabase/migrations/20260607180000_snapshot_client_approval.sql
+new file mode 100644
+index 00000000..8b4ee498
+--- /dev/null
++++ b/supabase/migrations/20260607180000_snapshot_client_approval.sql
+@@ -0,0 +1,150 @@
++-- POC-57: Client Approve action on a published budget version (single sign-off).
++-- Adds durable, attributable approval fields to budget_snapshots, a gated
++-- SECURITY DEFINER RPC for clients to record sign-off, and a notification
++-- trigger to alert the internal publisher.
++
++-- ============================================================================
++-- 1. Approval columns on budget_snapshots
++-- ============================================================================
++ALTER TABLE public.budget_snapshots
++    ADD COLUMN IF NOT EXISTS approved_at timestamptz,
++    ADD COLUMN IF NOT EXISTS approved_by_contact_id uuid,
++    ADD COLUMN IF NOT EXISTS approval_note text;
++
++DO $$
++BEGIN
++    IF NOT EXISTS (
++        SELECT 1 FROM pg_constraint
++        WHERE conname = 'budget_snapshots_approved_by_contact_id_fkey'
++    ) THEN
++        ALTER TABLE public.budget_snapshots
++            ADD CONSTRAINT budget_snapshots_approved_by_contact_id_fkey
++            FOREIGN KEY (approved_by_contact_id)
++            REFERENCES public.contacts(id);
++    END IF;
++END $$;
++
++-- ============================================================================
++-- 2. approve_snapshot RPC — gated client sign-off
++-- ============================================================================
++-- Why a SECURITY DEFINER RPC and not a permissive RLS UPDATE: the snapshots_update
++-- RLS policy gates on producer-only edit access, and RLS cannot column-scope an
++-- UPDATE. A permissive client UPDATE policy would let clients rewrite ANY snapshot
++-- column. This RPC enforces an explicit access gate and writes only the approval
++-- fields (cf. POC-87, which ADDED auth checks to SECURITY DEFINER version RPCs).
++CREATE OR REPLACE FUNCTION public.approve_snapshot(
++    p_snapshot_id uuid,
++    p_note text DEFAULT NULL
++)
++RETURNS public.budget_snapshots
++LANGUAGE plpgsql
++SECURITY DEFINER
++SET search_path = 'public'
++AS $$
++DECLARE
++    v_contact  uuid;
++    v_snapshot public.budget_snapshots;
++    v_result   public.budget_snapshots;
++BEGIN
++    v_contact := get_current_contact_id();
++    IF v_contact IS NULL THEN
++        RAISE EXCEPTION 'not authenticated';
++    END IF;
++
++    SELECT * INTO v_snapshot
++    FROM public.budget_snapshots
++    WHERE id = p_snapshot_id;
++
++    IF NOT FOUND THEN
++        RAISE EXCEPTION 'snapshot not found';
++    END IF;
++
++    IF v_snapshot.is_snapshot IS NOT TRUE THEN
++        RAISE EXCEPTION 'not a published version';
++    END IF;
++
++    IF v_snapshot.approved_at IS NOT NULL THEN
++        RAISE EXCEPTION 'already approved';
++    END IF;
++
++    IF NOT user_has_project_access(v_snapshot.project_id) THEN
++        RAISE EXCEPTION 'no project access';
++    END IF;
++
++    UPDATE public.budget_snapshots
++    SET approved_at = now(),
++        approved_by_contact_id = v_contact,
++        approval_note = p_note
++    WHERE id = p_snapshot_id
++      AND approved_at IS NULL
++    RETURNING * INTO v_result;
++
++    RETURN v_result;
++END;
++$$;
++
++ALTER FUNCTION public.approve_snapshot(uuid, text) OWNER TO postgres;
++REVOKE ALL ON FUNCTION public.approve_snapshot(uuid, text) FROM public;
++GRANT EXECUTE ON FUNCTION public.approve_snapshot(uuid, text) TO authenticated;
++
++-- ============================================================================
++-- 3. Notify the internal publisher when a version is approved
++-- ============================================================================
++CREATE OR REPLACE FUNCTION public.notify_on_snapshot_approval()
++RETURNS TRIGGER
++LANGUAGE plpgsql
++SECURITY DEFINER
++SET search_path = 'public'
++AS $$
++DECLARE
++    v_recipient    uuid;
++    v_approver_name text;
++BEGIN
++    -- Recipient: the internal publisher (snapshot_by), fallback created_by.
++    v_recipient := COALESCE(NEW.snapshot_by, NEW.created_by);
++
++    -- No publisher recorded -> nothing to notify.
++    IF v_recipient IS NULL THEN
++        RETURN NEW;
++    END IF;
++
++    -- Don't notify if the approver is also the publisher.
++    IF v_recipient = NEW.approved_by_contact_id THEN
++        RETURN NEW;
++    END IF;
++
++    SELECT name INTO v_approver_name
++    FROM public.contacts
++    WHERE id = NEW.approved_by_contact_id;
++
++    PERFORM enqueue_notification(
++        p_recipient_contact_id := v_recipient,
++        p_notification_type := 'mention',
++        p_entity_type := 'budget_snapshot',
++        p_entity_id := NEW.id,
++        p_project_id := NEW.project_id,
++        p_context := jsonb_build_object(
++            'sender_name', COALESCE(v_approver_name, 'A client'),
++            'comment_preview', 'approved version v' || COALESCE(NEW.version_major::text, '0') || '.' || COALESCE(NEW.version_minor::text, '0'),
++            'notification_subtype', 'snapshot_approval',
++            'snapshot_id', NEW.id
++        )
++    );
++
++    RETURN NEW;
++END;
++$$;
++
++ALTER FUNCTION public.notify_on_snapshot_approval() OWNER TO postgres;
++
++DROP TRIGGER IF EXISTS trg_notify_snapshot_approval ON public.budget_snapshots;
++CREATE TRIGGER trg_notify_snapshot_approval
++    AFTER UPDATE ON public.budget_snapshots
++    FOR EACH ROW
++    WHEN (OLD.approved_at IS NULL AND NEW.approved_at IS NOT NULL)
++    EXECUTE FUNCTION public.notify_on_snapshot_approval();
++
++-- ============================================================================
++-- 4. Reload PostgREST schema cache so the new columns/RPC are visible
++-- ============================================================================
++NOTIFY pgrst, 'reload schema';
+diff --git a/tests/rls/snapshot-approval-rpc.test.js b/tests/rls/snapshot-approval-rpc.test.js
+new file mode 100644
+index 00000000..124eedc3
+--- /dev/null
++++ b/tests/rls/snapshot-approval-rpc.test.js
+@@ -0,0 +1,188 @@
++// POC-57 — client snapshot approval RPC authorization + notification suite.
++//
++// approve_snapshot(p_snapshot_id, p_note) is a gated SECURITY DEFINER RPC that
++// records a single client sign-off (approved_at + approved_by_contact_id +
++// approval_note) on a PUBLISHED version (is_snapshot = true). Gates, in order:
++//   - not authenticated            -> RAISE 'not authenticated'
++//   - snapshot not found           -> RAISE 'snapshot not found'
++//   - is_snapshot != true          -> RAISE 'not a published version'
++//   - approved_at already set      -> RAISE 'already approved' (one-time invariant)
++//   - no project access            -> RAISE 'no project access'
++//
++// An AFTER UPDATE trigger (trg_notify_snapshot_approval) enqueues a notification
++// to the internal publisher (snapshot_by, fallback created_by) on approval.
++//
++// Fixtures: P_B (entity E2). Approver WITH access = `projectGranted` (project_contacts
++// read grant on P_B → user_has_project_access true). Attacker WITHOUT access =
++// `ungranted`. Publisher = `entityAdmin` contact (set as snapshot_by on the target
++// rows). Targets are dedicated snapshot rows under P_B created via the service-role
++// admin client so the shared fixture working draft stays pristine.
++//
++// Run: supabase start; export SUPABASE_URL/ANON/SERVICE from `supabase status -o
++// json`; npm run test:rls. If the local stack 502s after a reset, run
++// `supabase stop && supabase start` first.
++
++import { setupFixtures, teardownFixtures, clientFor, admin, fixtures } from './fixtures.mjs';
++
++let approver; // authed client for projectGranted (read grant on P_B → has access)
++let attacker; // authed client for ungranted (no access anywhere)
++
++const RANDOM_UUID = '00000000-0000-4000-8000-0000000000bb';
++
++// Create a throwaway snapshot row under a project. Defaults make a published
++// (is_snapshot=true) locked version not yet approved, with snapshot_by set to the
++// entityAdmin contact so it is a valid notification recipient.
++async function makeSnapshot(projectId, overrides = {}) {
++    const { data, error } = await admin
++        .from('budget_snapshots')
++        .insert({
++            project_id: projectId,
++            name: `poc57-${fixtures.runId}-${Math.random().toString(36).slice(2, 8)}`,
++            version_major: 7,
++            version_minor: 0,
++            is_locked: true,
++            is_snapshot: true,
++            is_archived: false,
++            snapshot_by: fixtures.users.entityAdmin.contactId,
++            ...overrides,
++        })
++        .select('id')
++        .single();
++    if (error) throw new Error(`makeSnapshot failed: ${error.message}`);
++    return data.id;
++}
++
++async function readSnapshot(id) {
++    const { data, error } = await admin
++        .from('budget_snapshots')
++        .select('id, is_snapshot, approved_at, approved_by_contact_id, approval_note')
++        .eq('id', id)
++        .maybeSingle();
++    if (error) throw new Error(`readSnapshot failed: ${error.message}`);
++    return data;
++}
++
++const createdSnapshots = [];
++async function trackSnapshot(id) {
++    createdSnapshots.push(id);
++    return id;
++}
++
++beforeAll(async () => {
++    await setupFixtures();
++    approver = await clientFor(fixtures.users.projectGranted);
++    attacker = await clientFor(fixtures.users.ungranted);
++}, 60000);
++
++afterAll(async () => {
++    for (const id of createdSnapshots) {
++        // Remove any notifications referencing this snapshot first, then the row.
++        await admin.from('notifications_queue').delete().eq('entity_id', id);
++        await admin.from('budget_snapshots').delete().eq('id', id);
++    }
++    await teardownFixtures();
++}, 60000);
++
++describe('approve_snapshot — authorization gates', () => {
++    test('contact WITH project access → succeeds, approval fields persist', async () => {
++        const snapId = await trackSnapshot(await makeSnapshot(fixtures.projects.P_B));
++        const { data, error } = await approver.rpc('approve_snapshot', {
++            p_snapshot_id: snapId,
++            p_note: 'Looks good, approved',
++        });
++        expect(error).toBeNull();
++        expect(data).toBeTruthy();
++
++        const row = await readSnapshot(snapId);
++        expect(row.approved_at).not.toBeNull();
++        expect(row.approved_by_contact_id).toBe(fixtures.users.projectGranted.contactId);
++        expect(row.approval_note).toBe('Looks good, approved');
++    });
++
++    test('contact WITHOUT project access → rejected, no approval field set', async () => {
++        const snapId = await trackSnapshot(await makeSnapshot(fixtures.projects.P_B));
++        const { error } = await attacker.rpc('approve_snapshot', { p_snapshot_id: snapId });
++        expect(error).not.toBeNull();
++        expect((error.message || '') + (error.details || '')).toMatch(/no project access/i);
++
++        const row = await readSnapshot(snapId);
++        expect(row.approved_at).toBeNull(); // mutation did not happen
++        expect(row.approved_by_contact_id).toBeNull();
++    });
++
++    test('working-draft (is_snapshot=false) → rejected', async () => {
++        const snapId = await trackSnapshot(
++            await makeSnapshot(fixtures.projects.P_B, { is_snapshot: false, is_locked: false }),
++        );
++        const { error } = await approver.rpc('approve_snapshot', { p_snapshot_id: snapId });
++        expect(error).not.toBeNull();
++        expect((error.message || '') + (error.details || '')).toMatch(/not a published version/i);
++
++        const row = await readSnapshot(snapId);
++        expect(row.approved_at).toBeNull();
++    });
++
++    test('already-approved version → rejected (one-time invariant)', async () => {
++        const snapId = await trackSnapshot(await makeSnapshot(fixtures.projects.P_B));
++        // First approval succeeds.
++        const first = await approver.rpc('approve_snapshot', { p_snapshot_id: snapId });
++        expect(first.error).toBeNull();
++        const firstRow = await readSnapshot(snapId);
++        const firstApprovedAt = firstRow.approved_at;
++        expect(firstApprovedAt).not.toBeNull();
++
++        // Second approval is rejected; the original approval is unchanged.
++        const second = await approver.rpc('approve_snapshot', { p_snapshot_id: snapId });
++        expect(second.error).not.toBeNull();
++        expect((second.error.message || '') + (second.error.details || '')).toMatch(
++            /already approved/i,
++        );
++        const secondRow = await readSnapshot(snapId);
++        expect(secondRow.approved_at).toBe(firstApprovedAt); // not overwritten
++    });
++
++    test('non-existent snapshot id → rejected (no silent success)', async () => {
++        const { error } = await approver.rpc('approve_snapshot', { p_snapshot_id: RANDOM_UUID });
++        expect(error).not.toBeNull();
++        expect((error.message || '') + (error.details || '')).toMatch(/snapshot not found/i);
++    });
++});
++
++describe('approve_snapshot — publisher notification', () => {
++    test('approving enqueues a notification targeting the publisher (snapshot_by)', async () => {
++        // Publisher = entityAdmin contact: it has access to P_B (E2 membership), which
++        // enqueue_notification requires of the RECIPIENT (POC-31 stripped god-mode, so
++        // siteproAdmin would be rejected here). The notification batching trigger
++        // merges unsent rows by recipient+type+project; the gate tests above already
++        // enqueued mention rows for entityAdmin, so clear any unsent ones first to
++        // guarantee a brand-new queue row keyed to this snapshot's entity_id.
++        const publisherContactId = fixtures.users.entityAdmin.contactId;
++        await admin
++            .from('notifications_queue')
++            .delete()
++            .eq('recipient_contact_id', publisherContactId)
++            .is('sent_at', null);
++
++        const snapId = await trackSnapshot(
++            await makeSnapshot(fixtures.projects.P_B, { snapshot_by: publisherContactId }),
++        );
++
++        const { error } = await approver.rpc('approve_snapshot', { p_snapshot_id: snapId });
++        expect(error).toBeNull();
++
++        // The trigger enqueues to the publisher (snapshot_by), referencing this
++        // project + snapshot.
++        const { data: notes, error: nErr } = await admin
++            .from('notifications_queue')
++            .select('recipient_contact_id, entity_type, entity_id, project_id, context')
++            .eq('entity_id', snapId)
++            .eq('entity_type', 'budget_snapshot');
++        expect(nErr).toBeNull();
++        expect(notes.length).toBeGreaterThan(0);
++
++        const note = notes[0];
++        expect(note.recipient_contact_id).toBe(publisherContactId);
++        expect(note.project_id).toBe(fixtures.projects.P_B);
++        expect(note.context.notification_subtype).toBe('snapshot_approval');
++    });
++});
+diff --git a/tests/versions.test.js b/tests/versions.test.js
+index 5515f814..25ed1527 100644
+--- a/tests/versions.test.js
++++ b/tests/versions.test.js
+@@ -35,6 +35,7 @@ const createVersion = (id, major, minor, opts = {}) => ({
+     is_snapshot: opts.is_snapshot || false,
+     description: opts.description || null,
+     created_at: opts.created_at || '2026-01-15T10:00:00Z',
++    approved_at: opts.approved_at || null,
+ });
+ 
+ describe('Version Sorting - sortVersionsDescending()', () => {
+@@ -303,6 +304,37 @@ describe('Version Label Formatting', () => {
+             const label = formatVersionLabel(version, { showDate: false });
+             expect(label).toBe('v1.00');
+         });
++
++        // POC-57: client approval stamp sourced from approved_at
++        test('renders Approved (date) stamp from approved_at', () => {
++            const version = createVersion('1', 1, 0, {
++                is_snapshot: true,
++                approved_at: '2026-02-20T09:00:00Z',
++            });
++            const label = formatVersionLabel(version, { showDate: false });
++            expect(label).toBe('v1.00 📷 Approved (Feb 20, 2026)');
++        });
++
++        test('omits Approved stamp when approved_at is null', () => {
++            const version = createVersion('1', 1, 0, { is_snapshot: true });
++            const label = formatVersionLabel(version, { showDate: false });
++            expect(label).not.toMatch(/Approved/);
++            expect(label).toBe('v1.00 📷');
++        });
++
++        test('approval stamp does NOT read description for the date', () => {
++            // description carries an author note that mentions approval, but the
++            // stamp must only appear when approved_at is set.
++            const version = createVersion('1', 1, 0, {
++                is_snapshot: true,
++                description: 'Approved by client verbally',
++                approved_at: null,
++            });
++            const label = formatVersionLabel(version, { showDate: false });
++            // The description still renders as a note, but no "Approved (date)" stamp.
++            expect(label).not.toMatch(/Approved \(/);
++            expect(label).toBe('v1.00 📷 Approved by client verbally');
++        });
+     });
+ 
+     describe('formatVersionLabels()', () => {

--- a/experiments/poc-57-backend-ab/setup-pilot.sh
+++ b/experiments/poc-57-backend-ab/setup-pilot.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Pilot harness for the POC-57 native-vs-VBW A/B (1 VBW + 1 native arm).
+# Safe + reversible: creates experiment branches/worktrees in SiteLine. No push, no Linear, no DB.
+# Teardown: scripts/teardown-pilot.sh
+set -euo pipefail
+
+SL="$HOME/Projects/SiteLine"
+PK="$HOME/Projects/pipekit"
+BASE_SHA="2fb49a14"                       # SiteLine origin/main @ experiment start (pinned; re-based 2026-06-07)
+PK_BRANCH="feat/native-workflow-executor" # where native-best lives
+SKILL="skills/work/skill.md"
+
+cd "$SL"
+
+# 1. Experiment base: main@BASE_SHA + the rebuilt native-best skill, as ONE setup commit.
+#    Both arms branch from here; the judge diffs each arm against exp/POC-57-base, so this
+#    skill swap never pollutes scoring.
+if ! git rev-parse --verify exp/POC-57-base >/dev/null 2>&1; then
+  git worktree add -b exp/POC-57-base .worktrees/POC-57-base "$BASE_SHA"
+  git -C "$PK" show "$PK_BRANCH:$SKILL" > ".worktrees/POC-57-base/.claude/skills/work/skill.md"
+  ( cd .worktrees/POC-57-base
+    git add .claude/skills/work/skill.md
+    git commit -m "chore(exp): install native-best executor for POC-57 A/B
+
+Source: pipekit $PK_BRANCH (commit 3954890). Experiment base only — never merged.
+Judge diffs each arm against this commit so the skill swap is invisible to scoring." )
+fi
+
+# 2. Pilot arm worktrees off the experiment base.
+for arm in vbw-1 native-1; do
+  wt=".worktrees/POC-57-$arm"
+  br="exp/POC-57-$arm"
+  if ! git rev-parse --verify "$br" >/dev/null 2>&1; then
+    git worktree add -b "$br" "$wt" exp/POC-57-base
+  fi
+done
+
+echo
+echo "=== pilot harness ready ==="
+git worktree list | grep POC-57
+echo
+echo "base commit (arms diff against this):"
+git rev-parse --short exp/POC-57-base

--- a/experiments/poc-57-backend-ab/teardown-pilot.sh
+++ b/experiments/poc-57-backend-ab/teardown-pilot.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Remove the POC-57 pilot worktrees + branches. Run after judging is captured.
+# Nothing here was pushed/merged, so this fully reverts SiteLine to pre-experiment state.
+set -uo pipefail
+SL="$HOME/Projects/SiteLine"
+cd "$SL"
+for arm in base vbw-1 native-1; do
+  git worktree remove --force ".worktrees/POC-57-$arm" 2>/dev/null && echo "removed worktree POC-57-$arm"
+done
+for br in exp/POC-57-base exp/POC-57-vbw-1 exp/POC-57-native-1; do
+  git branch -D "$br" 2>/dev/null && echo "deleted branch $br"
+done
+git worktree prune
+echo "done — SiteLine reverted."

--- a/method.md
+++ b/method.md
@@ -360,13 +360,13 @@ Pipekit wraps VBW — it does not replace VBW's planning layer. The two systems 
 | File / System | Owned by | Writers | Readers |
 |---|---|---|---|
 | `.vbw-planning/ROADMAP.md` | VBW | `/vbw:init` creates it; `/roadmap-create` merges strategy-derived requirements **into** it (never overwrites) | All Pipekit skills, VBW agents |
-| `.vbw-planning/phases/*/PLAN.md` | VBW | `vbw-lead` agent (spawned by `/work` when `Backend: vbw`) | `/work`, `/review-plan`, `/phase-plan --status`, vbw-dev/vbw-qa agents |
+| `.vbw-planning/phases/*/PLAN.md` | VBW | `vbw-lead` (direct VBW use / `/vbw:vibe --plan`). **Pipekit's `/work` does not spawn `vbw-lead`** — it plans inline (native → `.pk-work/<ID>-PLAN.md`; vbw backend → hands the inline plan to `vbw-dev`) | `/work`, `/review-plan`, `/phase-plan --status`, `vbw-dev`/`vbw-qa` agents |
 | `.vbw-planning/.execution-state.json` | VBW | vbw-dev / vbw-qa agents | `/phase-plan --status` |
 | `.vbw-planning/linear-map.json` | Pipekit | `/roadmap-create`, `/sync-linear` | `pk next`, `pk *`, all Pipekit skills |
 | `.vbw-planning/PHASES.md` | Pipekit | `/phase-plan` | `pk next` (phase-aware), all Pipekit skills |
 | `notepad.md` (project root, gitignored) | Human | Whoever's typing | Whoever's reading. v2 retired the auto-written `NEXT.md` mirror — `pk next` reads "what's next?" live from Linear instead. |
 | Linear issues | Pipekit | `/light-spec`, `pk branch`, `pk ship`, `pk done`, `/roadmap-create`, `/phase-plan` | Everyone |
-| `concept-brief.md`, `project-definition.md`, `Strategy/` | Pipekit | `/concept`, `/define`, `/strategy-create`, `/strategy-sync` | `/light-spec`, vbw-lead |
+| `concept-brief.md`, `project-definition.md`, `Strategy/` | Pipekit | `/concept`, `/define`, `/strategy-create`, `/strategy-sync` | `/light-spec`, `/work` (inline planning) |
 | `method.config.md` | Pipekit | `/startup` (populates); human (edits) | All Pipekit skills, `bin/pk` |
 
 ### Rules of Engagement
@@ -375,11 +375,11 @@ Pipekit wraps VBW — it does not replace VBW's planning layer. The two systems 
 2. **Pipekit owns the visibility layer.** Linear issues, `linear-map.json`, `PHASES.md`, strategy docs, and project config are Pipekit's. VBW does not write to these. (v2 retired the `NEXT.md` mirror — `pk next` reads "what's next?" live from Linear.)
 3. **Initial merge happens once** — at `/roadmap-create`. Strategy-derived requirements are added **into** VBW's existing phase structure. VBW's phases, goals, and success criteria are preserved verbatim.
 4. **After the merge, the split is one-way.** Pipekit reads VBW state (plan progress, execution state) to update Linear. VBW does not read Linear — its source of truth is its own files.
-5. **Pipekit owns gates; VBW owns build.** `pk branch` opens Linear → In Progress; `/work` (with `Backend: vbw`) dispatches `vbw-lead` and `vbw-dev`; `/verify` runs the pre-deploy gate; `pk ship` transitions Linear → UAT (PR open on preview); `pk done` verifies merge, transitions Linear UAT → `In <FirstEnv>` (e.g. `In Dev`), cleans up the worktree; `pk promote <env>` walks `Ship environments` one hop at a time and transitions issues → `In <Env>` (intermediate) or → Done (final). The plan-review gate (Pipekit's value-add over raw VBW) lives in the standalone `/review-plan` skill, which spawns the `plan-reviewer` agent at `model: opus` between `vbw-lead`'s plan and `vbw-dev`'s execution.
+5. **Pipekit owns gates; VBW owns build.** `pk branch` opens Linear → In Progress; `/work` (with `Backend: vbw`) dispatches the `vbw-dev` executor (planning is `/work`'s inline step — no `vbw-lead`); `/verify` runs the pre-deploy gate; `pk ship` transitions Linear → UAT (PR open on preview); `pk done` verifies merge, transitions Linear UAT → `In <FirstEnv>` (e.g. `In Dev`), cleans up the worktree; `pk promote <env>` walks `Ship environments` one hop at a time and transitions issues → `In <Env>` (intermediate) or → Done (final). The plan-review gate (Pipekit's value-add over raw VBW) lives in the standalone `/review-plan` skill, which spawns the `plan-reviewer` agent at `model: opus` between `/work`'s inline plan and `vbw-dev`'s execution.
 
    **Pipekit's VBW-steering surface:**
    1. **One direct agent spawn** — `plan-reviewer` in `/review-plan`. Not a VBW agent; Pipekit-shipped.
-   2. **`/work` dispatches VBW agents (vbw backend) or runs in-context (native backend).** Backend choice is per-project in `method.config.md`; per-invocation override via `--backend=`.
+   2. **`/work` dispatches the `vbw-dev` agent (vbw backend) or runs in-context (native backend).** Backend choice is per-project in `method.config.md`; per-invocation override via `--backend=`.
    3. **Read-only state observation** — `.vbw-planning/{ROADMAP,STATE,PHASES,linear-map}.md` reads from `/sync-linear`, `/phase-plan`, `/00-roadmap-review`, `/01-light-spec`, `/10-strategy-sync`, `pk next`, `pk status`.
    4. **One lifecycle hook** — `scripts/pipekit-post-archive.sh` fires on `/vbw:vibe --archive`, writes a `pending-strategy-sync` marker into Pipekit's machine-local state directory.
    5. **Pipekit-side ephemeral state** lives **outside the repo** at `${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>/`, resolved by `scripts/pipekit-state-dir.sh`. It holds the `pending-strategy-sync` marker and per-issue pipeline-state records consumed by `pk *` commands. Out-of-repo by design — v1.6.0 placed these at `.pipekit/`, but VBW's file-guard hook silently blocked writes during active-plan scope (#13). The relocation made writes succeed unconditionally.
@@ -463,7 +463,7 @@ VBW resolves the path relative to the project root. The hook is fail-open — if
 | `pk doctor` | Diagnostic: config, Linear API, worktree dir, stale artifacts. v2.7.0+: **false-ship cross-check** — flags UAT/Done WITs with no real commits on the integration branch (git evidence). |
 | `/pipekit-help` | Read project state, recommend the next pipeline step. |
 | `/pipekit-update` | Pull latest Pipekit from GitHub into the project (`--push` round-trips improvements back). v2.7.0 **Phase P** also ensures managed plugin dependencies — installs/updates `pr-review-toolkit` at user scope so `/pr-fix`'s native engine resolves. |
-| `/review-plan {phase-slug}` | Run plan-reviewer agent against PLAN.md (vbw backend). Run between vbw-lead's plan and vbw-dev's execution. |
+| `/review-plan {phase-slug}` | Run plan-reviewer agent against the inline `PLAN.md` before execution. Most relevant on the `vbw` backend, where `/work` hands the plan to `vbw-dev` wholesale. |
 | `/sync-linear` | Bidirectional VBW ↔ Linear sync |
 | `/strategy-sync` | Post-pipeline: update Strategy docs to reflect shipped features |
 | `/release-changelog` | Generate draft CHANGELOG entry from git commits between tags. Output to stdout for human edit. |

--- a/skills/review-plan/skill.md
+++ b/skills/review-plan/skill.md
@@ -7,9 +7,9 @@ description: Run plan-reviewer agent against a VBW PLAN.md before execution. Use
 
 > **Fresh-chat check.** If this conversation ran `/vbw:vibe --plan` or watched the plan get drafted, start a new conversation. The reviewer must be independent of the planner. See `method.md` § Fresh-Chat Discipline.
 
-You are a plan-review coordinator. Your job is to invoke the `plan-reviewer` agent against a `PLAN.md` produced by VBW Lead, present the structured review back to the user, and recommend a path forward (proceed to execute, route back to Lead for revision, or escalate).
+You are a plan-review coordinator. Your job is to invoke the `plan-reviewer` agent against a `PLAN.md` before execution, present the structured review back to the user, and recommend a path forward (proceed to execute, route back for plan revision, or escalate). The plan comes from VBW's planner in direct VBW use (`/vbw:vibe --plan` / `vbw:vbw-lead`), or from `/work`'s inline planning on the `vbw` backend.
 
-This skill is part of Pipekit Tier 1 (Option 3): Pipekit owns the plan-review gate; VBW owns plan generation, execution, and verification. Run this **between** `/vbw:vibe --plan` and `/vbw:vibe --execute`.
+This skill is Pipekit's plan-review gate — an independent stress-test between planning and execution. It is **most relevant on the `vbw` backend** (and in direct VBW use), where the whole plan is handed to `vbw-dev` **wholesale** with no per-task gate; the `native` backend's per-task verify-before-integrate is its own plan-safety mechanism, so upfront review matters less there. In direct VBW use, run this **between** `/vbw:vibe --plan` and `/vbw:vibe --execute`.
 
 ## Triggers
 
@@ -34,7 +34,7 @@ The `plan-reviewer` agent fills that gap. This skill orchestrates the call.
 
 ## Prerequisites
 
-- A `PLAN.md` exists in `.vbw-planning/phases/{phase-slug}/` (produced by `/vbw:vibe --plan` or directly by `vbw:vbw-lead`)
+- A `PLAN.md` to review. In direct VBW use it lives in `.vbw-planning/phases/{phase-slug}/` (produced by `/vbw:vibe --plan` / `vbw:vbw-lead`). On the `vbw` `/work` backend the plan is `/work`'s inline output — `/work` hands it to `vbw-dev` without filing it, so provide that plan to this skill directly
 - The approved Light Spec is available — either as the description of a Linear issue tied to the current branch, or readable from a known location
 - `.claude/agents/plan-reviewer.md` is installed (Pipekit ships this; if missing, run `bash scripts/sync-method.sh`)
 
@@ -93,7 +93,7 @@ Agent(
   subagent_type: "plan-reviewer",
   model: "opus",
   description: "Review {phase-slug} plan",
-  prompt: "Independent review of VBW Lead's plan(s) for {phase-slug} before execution.
+  prompt: "Independent review of the plan(s) for {phase-slug} before execution.
 
   Plan path(s):
     {list of *-PLAN.md absolute paths}
@@ -187,7 +187,7 @@ Thoughts that mean "slow down on the review." Paired with `.claude/rules/pipekit
 
 | Skill | Relationship |
 |-------|-------------|
-| `/work` (vbw backend) | Spawns `vbw-lead` to produce `PLAN.md`; the user then runs `/review-plan` between vbw-lead's output and vbw-dev's execution. `/work` does not spawn plan-reviewer directly. |
+| `/work` (vbw backend) | Plans **inline** (no `vbw-lead`); run `/review-plan` against that plan before `/work` hands it to `vbw-dev` wholesale. `/work` does not spawn plan-reviewer directly. |
 | `/vbw:vibe --plan` | Produces the `PLAN.md` this skill reviews. |
 | `/vbw:vibe --execute` | Next step after Pass / Revise. |
 | `/02-light-spec-revise` | Route here when plan-reviewer's Block verdict points at spec-level issues (framing, missing AC, scope ambiguity). |


### PR DESCRIPTION
Doc-accuracy + evidence-housekeeping ahead of `v3.0.0` final. **Docs only — no behavior change, no version bump** (the method.md stamp rides with the 3.0-final release PR per the CHANGELOG checklist).

## What's in here (4 atomic commits)

1. **`docs(method):`** — closes the rc1-named follow-up. The ownership table, Rule 5, the steering-surface list, and the `/review-plan` row in `method.md` still phrased `/work` as spawning `vbw-lead`. False under 3.0: the `vbw` backend dispatches only `vbw-dev`, and planning is `/work`'s inline step in every backend. Now consistent with the already-correct Stage 2 (§201–208) text.
2. **`docs(experiments):`** — commits the POC-57 native-vs-vbw blind A/B (frozen spec, runcards, diffs, de-blind key) plus a written `VERDICT.md`.
3. **`docs(logs):`** — the untracked 2026-06-07 session record (v2.8.0 rc2/rc3 + CI-reviewer hardening).
4. **`docs(skill):`** — same `vbw-lead` drift scrub in `skills/review-plan/skill.md` (it claimed `/work` vbw-backend "spawns `vbw-lead` to produce `PLAN.md`").

## POC-57 verdict — read it as a caution flag, not a coronation

Blind-judged (judge never saw the de-blind key), grounded against live SiteLine + the actually-shipped migration chain. The result is a **split**, single pilot rep:

- **native** got the architecture right (plain RLS, no SECDEF — matched the spec's DEFINED decision *and* what shipped) but under-tested it, shipped a forgeable client-clock timestamp, and a notification trigger that silently can't fire.
- **vbw** was tested + server-bound + had a working notification path, but **violated the DEFINED no-SECDEF decision** and left the notification fail-closed.
- **Both** failed the notification AC. The real ship was a **hybrid** (vbwfull DB + native UI) that still needed two follow-up migrations.

It does **not** overturn native-as-default (POC-48 round-two justifies that) and does **not** cleanly confirm "native wins." Its load-bearing lesson: native's recurring weakness is execution discipline (test-authoring), which is exactly what the gate layer — run by **both** backends — exists to backstop. The safety net is the gate, not the executor.

## Deliberately NOT in scope (flagged, not silently expanded)

- **Native plan-review path** — `/review-plan` stays VBW-oriented on purpose. Native's per-task verify-before-integrate *is* its plan-safety gate, so it needs no upfront review skill.
- **`/verify`↔`pk ship` tier-detection mismatch** — a real edge (unlabeled trivial issue: `/verify` writes no `verify-complete.md`, `pk ship` defaults to `standard` and demands it). Downstream of finishing tier-label reinstatement; immediate unblock is `pk ship --force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)