### PR TITLE
chore(release): v4.0.0-rc2 — de-stale + debrand VBW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ---
 
+## v4.0.0-rc2 — 2026-06-16
+
+> **De-stale + debrand follow-up to rc1.** rc1 removed the VBW *executor* but left stale references that still routed users to it, plus cosmetic "VBW" branding that no longer matches reality. This pass fixes the wrong-routing bugs and debrands prose where the name isn't load-bearing. **No behavior change to the planning layer** — `.vbw-planning/`, `/vbw:init`, `/roadmap-create`, `/phase-plan`, `/review-plan`, `pk_vbw_*`, and the vbw plugin are all untouched. The brand necessarily persists in the plugin-owned `.vbw-planning/` directory and the `/vbw:*` commands until a separate planning-layer retirement.
+
+- **Executor-stale bug fixes (were misrouting users to removed infra):**
+  - `skills/verify/skill.md`: QA + adversarial subagents now use `subagent_type: "general-purpose"` directly (dropped the `Backend`-keyed `vbw:vbw-qa` selection and the `Backend` config read); fallback row no longer names `vbw:vbw-qa`.
+  - `skills/pk-bug/skill.md`: dropped the `Backend (vbw or native)` config read and the `vbw-debugger` agent suggestion (now a `general-purpose` debugging subagent).
+  - `skills/review-plan/skill.md`: reframed native-first — all 14 `/vbw:vibe --plan/--execute` references now point at `/work`'s inline planning (`.pk-work/<ID>-PLAN.md`) and native execution; legacy `.vbw-planning/phases/` layout still reviewed.
+  - `templates/tier-standard.md`, `templates/tier-heavy.md`: execution rows say native `/work` (planning still required; `PLAN.md` at `.pk-work/<ID>-PLAN.md`).
+  - `sop/Linear_SOP.md`: `Building` state now correctly attributes execution + QA to native `/work` + `/verify`, not "VBW execution / VBW QA agent". Planning-layer ownership model preserved.
+  - `method.md`: "VBW agents read CLAUDE.md / VBW agents execute plans" → "the executor".
+- **Debrand (cosmetic):** "VBW SUMMARY" → "planning SUMMARY" (`GUIDE.md`, `sop/Git_and_Deployment.md`); `01-light-spec` "VBW-ingestible" → "plan-ready"; `templates/CLAUDE.md.template` dropped the stale "planning and execution engine" claim (execution is native).
+- **Deliberately not touched:** the `## VBW Integration` / `Step 0.5: VBW Init` section headings (named after the real `/vbw:init` command, TOC-anchored, kept in rc1) and `VBW_COMMANDS.md` / `sop/VBW_Help.md` (real planning-command references). Fully removing "VBW" from these requires the deferred planning-layer retirement.
+- **Migration:** none. Consumers re-sync (`./scripts/sync-method.sh v4.0.0-rc2`) to pick up the corrected guidance.
+
+---
+
 ## v4.0.0-rc1 — 2026-06-15
 
 > **VBW executor removed.** v3.2.0 deprecated the optional `vbw` `/work` executor on production evidence (0/30 recent SiteLine PRs used it); v4.0.0 makes good on the removal. Native-on-Workflow is now the **sole** executor — there is no pluggable backend, no `--backend=` flag, and no `vbw-dev`/`vbw-scout` dispatch in `/work`. This is the breaking change that justifies the major bump: a stale `Backend: vbw`/`auto` in `method.config.md` or a `--backend=vbw` flag now **refuses with a migration message** rather than silently routing. **The VBW *planning* layer is untouched** — `.vbw-planning/`, `/vbw:init`'s roadmap scaffold, `/roadmap-create`'s phase merge, `/phase-plan`, `/review-plan`, and the `pk_vbw_*` roadmap helpers all stay. Retiring the planning layer (and rewriting Stage 0 onto Linear + a native phase surface) is a separate, later effort, deliberately not bundled here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,10 @@ Stage 0: Foundation (a contract — see Entry Modes)
   /concept → /define → /strategy-create → /startup → /vbw:init → /roadmap-create → /phase-plan
 
 Stages 1-5: Development — the v2 daily loop (repeats per issue)
