### PR TITLE
feat(pk): pk branch secrets hygiene — never link .env.prod, announce symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ## Unreleased
 
-_Nothing yet._
+- **`pk branch` secrets hygiene — 1Password pattern round-trip.** Closes the "promote into Pipekit" item from the SiteLine (POC-85/86) and Piper (WIT-559) 1Password rollouts. `pk_link_env_files` no longer links `.env.prod` into worktrees (root or nested) — prod credentials have no business in a feature worktree; deploys render prod values from the vault. Env linking is no longer silent: `pk branch` now announces every plaintext symlink it creates and names `.env.prod` files it skipped. New `pipekit-security.md` § Secrets Managers and Worktrees codifies the portable contract: committed `op://` reference files travel via git checkout (no linking needed), a reference is not a credential, the op-recipe `.envrc` is config (still linked + direnv-allowed), plaintext symlinking is the legacy fallback, and loaded ≠ valid for write-only secret migrations. Regression coverage added to `scripts/test-pk-env-links.sh`.
 
 ---
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -537,7 +537,7 @@ After agent review passes, you review the spec in Linear. This is where product 
 
 - Creates `feature/<ID>-<3-word-slug>` (slug derived from issue title)
 - Worktree at `.worktrees/<ID>-<slug>`
-- Symlinks `.env` / `.env.local` / `.mcp.json` into the worktree — plus **nested per-app env files** (v2.7.0+): auto-discovers and links real nested env files (e.g. `apps/web/.env.local`, `packages/*/.env`) at the same relative path, so monorepo worktrees don't come up reading the `*.example` placeholder. Exact-name match (never `*.example`), idempotent, never clobbers a real file already in the worktree.
+- Symlinks `.env` / `.env.local` / `.mcp.json` into the worktree — plus **nested per-app env files** (v2.7.0+): auto-discovers and links real nested env files (e.g. `apps/web/.env.local`, `packages/*/.env`) at the same relative path, so monorepo worktrees don't come up reading the `*.example` placeholder. Exact-name match (never `*.example`), idempotent, never clobbers a real file already in the worktree. **Never links `.env.prod`** — prod credentials stay out of feature worktrees — and announces every link it makes on stdout. Projects on the secrets-manager pattern (committed `op://` reference files) don't need the symlinks at all: tracked reference files travel via git checkout. See `pipekit-security.md` § Secrets Managers and Worktrees.
 - Copies parent's `bin/pk` so v2 commands work from inside the worktree
 - Linear: Approved → In Progress
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -130,6 +130,7 @@ Consumes Approved issues from the spec loop. Each pass produces a merged PR and 
   │     • creates feature/<ID>-<3-word-slug>                 │
   │     • worktree at .worktrees/<ID>-<slug>                 │
   │     • symlinks .env / .env.local / .mcp.json             │
+  │       (announced; never .env.prod)                       │
   │     • copies parent's bin/pk into worktree               │
   │     • Linear: Approved → In Progress                     │
   └──────────────────────────────────────────────────────────┘

