### PR TITLE
feat(pk): upstream-staleness check in pk doctor

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -2512,6 +2512,39 @@ cmd_doctor() {
     warn=$((warn+1))
   fi
 
+  # --- Upstream staleness (method repo) -----------------------------------
+  # The synced pk's PK_VERSION is the project's sync marker. Compare it
+  # against the method repo's latest release tag so a project can't silently
+  # fall releases behind (Piper sat a full release back through the 2.8/3.0
+  # cycle with no signal). Network-soft: unreachable repo is an info line,
+  # never an error — doctor must work offline. rc tags don't count as
+  # "latest"; running an rc of the latest release still warns.
+  local method_repo latest_tag
+  method_repo=$(pk_config "Method repo" "${METHOD_REPO:-https://github.com/withpiper/pipekit.git}")
+  # `|| true`: ls-remote fails on an unreachable repo and pipefail would
+  # kill doctor mid-run; empty latest_tag is the offline signal instead.
+  latest_tag=$(git ls-remote --tags --refs "$method_repo" 2>/dev/null \
+    | sed 's#.*refs/tags/##' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | awk -F'[v.]' '{ n = $2*1000000 + $3*1000 + $4; if (n > m) { m = n; t = $0 } } END { print t }' || true)
+  if [ -z "$latest_tag" ]; then
+    echo "  • method repo unreachable — skipped upstream-staleness check"
+  else
+    local cur_base cur_n latest_n
+    cur_base=${PK_VERSION%%-*}
+    cur_n=$(echo "$cur_base" | awk -F. '{print $1*1000000 + $2*1000 + $3}')
+    latest_n=$(echo "${latest_tag#v}" | awk -F. '{print $1*1000000 + $2*1000 + $3}')
+    if [ "$cur_n" -gt "$latest_n" ]; then
+      echo "  ✓ synced Pipekit v$PK_VERSION (ahead of latest release $latest_tag)"
+    elif [ "$cur_n" -eq "$latest_n" ] && [ "$PK_VERSION" = "$cur_base" ]; then
+      echo "  ✓ synced Pipekit v$PK_VERSION (latest release)"
+    else
+      echo "  ⚠ synced Pipekit is v$PK_VERSION; latest release is $latest_tag"
+      echo "    update: /pipekit-update  (or ./scripts/sync-method.sh $latest_tag)"
+      warn=$((warn+1))
+    fi
+  fi
+
   # --- Linear↔git integrity (false-ship detection) -----------------------
   # For WITs the board calls built/shipped (UAT, Done), confirm git history
   # actually contains implementation referencing the id. A Done/UAT issue with

--- a/tests/pk-smoke.sh
+++ b/tests/pk-smoke.sh
@@ -184,6 +184,30 @@ run_pk promote
 [ $RUN_CODE -eq 0 ] && case "$RUN_OUT" in *disabled*) ok "promote: single-tier no-op" ;; *) fail "promote: single-tier no-op" "output: $RUN_OUT" ;; esac \
   || fail "promote: single-tier no-op" "exit $RUN_CODE, want 0"
 
+# ── CLI tests: doctor upstream-staleness check ───────────────────────────────
+
+echo "== doctor staleness check =="
+
+# Unreachable method repo → info line, never an error (offline-safe).
+RUN_OUT=$(cd "$FIXTURE" && PATH="$FIXTURE/shim:$PATH" METHOD_REPO="$FIXTURE/no-such-repo.git" "$PK" doctor 2>&1)
+case "$RUN_OUT" in
+  *"skipped upstream-staleness check"*) ok "doctor: unreachable method repo is soft" ;;
+  *) fail "doctor: unreachable method repo is soft" "no skip line in output" ;;
+esac
+
+# Local method repo whose latest tag is ahead of PK_VERSION → staleness warning.
+METHOD_FIXTURE=$(mktemp -d)
+git -C "$METHOD_FIXTURE" init -q -b main
+git -C "$METHOD_FIXTURE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$METHOD_FIXTURE" tag v99.0.0
+git -C "$METHOD_FIXTURE" tag v99.1.0-rc1   # rc tags must not count as "latest"
+RUN_OUT=$(cd "$FIXTURE" && PATH="$FIXTURE/shim:$PATH" METHOD_REPO="$METHOD_FIXTURE" "$PK" doctor 2>&1)
+case "$RUN_OUT" in
+  *"latest release is v99.0.0"*) ok "doctor: warns when behind latest release (rc tags ignored)" ;;
+  *) fail "doctor: warns when behind latest release (rc tags ignored)" "$(echo "$RUN_OUT" | grep -i 'pipekit v\|latest' | head -2)" ;;
+esac
+rm -rf "$METHOD_FIXTURE"
+
 # ── CLI tests: ship guard rails ──────────────────────────────────────────────
 
 echo "== ship guard rails =="


### PR DESCRIPTION
Item 5 of the system-review priority list.

`pk doctor` now compares the synced `PK_VERSION` against the method repo's latest release tag (`git ls-remote`, env/config-overridable `Method repo`). Behind → warning with the exact update command; current/ahead → green; unreachable → info line only (doctor must work offline; `|| true` guards pipefail). rc tags are excluded from "latest", and running an rc of the latest release still warns.

Motivation: a consumer can silently fall releases behind — the local Piper checkout sat a full release back through the 2.8/3.0 cycle with no signal anywhere in the project.

Two offline smoke tests added (23 total, all green): unreachable-repo soft skip, and a local fixture method-repo tagged `v99.0.0` + `v99.1.0-rc1` proving the warning fires and rc tags don't count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)