-  pk next → pk branch → /work → /verify → pk ship (Draft) → pk ready → [PR review + preview UAT] → pk done [--merge] → [dev UAT] → pk promote <env> → (PR merges) → pk promote <env> --finish → /pk-exit
+  pk next → pk branch → /work → /verify → pk ship (Draft) → pk ready → [PR review + preview UAT] → pk done [--merge] → [dev UAT] → pk promote <env> → (PR merges) → pk promote <env> --finish
+
+Per session (NOT part of the issue chain): /pk-exit — the last command of whatever session you're in.
+  pk done runs from the parent repo and deletes the worktree, so in a worktree session: /pk-exit first, THEN leave the worktree and run pk done from the parent.
 ```
 
 Stage 0 is a **contract** (a set of artifacts the dev pipeline requires), not a script. Three entry modes satisfy the contract: greenfield (full chain), brownfield (skip /concept and /define), inherited (verify and proceed). `/startup` auto-detects mode and confirms with the user. The v2 daily loop replaces v1's `/branch → /launch → /verify → /launch --close` chain — see `RUNBOOK.md` for the one-page flowchart. Full Entry Modes table in `method.md`.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**v4.0.0-rc1** — Last updated: 2026-06-15  *(VBW executor removed: native-on-Workflow is the sole executor — the pluggable `vbw` backend, the `--backend=` flag, and the `vbw-dev`/`vbw-scout` dispatch are gone (the `auto` router in v3.2.0); a stale `Backend: vbw`/`--backend=vbw` now refuses with a migration message. The VBW Integration section is reframed as the **roadmap scaffold** (`/vbw:init`), which stays. Carries the v3.1.0 distribution-layer rows (`pk doctor` staleness check, `.local-skills` manifest), 3.0 final's `vbw-lead` dispatch scrub, the native-on-Workflow reframe, and the v2.8.x substrate)*
+**v4.0.0-rc2** — Last updated: 2026-06-16  *(De-stale + debrand follow-up to rc1: purged executor-stale VBW references that still routed to the removed backend (`/verify` + `/pk-bug` QA-subagent now `general-purpose`, `/review-plan`'s `/vbw:vibe` routing now native `/work`, tier-template execution rows, `Linear_SOP` execution-ownership) and debranded cosmetic prose ("VBW SUMMARY" → "planning SUMMARY"). The VBW Integration section stays as the **roadmap scaffold** (`/vbw:init`); the planning layer and vbw plugin are untouched. rc1: VBW executor removed — native-on-Workflow is the sole executor; a stale `Backend: vbw`/`--backend=vbw` refuses with a migration message. Carries the v3.1.0 distribution-layer rows and the v2.8.x substrate)*
 
 ---
 
@@ -702,7 +702,7 @@ feature/* → pk ship (Draft) → pk ready → pk done (UAT → In Dev)
 ```
 - `pk ship` opens the feature → dev PR as Draft (Linear → `UAT`)
 - `pk ready` flips Draft → Ready (fires outside reviewers)
-- `pk done <ID>` after merge: cleanup + Linear → `In Dev` + auto-pull + VBW SUMMARY/PLAN-flip
+- `pk done <ID>` after merge: cleanup + Linear → `In Dev` + auto-pull + planning SUMMARY/PLAN-flip
 - `pk promote main` (or `pk promote` with no arg) opens the dev → main PR. WITs stay in `In Dev`.
 - `pk promote main --finish` (v2.6.0+ Phase 2) after the promote PR merges: transitions the issue → `Done`
 