--- a/bin/pk
+++ b/bin/pk
@@ -566,23 +566,39 @@ pk_worktree_path() {
 # nested env file at the same relative path. Exact-name match (never *.example),
 # pruning node_modules/.git/.worktrees so we never recurse into a dependency
 # tree or a sibling worktree.
+#
+# .env.prod is deliberately NOT linked — prod credentials have no business in
+# a feature worktree; prod values are rendered from the secrets manager at
+# deploy time. Committed secrets-manager reference files (op:// pointers,
+# *.tpl) are tracked, so they reach worktrees via git checkout — no linking
+# needed. See pipekit-security.md § Secrets Managers and Worktrees.
 pk_link_env_files() {
-  local root="$1" wt_path="$2" envf abs rel
-  for envf in .env .env.local .env.dev .env.prod .envrc .mcp.json .sentryclirc; do
+  local root="$1" wt_path="$2" envf abs rel linked="" skipped=""
+  for envf in .env .env.local .env.dev .envrc .mcp.json .sentryclirc; do
     if [ -f "$root/$envf" ] && [ ! -e "$wt_path/$envf" ]; then
       ln -sf "$root/$envf" "$wt_path/$envf"
+      linked="$linked $envf"
     fi
   done
+  [ -f "$root/.env.prod" ] && skipped=" .env.prod"
   while IFS= read -r abs; do
     [ -n "$abs" ] || continue
     rel="${abs#"$root"/}"
     case "$rel" in */*) ;; *) continue ;; esac   # root-level handled above
+    case "$rel" in *.env.prod) skipped="$skipped $rel"; continue ;; esac
     if [ ! -e "$wt_path/$rel" ]; then
       mkdir -p "$wt_path/$(dirname "$rel")"
       ln -sf "$abs" "$wt_path/$rel"
+      linked="$linked $rel"
     fi
   done < <(find "$root" \( -name node_modules -o -name .git -o -name .worktrees \) -prune \
              -o -type f \( -name .env -o -name .env.local -o -name .env.dev -o -name .env.prod \) -print 2>/dev/null)
+  if [ -n "$linked" ]; then
+    echo "  Linked from parent (plaintext symlinks):$linked"
+  fi
+  if [ -n "$skipped" ]; then
+    echo "  Skipped:$skipped — prod secrets stay out of worktrees (pipekit-security.md)"
+  fi
 }
 
 # Classify whether a WIT identifier has real implementation evidence in git

--- a/resources/handoffs/nebula-2026-06-10-pk-gh-failure-resilience.md
+++ b/resources/handoffs/nebula-2026-06-10-pk-gh-failure-resilience.md
@@ -1,0 +1,43 @@
+# Handoff: pk resilience on gh/GitHub API failures
+
+**From:** Nebula, SiteLine POC-49 ship session, 2026-06-10
+**Status:** proposal — not started
+
+## Incident anchor
+
+During the POC-49 ship (SiteLine, 2026-06-10), GitHub had a multi-hour "Partial System
+Outage — API Requests: major_outage" (confirmed via githubstatus.com/api/v2/summary.json,
+~16:59–17:37 UTC). Symptoms as seen from pk and gh:
+
+- `pk ready POC-49` failed with a 401 "Requires authentication" on a **valid** keyring token.
+- `gh pr edit` / `gh run rerun` 401'd intermittently while gh **reads** interleaved fine.
+- A fresh CI push failed every job in ~2s with zero steps (`steps: []`) across all
+  workflows, including previously-green ones.
+
+Two wrong diagnoses were chased before the outage was found (pk token resolution, then
+macOS keychain flakiness) — roughly an hour of misdirected debugging. GitHub's API returns
+spurious 401s during outages, which pattern-matches perfectly to a local auth problem.
+
+## The ask (small, two parts)
+
+1. **Retry once.** pk subcommands that shell to `gh` (`cmd_ready`, `cmd_ship`, anything
+   doing PR writes) should retry a failed gh call once (short backoff) before surfacing
+   the error. The outage phase was intermittent; a single retry rode through most calls.
+2. **Surface context on persistent failure.** When the retry also fails with an auth-shaped
+   error (401/"Requires authentication"), print a diagnostic hint instead of the bare gh
+   error:
+   - `gh auth status` output (is the token actually healthy?)
+   - a pointer to check `https://www.githubstatus.com/api/v2/summary.json` BEFORE
+     debugging local auth — spurious 401s on healthy tokens and mass 2s/zero-step CI
+     failures are the platform-outage tells.
+
+Explicitly NOT asking for: an outage-detection daemon, automatic githubstatus polling, or
+retry loops beyond one attempt. pk was not at fault here — `cmd_ready` just shells to gh
+with no token path of its own — this is about making the failure mode self-explaining so
+the next session doesn't burn an hour on a non-bug.
+
+## Suggested home
+
+`bin/pk` — a small `gh_with_retry()` wrapper around the existing gh invocations, plus the
+hint block on persistent auth-shaped failure. Possibly a line in RUNBOOK.md's
+troubleshooting section with the two platform-outage tells.

--- a/scripts/test-pk-env-links.sh
+++ b/scripts/test-pk-env-links.sh
@@ -8,6 +8,8 @@
 #     *.example placeholder (NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co)
 #     so the browser client had no backend to talk to
 #   - *.example placeholders are NEVER linked (exact-name match)
+#   - .env.prod is NEVER linked, root or nested (prod secrets stay out of
+#     worktrees — pipekit-security.md § Secrets Managers and Worktrees)
 #   - node_modules / .git / .worktrees are pruned (no dep-tree or sibling-worktree recursion)
 #   - the operation is idempotent (re-run is a no-op, never errors)
 #
@@ -53,11 +55,13 @@ printf 'NEXT_PUBLIC_SUPABASE_URL=your-project.supabase.co\n'  > "$root/apps/web/
 printf 'DB=postgres://real\n'                                 > "$root/packages/db/.env"
 printf 'SHOULD_NOT_LINK=1\n'                                  > "$root/node_modules/pkg/.env"
 printf 'ROOT=1\n'                                             > "$root/.env.local"
+printf 'PROD_SECRET=1\n'                                      > "$root/.env.prod"
+printf 'NESTED_PROD_SECRET=1\n'                               > "$root/apps/web/.env.prod"
 
 # Fresh worktree: tracked dirs only, no gitignored env files present.
 mkdir -p "$wt/apps/web" "$wt/packages/db"
 
-pk_link_env_files "$root" "$wt"
+link_output=$(pk_link_env_files "$root" "$wt")
 
 # Nested real env file linked to the REAL value (the core regression).
 if [ -L "$wt/apps/web/.env.local" ] && \
@@ -79,9 +83,23 @@ fi
 # Root-level file handled by pass (1).
 [ -L "$wt/.env.local" ] && ok "root .env.local linked" || nope "root .env.local linked"
 
+# .env.prod must never be linked — root or nested.
+[ ! -e "$wt/.env.prod" ] && ok "root .env.prod NOT linked" || nope "root .env.prod NOT linked"
+[ ! -e "$wt/apps/web/.env.prod" ] && ok "nested apps/web/.env.prod NOT linked" || nope "nested apps/web/.env.prod NOT linked"
+
+# Linking is announced (visibility — plaintext propagation must not be silent).
+case "$link_output" in
+  *"Linked from parent"*) ok "linked files announced on stdout" ;;
+  *) nope "linked files announced on stdout" "got: $link_output" ;;
+esac
+case "$link_output" in
+  *"Skipped"*".env.prod"*) ok ".env.prod skip announced on stdout" ;;
+  *) nope ".env.prod skip announced on stdout" "got: $link_output" ;;
+esac
+
 # Idempotency: a second run must not error and must not change anything.
 before=$(cd "$wt" && find . -name '.env*' | sort)
-if pk_link_env_files "$root" "$wt" 2>/dev/null; then
+if pk_link_env_files "$root" "$wt" >/dev/null 2>&1; then
   after=$(cd "$wt" && find . -name '.env*' | sort)
   [ "$before" = "$after" ] && ok "idempotent re-run (no change, no error)" || nope "idempotent re-run" "set changed"
 else
@@ -93,7 +111,7 @@ fi
 mkdir -p "$wt/apps/api" "$root/apps/api"
 printf 'PREEXISTING=1\n' > "$wt/apps/api/.env.local"
 printf 'PARENT=1\n'      > "$root/apps/api/.env.local"
-pk_link_env_files "$root" "$wt"
+pk_link_env_files "$root" "$wt" >/dev/null
 if [ ! -L "$wt/apps/api/.env.local" ] && [ "$(cat "$wt/apps/api/.env.local")" = "PREEXISTING=1" ]; then
   ok "pre-existing worktree env file not clobbered"
 else

--- a/templates/rules/pipekit-security.md
+++ b/templates/rules/pipekit-security.md
@@ -15,6 +15,16 @@ Never commit secrets to git. Ever. No exceptions for "just for testing" or "I'll
 
 If you accidentally commit a secret: rotate it immediately, then rewrite history. A committed secret is a leaked secret even if you delete the commit — assume it was scraped.
 
+## Secrets Managers and Worktrees
+
+When the project uses a secrets manager (reference pattern: 1Password for Developers, proven on SiteLine POC-85/86 and Piper WIT-559), the contract is:
+
+- **Committed reference files carry pointers, never values.** `op://` reference files (`secrets.op`, `op-references.conf`, `*.tpl`) are tracked in git, so they reach every worktree via checkout — no copying or symlinking needed. Injection happens at the edge: `op run --env-file=<refs> -- <cmd>` locally, `op inject` on templates at deploy, `1password/load-secrets-action` in CI.
+- **A reference is not a credential.** `op://` lines are safe to commit; exempt them from secret scanners.
+- **An `.envrc` wrapping the secrets-manager recipe** (direnv + `op run`) is config, not a secret — `pk branch` symlinks it into worktrees and auto-allows direnv so worktree shells load the vault-backed env.
+- **Plaintext `.env*` symlinking into worktrees is the legacy fallback** for projects not yet migrated. `pk branch` announces what it links, and **never links `.env.prod`** — prod credentials have no business in a feature worktree. When a deploy needs prod values, render them from the vault at deploy time.
+- **Loaded ≠ valid.** When migrating a write-only secret (GitHub Actions secrets cannot be read back), exercise the real auth path once before declaring the cutover done — a token that resolves from the vault can still be expired.
+
 ## Input Validation at Boundaries Only
 
 - Validate user input at the entry point (API handlers, form submissions, CLI args)


### PR DESCRIPTION
## What

Round-trips the 1Password secrets-manager rollout (SiteLine POC-85/86, Piper WIT-559) into Pipekit's portable layer — the pending "promote into Pipekit" item from that work.

- **`pk_link_env_files` no longer links `.env.prod`** into worktrees, root or nested. Prod credentials have no business in a feature worktree; deploys render prod values from the vault at deploy time.
- **Env linking is no longer silent.** `pk branch` announces every plaintext symlink it creates and names any `.env.prod` it skipped.
- **New `pipekit-security.md` § Secrets Managers and Worktrees** codifies the portable contract: committed `op://` reference files travel via git checkout (no linking needed); a reference is not a credential; the op-recipe `.envrc` is config and stays linked + direnv-allowed; plaintext symlinking is the legacy fallback; loaded ≠ valid for write-only secret migrations.
- GUIDE.md / RUNBOOK.md updated to match; CHANGELOG Unreleased entry added.

## Why now

`pk branch` was riding on coincidental compatibility with the 1Password pattern — the `.envrc` symlink + direnv auto-allow happened to carry the op recipe into worktrees, but the tool still silently propagated `.env.prod` links into every worktree (observed live on SiteLine poc-129, 2026-06-10) and nothing in the rules documented the contract.

## Verify

- `bash scripts/test-pk-env-links.sh` — 11/11 pass, including 4 new assertions (.env.prod excluded root+nested, links announced, skip announced)
- `bash tests/pk-smoke.sh` — 23/23 pass
- `bash -n bin/pk` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)