@@ -714,7 +714,7 @@ feature/* → pk ship (Draft) → pk ready → pk done (UAT→In Dev)
 ```
 - `pk ship` opens the feature → dev PR as Draft (Linear → `UAT`)
 - `pk ready` flips Draft → Ready (fires outside reviewers)
-- `pk done <ID>` after merge: cleanup + Linear → `In Dev` + auto-pull + VBW SUMMARY/PLAN-flip
+- `pk done <ID>` after merge: cleanup + Linear → `In Dev` + auto-pull + planning SUMMARY/PLAN-flip
 - `pk promote beta` opens dev → beta. WITs stay in `In Dev`. `--finish` after merge transitions → `In Beta`.
 - `pk promote main` opens beta → main. WITs stay in `In Beta`. `--finish` after merge transitions → `Done`.
 
@@ -1197,7 +1197,7 @@ Add to `.git/hooks/post-commit` or your project's hook system:
 
 | Command | Invocation | What It Does |
 |---------|------------|-------------|
-| Cleanup | `pk done <ID> [--merge]` | Post-merge: verify merge, cleanup worktree+branch, post commits/diffstat to Linear, transition UAT → In `<FirstEnv>` (or → Done for 1-tier). v2.6.0+: also auto-pulls integration + writes VBW SUMMARY + flips PLAN status. v2.7.0+: resets the parent branch, prints a stack advisory, and reminds you to deploy when a `Deploy command` is configured (script-deploy projects). |
+| Cleanup | `pk done <ID> [--merge]` | Post-merge: verify merge, cleanup worktree+branch, post commits/diffstat to Linear, transition UAT → In `<FirstEnv>` (or → Done for 1-tier). v2.6.0+: also auto-pulls integration + writes planning SUMMARY + flips PLAN status. v2.7.0+: resets the parent branch, prints a stack advisory, and reminds you to deploy when a `Deploy command` is configured (script-deploy projects). |
 | Promote — open | `pk promote <env>` | Phase 1 (v2.6.0+): opens promote PR. WITs stay in source state. PR body embeds bundled-WIT tracker. 2-tier: `pk promote` with no arg picks the only hop. |
 | Promote — finish | `pk promote <env> --finish` | Phase 2 (v2.6.0+): after the promote PR merges, transitions matching issues → `In <Env>` (intermediate) or → Done (final). |
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v4.0.0-rc1** — Last updated: 2026-06-15  *(VBW executor removed: native-on-Workflow is the sole executor — the pluggable `vbw` backend, the `--backend=` flag, and the `Backend` config row are gone (a stale `Backend: vbw`/`--backend=vbw` now refuses with a migration message). No other daily-flow change; the VBW planning layer (`.vbw-planning/`, `/vbw:init` roadmap scaffold) is untouched. Carries Pipekit 3.0–3.2 (native executor, distribution-layer hardening) and the v2.8.x substrate; sync-method.sh example bumped to v4.0.0-rc1)*
+**v4.0.0-rc2** — Last updated: 2026-06-16  *(De-stale + debrand follow-up to rc1: purged executor-stale VBW references that still routed to the removed backend (`/verify` + `/pk-bug` QA-subagent now `general-purpose`, `/review-plan`'s `/vbw:vibe` routing now native `/work`, tier-template execution rows, `Linear_SOP` execution-ownership, method.md "VBW agents" claims) and debranded cosmetic prose ("VBW SUMMARY" → "planning SUMMARY"). The VBW planning layer (`.vbw-planning/`, `/vbw:init` roadmap scaffold) and the vbw plugin are untouched. rc1: VBW executor removed — native-on-Workflow is the sole executor; a stale `Backend: vbw`/`--backend=vbw` refuses with a migration message. Carries Pipekit 3.0–3.2 and the v2.8.x substrate)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -11,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v4.0.0-rc1             (or latest tag)
+1. ./scripts/sync-method.sh v4.0.0-rc2             (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)

--- a/bin/pk
+++ b/bin/pk
@@ -29,7 +29,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="4.0.0-rc1"
+PK_VERSION="4.0.0-rc2"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.md
+++ b/method.md
@@ -1,6 +1,6 @@
 # Pipekit
 
-**v4.0.0-rc1** — Last updated: 2026-06-15  *(**VBW executor removed.** Native-on-Workflow is the sole executor; the pluggable `vbw` backend, the `--backend=` flag, and the `vbw-dev`/`vbw-scout` dispatch in `/work` are gone (the `auto` router went in v3.2.0). A stale `Backend: vbw`/`auto` or `--backend=vbw` now refuses with a migration message. Makes good on the v3.2.0 deprecation, grounded in production evidence: 0/30 recent SiteLine PRs used vbw, and native shipped 12/13 clean first-pass with the gate layer — not the executor — catching the one defect. The **VBW planning layer** (`.vbw-planning/`, `/vbw:init` roadmap scaffold, `/roadmap-create` phase merge, `/phase-plan`, `/review-plan`) is untouched. The deep-analysis safety net remains the gate layer (`/financial-review`, `/pr-security-review`), which native runs. Carries Pipekit 3.0–3.2: native-on-Workflow executor, distribution-layer hardening, see `experiments/`)*
+**v4.0.0-rc2** — Last updated: 2026-06-16  *(**De-stale + debrand follow-up to rc1.** Purged executor-stale VBW references that still routed users to the removed backend: `/verify` + `/pk-bug` QA-subagent defaults are now `general-purpose`, `/review-plan`'s `/vbw:vibe --plan/--execute` routing is now native `/work`, the tier templates' execution rows and `Linear_SOP`'s execution-ownership now name native, and method.md's "VBW agents read/execute" claims now say "the executor". Debranded cosmetic prose ("VBW SUMMARY" → "planning SUMMARY"). The **VBW planning layer** (`.vbw-planning/`, `/vbw:init` roadmap scaffold, `/roadmap-create` phase merge, `/phase-plan`, `/review-plan`) and the vbw plugin are untouched — the brand persists in the plugin-owned dir + `/vbw:*` commands until a separate planning-layer retirement. rc1: **VBW executor removed** — native-on-Workflow is the sole executor; a stale `Backend: vbw`/`auto`/`--backend=vbw` refuses with a migration message; grounded in production evidence (0/30 recent SiteLine PRs used vbw). Carries Pipekit 3.0–3.2: native-on-Workflow executor, distribution-layer hardening, see `experiments/`)*
 
 > **v2.4.3.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >
@@ -53,7 +53,7 @@ Per session (not per issue): /pk-exit          (last command of every Claude Cod
 
 **Bookends:** `/roadmap-review` validates Stage 0 outputs and plan health before entering the pipeline. `/strategy-sync` updates Strategy docs after features ship — closing the documentation loop.
 
-**Three-layer enforcement.** Conventions live in `CLAUDE.md` (VBW agents read this), hard gates live in CI + hooks (block merges that violate them), and skills are interactive shortcuts for hands-on sessions. The same rule is enforced at multiple layers so neither a missed skill invocation nor a permissive prompt can bypass it.
+**Three-layer enforcement.** Conventions live in `CLAUDE.md` (the executor reads this), hard gates live in CI + hooks (block merges that violate them), and skills are interactive shortcuts for hands-on sessions. The same rule is enforced at multiple layers so neither a missed skill invocation nor a permissive prompt can bypass it.
 
 ### Step-by-Step
 
@@ -343,11 +343,11 @@ The spec-as-contract principle ("no stage may introduce guesswork into the next 
 
 | Layer | Purpose | Who it serves |
 |---|---|---|
-| **CLAUDE.md** | Documents conventions so VBW agents follow them automatically | VBW dev agents during plan execution |
+| **CLAUDE.md** | Documents conventions so the executor follows them automatically | The native executor during plan execution |
 | **CI / Hooks** | Hard enforcement — blocks merges that violate conventions | Everyone (agents and humans) |
 | **Skills** | Interactive shortcuts for hands-on sessions | You, when working with Claude directly |
 
-Skills are convenience wrappers. They automate the same conventions documented in CLAUDE.md. VBW agents don't call skills — they read CLAUDE.md and write code directly.
+Skills are convenience wrappers. They automate the same conventions documented in CLAUDE.md. The executor doesn't call skills — it reads CLAUDE.md and writes code directly.
 
 ---
 

--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -5,7 +5,7 @@ description: Structured spec generation with auto-cycled agent review + tier aut
 
 # Light Spec Skill
 
-Draft a structured, VBW-ingestible specification for a Linear issue. Bridges the gap between raw brainstorms and full VBW PLAN.md files.
+Draft a structured, plan-ready specification for a Linear issue. Bridges the gap between raw brainstorms and full PLAN.md files.
 
 ## Triggers
 

--- a/skills/linear/skill.md
+++ b/skills/linear/skill.md
@@ -136,7 +136,7 @@ Keep Linear comments concise and useful:
 ## Related
 
 - Branch + worktree: `pk branch <ID>` — creates worktree + branch + Linear → In Progress (idempotent)
-- v2 daily loop: `pk next` → `pk branch` → `/work` → `/verify` → `pk ship` → `pk done` → `/pk-exit` (recommended path; this skill is the manual hands-on alternative)
+- v2 daily loop: `pk next` → `pk branch` → `/work` → `/verify` → `pk ship` → `pk done` (recommended path; this skill is the manual hands-on alternative). `/pk-exit` is not part of this chain — it's the per-session log command (see below); `pk done` runs from the parent repo and deletes the worktree, so in a worktree session run `/pk-exit` first, then leave the worktree and run `pk done`.
 - Batch processing: `/linear-todo-runner` — rolling parallel queue for multiple issues
 - Promotion: `pk ship` (feature → integration branch) + `pk promote` (walks the chain per `Ship environments` in `method.config.md`)
 - Session log: `/pk-exit` — narrative session log to `Logs/Sessions/<date>_<HHMM>.md` (last command of every Claude Code session)

--- a/skills/pk-bug/skill.md
+++ b/skills/pk-bug/skill.md
@@ -34,7 +34,6 @@ Do NOT use for:
 Read `method.config.md` for:
 - Linear team ID, workflow state IDs
 - Pre-deploy gate commands
-- Backend (`vbw` or `native`) — passed through to `/work`
 
 ## Preflight — checkout guard  *(applies to Phases 1–2 only)*
 
@@ -139,7 +138,7 @@ Use the scientific method:
 3. Narrow until you have a one-paragraph root-cause statement
 4. Append the root cause to the Linear issue body under `## Root Cause`
 
-If diagnosis takes more than ~30 minutes of investigation, consider spawning the `vbw-debugger` agent. Don't burn the main context on a deep dive.
+If diagnosis takes more than ~30 minutes of investigation, consider spawning a dedicated debugging subagent (`general-purpose`) to investigate in a fresh context. Don't burn the main context on a deep dive.
 
 ### 3b — Write the failing test
 

--- a/skills/review-plan/skill.md
+++ b/skills/review-plan/skill.md
@@ -5,11 +5,11 @@ description: Run plan-reviewer agent against a PLAN.md before execution. Use aft
 
 # Review Plan Skill
 
-> **Fresh-chat check.** If this conversation ran `/vbw:vibe --plan` or watched the plan get drafted, start a new conversation. The reviewer must be independent of the planner. See `method.md` § Fresh-Chat Discipline.
+> **Fresh-chat check.** If this conversation drafted the plan (e.g. ran `/work`'s planning phase) or watched it get drafted, start a new conversation. The reviewer must be independent of the planner. See `method.md` § Fresh-Chat Discipline.
 
-You are a plan-review coordinator. Your job is to invoke the `plan-reviewer` agent against a `PLAN.md` before execution, present the structured review back to the user, and recommend a path forward (proceed to execute, route back for plan revision, or escalate). The plan comes from VBW's planner in direct VBW use (`/vbw:vibe --plan` / `vbw:vbw-lead`), or from `/work`'s inline planning (native, filed at `.pk-work/<ID>-PLAN.md`).
+You are a plan-review coordinator. Your job is to invoke the `plan-reviewer` agent against a `PLAN.md` before execution, present the structured review back to the user, and recommend a path forward (proceed to execute, route back for plan revision, or escalate). The plan comes from `/work`'s inline planning, filed at `.pk-work/<ID>-PLAN.md` (native-on-Workflow is the sole executor as of v4.0.0).
 
-This skill is Pipekit's plan-review gate — an independent stress-test between planning and execution. It is **most relevant in direct VBW use**, where the whole plan is handed to `vbw-dev` **wholesale** with no per-task gate. For native `/work`, per-task verify-before-integrate is its own plan-safety mechanism, so upfront review matters less — reach for it when a plan is large or high-risk. In direct VBW use, run this **between** `/vbw:vibe --plan` and `/vbw:vibe --execute`.
+This skill is Pipekit's plan-review gate — an independent stress-test between planning and execution. Native `/work` runs per-task verify-before-integrate, which is its own plan-safety mechanism, so upfront review matters most when a plan is **large or high-risk** — reach for `/review-plan` against `.pk-work/<ID>-PLAN.md` before kicking off execution in those cases.
 
 ## Triggers
 
@@ -20,7 +20,7 @@ This skill is Pipekit's plan-review gate — an independent stress-test between 
 
 ## Purpose
 
-VBW Lead's Stage 3 self-review covers structural correctness (requirements coverage, circular deps, same-wave file conflicts, task counts, skill refs). It cannot see:
+The planner's own self-review covers structural correctness (requirements coverage, circular deps, same-wave file conflicts, task counts, skill refs). It cannot see:
 
 - **Scope drift** vs the approved spec
 - **Framing errors** (solving the wrong problem)
@@ -34,7 +34,7 @@ The `plan-reviewer` agent fills that gap. This skill orchestrates the call.
 
 ## Prerequisites
 
-- A `PLAN.md` to review. In direct VBW use it lives in `.vbw-planning/phases/{phase-slug}/` (produced by `/vbw:vibe --plan` / `vbw:vbw-lead`). With native `/work` the plan is filed at `.pk-work/<ID>-PLAN.md` — point this skill at that path
+- A `PLAN.md` to review. With native `/work` the plan is filed at `.pk-work/<ID>-PLAN.md` — point this skill at that path. (Legacy VBW-planned phases keep `PLAN.md` under `.vbw-planning/phases/{phase-slug}/`; this skill still reviews those.)
 - The approved Light Spec is available — either as the description of a Linear issue tied to the current branch, or readable from a known location
 - `.claude/agents/plan-reviewer.md` is installed (Pipekit ships this; if missing, run `bash scripts/sync-method.sh`)
 
@@ -138,9 +138,9 @@ Based on the verdict:
 
 | Verdict | Recommendation |
 |---------|----------------|
-| **Pass** | "Plan is execution-safe. Run `/vbw:vibe --execute {phase}` when ready." |
-| **Revise** (non-blocking only) | "Plan can proceed but here are improvements to apply during execution: {list}. Run `/vbw:vibe --execute {phase}` when you've decided which to address." |
-| **Block** | "Do not execute. Route the Fast Path items back to Lead via `/vbw:vibe --plan {phase}` or amend the spec via `/02-light-spec-revise PROJ-XXX` if scope/framing is wrong. Specifically: {list of blocking issues}." |
+| **Pass** | "Plan is execution-safe. Proceed to execution when ready." |
+| **Revise** (non-blocking only) | "Plan can proceed but here are improvements to apply during execution: {list}. Proceed to execution when you've decided which to address." |
+| **Block** | "Do not execute. Re-run `/work`'s planning to address the Fast Path items, or amend the spec via `/02-light-spec-revise PROJ-XXX` if scope/framing is wrong. Specifically: {list of blocking issues}." |
 
 Always quote the agent's own Fast Path to Pass section verbatim — those are the concrete moves the user has to make.
 
@@ -148,9 +148,9 @@ Always quote the agent's own Fast Path to Pass section verbatim — those are th
 
 Emit an inline `➜ Next:` line in your terminal output. Pointer logic:
 
-- **Pass** → `/vbw:vibe --execute {phase-slug}`
-- **Revise** → `/vbw:vibe --execute {phase-slug}` (with note about non-blocking improvements)
-- **Block** → either `/vbw:vibe --plan {phase-slug}` (if Lead-revise scope) or `/02-light-spec-revise PROJ-XXX` (if spec/framing scope)
+- **Pass** → proceed to execution (`/work`)
+- **Revise** → proceed to execution (`/work`) (with note about non-blocking improvements)
+- **Block** → re-plan via `/work` (if plan-revise scope) or `/02-light-spec-revise PROJ-XXX` (if spec/framing scope)
 
 Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
 
@@ -178,7 +178,7 @@ Thoughts that mean "slow down on the review." Paired with `.claude/rules/pipekit
 
 - **Skipping the spec resolution** → reviewing a plan without the approved spec means the agent can't catch scope drift. Always pass the spec verbatim.
 - **Summarizing the spec for the agent** → the agent needs the AC section as written. Summary loses the testable conditions.
-- **Running review against partial PLAN.md** → wait for `/vbw:vibe --plan` to complete before reviewing. Partial plans return inflated Block verdicts.
+- **Running review against partial PLAN.md** → wait for planning to complete before reviewing. Partial plans return inflated Block verdicts.
 - **Treating Revise as Pass** → non-blocking improvements are not free; they accumulate technical debt if always deferred. Address each one or explicitly accept the trade-off.
 
 ---
@@ -187,9 +187,7 @@ Thoughts that mean "slow down on the review." Paired with `.claude/rules/pipekit
 
 | Skill | Relationship |
 |-------|-------------|
-| `/work` (native) | Plans **inline** and files the plan at `.pk-work/<ID>-PLAN.md`; run `/review-plan` against it before execution. `/work` does not spawn plan-reviewer directly. |
-| `/vbw:vibe --plan` | Produces the `PLAN.md` this skill reviews. |
-| `/vbw:vibe --execute` | Next step after Pass / Revise. |
+| `/work` (native) | Plans **inline** and files the plan at `.pk-work/<ID>-PLAN.md`; run `/review-plan` against it before execution, then proceed to execution. `/work` does not spawn plan-reviewer directly. |
 | `/02-light-spec-revise` | Route here when plan-reviewer's Block verdict points at spec-level issues (framing, missing AC, scope ambiguity). |
 | `plan-reviewer` agent | The actual review work happens here; this skill orchestrates the invocation. |
 
@@ -245,11 +243,11 @@ Missed: OAuth-callback-server-bypass note.
 2. Add Task 0.5 or Task 4 note: "RLS bypass acknowledged on callback path" (5 min)
 
 ### Final Recommendation
-proceed to Dev with these two improvements applied during execution.
+proceed to execution with these two improvements applied.
 
 ---
 
-➜ Next: /vbw:vibe --execute rs-14-login-routes
+➜ Next: proceed to execution (rs-14-login-routes)
    (apply the two non-blocking improvements during execution; verify-step
    sharpening can land in the same task commit)
 ```

--- a/skills/verify/skill.md
+++ b/skills/verify/skill.md
@@ -70,7 +70,6 @@ For tier:quick, the rest of this skill executes against stdout only — no file 
 Read from `method.config.md`:
 
 - `Require QA review` (default `false`) — controls whether QA subagent runs by default
-- `Backend` (default `vbw`) — used for QA subagent type selection
 - `## Pre-Deploy Gate` — bash code block of test/lint/type commands
 
 Resolve `--qa`:
@@ -183,10 +182,7 @@ git diff "origin/$INTEGRATION...HEAD"
 
 ### Step 4c — Spawn the QA subagent
 
-Backend-pluggable:
-
-- **vbw** backend: use `subagent_type: "vbw:vbw-qa"` (project must have VBW installed)
-- **native** backend: use `subagent_type: "general-purpose"`
+Use `subagent_type: "general-purpose"`.
 
 The subagent is configured with `allowed-tools: Read, Bash, Write` (the `Write` permission is what lets it land the verdict file). Recommend `model: sonnet` — deterministic file-shaping work.
 
@@ -316,10 +312,7 @@ The reasoning: these are the exact surfaces where shipping without adversarial r
 
 ### Step 5a — Spawn the adversarial subagent
 
-Backend-pluggable (same as QA):
-
-- **vbw** backend: use `subagent_type: "vbw:vbw-qa"` (re-uses QA agent — only the prompt differs)
-- **native** backend: use `subagent_type: "general-purpose"`
+Use `subagent_type: "general-purpose"` (same agent as QA — only the prompt differs).
 
 Configure with `allowed-tools: Read, Bash, Write`. Recommend `model: opus` — adversarial review benefits from deeper reasoning.
 
@@ -683,7 +676,7 @@ If `--auto-ship` is **not** in this skill's args (standalone `/verify` invocatio
 | No commits ahead of integration | Refuse with clear message. |
 | Pre-Deploy Gate not configured | Print: "Configure § Pre-Deploy Gate in method.config.md, then re-run." |
 | Gate command fails | Stop. Print failing command + last 30 lines. Write reality-check.md with status NEEDS WORK. Don't run QA. Don't write verify-complete.md. |
-| QA subagent type missing (e.g., `vbw:vbw-qa` not installed) | Fall back to `general-purpose`. Warn. |
+| QA subagent type unavailable | Warn and skip QA rather than blocking the gate. |
 | Spec has no AC | QA subagent should report "AC missing" as Fail; user gets clear next-action. |
 | `$VERIFY_DIR` unwritable (perms, disk full) | Print error, fall through to stdout-only mode for this run (tier downgraded to virtual). Day 3 gate will block ship in this case since `verify-complete.md` cannot be written. |
 | Linear unreachable for tier lookup | `pk_linear_tier` returns "standard" — evidence layer still written. |

--- a/sop/Git_and_Deployment.md
+++ b/sop/Git_and_Deployment.md
@@ -2,7 +2,7 @@
 
 > For the full development pipeline, see [method.md](../method.md).
 
-**v2.6.0** — Last updated: 2026-05-23  *(two-phase `pk promote` + `pk ship` Draft default + `pk ready` flip command; `pk done` auto-pulls integration and writes VBW SUMMARY)*
+**v2.6.0** — Last updated: 2026-05-23  *(two-phase `pk promote` + `pk ship` Draft default + `pk ready` flip command; `pk done` auto-pulls integration and writes planning SUMMARY)*
 **Source of truth:** Your project's CLAUDE.md defines the authoritative branch strategy, release flow, and deployment mapping. This SOP provides the day-to-day procedures.
 
 ---
@@ -29,7 +29,7 @@ dev  (active development)
 
 **Release flow:** `feature/*` → PR to `dev` → PR to `main`
 **Promotion mechanism:** `pk ship` opens the feature → `dev` PR as Draft (v2.6.0+; Linear → `UAT`). `pk ready` flips it to Ready (fires outside reviewers). `pk done` after merge → `In Dev`. `pk promote main` (or `pk promote` with no arg, since only one hop exists) opens the `dev` → `main` PR; `pk promote main --finish` runs after merge.
-**Linear transitions (v2.6.0+):** `pk ship` → `UAT` (PR open as Draft on preview); `pk done` → `In Dev` (merge confirmed; also auto-pulls integration + writes VBW SUMMARY); `pk promote main --finish` → `Done` (after promote PR merges — two-phase, not optimistic).
+**Linear transitions (v2.6.0+):** `pk ship` → `UAT` (PR open as Draft on preview); `pk done` → `In Dev` (merge confirmed; also auto-pulls integration + writes planning SUMMARY); `pk promote main --finish` → `Done` (after promote PR merges — two-phase, not optimistic).
 
 ### Three-Tier (dev → beta → main)
 
@@ -210,7 +210,7 @@ PR is reviewed, approved, and merged (rebase or merge-commit per § Merge Strate
 ```
 pk done <ID> [--merge] # verify merge, cleanup worktree+branch, post commits to Linear,
                        # transition UAT → In <FirstEnv>, auto-pull integration (v2.6.0+),
-                       # write VBW SUMMARY + flip PLAN status (v2.6.0+; skipped if no VBW)
+                       # write planning SUMMARY + flip PLAN status (v2.6.0+; skipped if no planning layer)
 ```
 
 ### Step 6: Promote to Production (two-phase as of v2.6.0)

--- a/sop/Linear_SOP.md
+++ b/sop/Linear_SOP.md
@@ -92,7 +92,7 @@ Every status maps to a pipeline position. An issue's status tells you whose turn
 | **Specced** | unstarted | You | Steps 2-3 | Light spec applied, agent reviewed. Awaiting your sign-off. **Config-driven (v2.7.0+):** this is the default `Spec ready state`, but the state `/light-spec` publishes to and `pk spec-cycle` requires is whatever `method.config.md` § `Spec ready state` names. Two-state boards with no `Specced` state set it to `Needs Spec`. |
 | **Approved** | unstarted | VBW (queued) | Post Step 3 | Human approved. Ready for VBW when a phase batch is complete. |
 | **In Progress** | started | You | Ad-hoc | Manual work outside the phase: hotfixes, quick bug fixes, chores. Not VBW-managed. |
-| **Building** | started | VBW | Steps 4-7 | VBW planning + execution + QA. Current-phase execution queue only. |
+| **Building** | started | VBW + `/work` | Steps 4-7 | VBW planning; native `/work` execution + `/verify` QA. Current-phase execution queue only. |
 | **UAT** | started | You | Step 8a | PR open on preview branch (pre-merge — v2.6.0+ opens as Draft; `pk ready` flips to Ready to fire outside reviewers). Code review + preview-URL acceptance testing happens here. **v2.4.3+**: `pk promote` (Phase 1) refuses if any bundled issue is still in UAT (PR not merged) — pass `--confirmed` to bypass after env-UAT signoff. |
 | **In `<FirstEnv>`** (e.g. `In Dev`) | started | You | Step 8b | Code merged to first deploy env. Interactive UAT in progress, or signed-off-awaiting-promote. Set by `pk done` after merge confirmation. |
 | **In `<Env>`** (e.g. `In Beta`) | started | You | Step 8c+ | Code promoted to a non-final env. One state per non-final env in `Ship environments`. **v2.6.0+**: set by `pk promote <env> --finish` (Phase 2, after the promote PR merges) — replaces the pre-v2.6.0 optimistic-at-PR-open transition. |
@@ -112,7 +112,7 @@ Every status maps to a pipeline position. An issue's status tells you whose turn
 | Specced | Needs Spec | Agent or human sends back for revision | You |
 | Specced | Approved | You approve scope, decisions, priority | You |
 | Approved | Building | Phase batch is ready for execution | You (or VBW pickup) |
-| Building | UAT | VBW QA passes + `pk ship` | VBW QA agent + you |
+| Building | UAT | `/verify` QA passes + `pk ship` | `/verify` QA + you |
 | UAT | In `<FirstEnv>` | `pk done` after PR merge (or `pk done --merge`) | You + `pk done` |
 | UAT | Done | `pk done` on 1-tier project (first env IS final env) | You + `pk done` |
 | In `<Env>` | In `<NextEnv>` | `pk promote <NextEnv>` opens PR (no state change); `pk promote <NextEnv> --finish` after merge transitions (v2.6.0+) | You + `pk promote` |
@@ -133,7 +133,7 @@ Every status maps to a pipeline position. An issue's status tells you whose turn
 
 `[In <Env> →]*` is one state per non-final env in `Ship environments`. 3-tier (`dev,beta,main`): `In Dev → In Beta → Done`. 2-tier (`dev,main`): `In Dev → Done`. 1-tier (`main`): `UAT → Done` (no intermediate `In <Env>`).
 
-**Building** = VBW owns it. Phase-batched, trigger rules apply. Never put ad-hoc work here.
+**Building** = phase-managed (VBW plans the batch; `/work` executes). Phase-batched, trigger rules apply. Never put ad-hoc work here.
 **In Progress** = You're doing it by hand, outside the phase. VBW ignores these.
 
 ### Phase Management

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -48,7 +48,7 @@ Promotion mechanism: `pk ship` (feature → integration branch from `method.conf
 
 ## Pipeline
 
-This project uses **Pipekit** (a portable AI-delivery methodology) wrapping **VBW** (planning and execution engine) with **Linear** (review and tracking layer).
+This project uses **Pipekit** (a portable AI-delivery methodology) with **VBW** for the planning-layer scaffold and **Linear** for review and tracking. Execution is native-on-Workflow (the sole executor as of v4.0.0).
 
 The full pipeline is documented in `method/method.md`; the one-page operational view is in `method/RUNBOOK.md`. Core loop:
 

--- a/templates/tier-heavy.md
+++ b/templates/tier-heavy.md
@@ -28,7 +28,7 @@ Heavy = Standard + the additions below. Every Standard gate is also required.
 
 ## Routing
 
-Heavy tier always routes through full VBW planning, regardless of complexity rating. Batch runner is disallowed — every Heavy issue gets a `PLAN.md` and explicit plan review.
+Heavy tier always requires a full plan and explicit plan review, regardless of complexity rating. Batch runner is disallowed — every Heavy issue gets a `PLAN.md` and a `/review-plan` pass before native execution.
 
 ## Required artifacts
 

--- a/templates/tier-standard.md
+++ b/templates/tier-standard.md
@@ -16,9 +16,9 @@
 | Human approval | ✅ required |
 | Dependency check | ✅ required |
 | Milestone-readiness (siblings specced) | ✅ required |
-| VBW plan | ✅ required (Medium/High complexity) |
+| Plan | ✅ required (Medium/High complexity) |
 | Plan review (`/review-plan`) | ✅ required (Medium/High complexity) |
-| Execution | ✅ VBW Dev (Medium/High) or batch runner (Low) |
+| Execution | ✅ native `/work` (Medium/High) or batch runner (Low) |
 | QA agent | ✅ required |
 | Strategy sync | recommended (post-ship, batched) |
 
@@ -29,13 +29,13 @@ Inside Standard, complexity still routes execution:
 | Complexity | Route |
 |------------|-------|
 | Low (~2–4h) | `/linear-todo-runner`, AC-as-plan |
-| Medium (~6–10h) | VBW Lead → plan review → Dev → QA |
-| High (~12–20h+) | VBW Lead → plan review → Dev → QA, likely multi-task |
+| Medium (~6–10h) | `/work` plan → plan review → native execute → QA |
+| High (~12–20h+) | `/work` plan → plan review → native execute → QA, likely multi-task |
 
 ## Required artifacts
 
 - Light spec in Linear (`## Light Spec`, `## Acceptance Criteria`)
-- `PLAN.md` in `.vbw-planning/phases/<slug>/` (Medium/High)
+- `PLAN.md` — `/work` materializes it at `.pk-work/<ID>-PLAN.md` (Medium/High)
 - Plan-review report (Medium/High)
 - QA verification report
 


### PR DESCRIPTION
## Summary

Follow-up to **v4.0.0-rc1** (which removed the VBW *executor*). rc1 left two problems: (1) **executor-stale references** that still routed users to the removed `vbw` backend/agents, and (2) cosmetic **"VBW" branding** that no longer matches reality. This release fixes the wrong-routing bugs and debrands prose where the name isn't load-bearing.

**Scope decision:** de-stale + debrand. The **planning layer is untouched** — `.vbw-planning/`, `/vbw:init`, `/roadmap-create`, `/phase-plan`, `/review-plan`, `pk_vbw_*`, and the vbw plugin all stay. The brand necessarily persists in the plugin-owned `.vbw-planning/` dir and `/vbw:*` commands until a separate planning-layer retirement (a future major version, not this rc).

## Executor-stale bug fixes (were misrouting users)

- `skills/verify/skill.md` — QA + adversarial subagents use `general-purpose` directly (dropped `Backend`-keyed `vbw:vbw-qa` selection).
- `skills/pk-bug/skill.md` — dropped `Backend (vbw or native)` read and the `vbw-debugger` suggestion.
- `skills/review-plan/skill.md` — reframed native-first; all 14 `/vbw:vibe --plan/--execute` refs now point at `/work` + `.pk-work/<ID>-PLAN.md`.
- `templates/tier-standard.md`, `templates/tier-heavy.md` — execution rows say native `/work`.
- `sop/Linear_SOP.md` — `Building` state attributes execution + QA to `/work` + `/verify`, not "VBW execution / VBW QA agent".
- `method.md` — "VBW agents read/execute" → "the executor".

## Debrand (cosmetic)

- "VBW SUMMARY" → "planning SUMMARY" (`GUIDE.md`, `sop/Git_and_Deployment.md`); `01-light-spec` "VBW-ingestible" → "plan-ready"; `CLAUDE.md.template` dropped the stale "execution engine" claim.

## Deliberately not touched

- `## VBW Integration` / `Step 0.5: VBW Init` headings (named after the real `/vbw:init` command, TOC-anchored) and `VBW_COMMANDS.md` / `sop/VBW_Help.md` — real planning-command references. Removing "VBW" there needs the deferred planning-layer retirement.

## Release mechanics

- `PK_VERSION` → `4.0.0-rc2`; `method.md`/`RUNBOOK.md`/`GUIDE.md` stamps bumped; RUNBOOK sync example → `v4.0.0-rc2`; CHANGELOG entry added.
- `tests/pk-smoke.sh`: **23/23 passing**.

> Note: this branch also carries one prior commit (`docs(loop): mark /pk-exit per-session`) that was committed to local `main` but not yet pushed to origin — it rides along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)