### PR TITLE
feat(skills): /linear-hygiene placement janitor + pk-exit hygiene check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ---
 
+## Unreleased
+
+- **New skill `/linear-hygiene`** — a fast, frequent Linear *placement* janitor. Scans all open states for issues that drift in during the daily loop (🏚️ orphaned / no project, 🔶 stuck in Triage, ⚪ unprioritized) and batch-homes them: parent-project inference → keyword match → human pick for ambiguous; importance-aware priority floors (never lowers an existing priority); Triage → Backlog / Needs-Spec mirroring `/brainstorm-review`'s tier routing. Propose-then-apply (one manifest, single `go`). Modes: `default` and `--check` (read-only). Placement only — "where does it belong?", distinct from `/brainstorm-review` (disposition: Now/Later/Kill) and `/roadmap-review` (plan-vs-requirements audit). Built against the `mcp__linear-server__{list_issues,get_issue,save_issue,list_projects}` house convention; payload-safe (minimal fields board-wide, bodies only for the drift subset). VBW-free (does not read `.vbw-planning/`).
+- **`/pk-exit` hygiene check** — new non-mutating step runs `/linear-hygiene --check` at session close and surfaces drift under "Outstanding / next session" while context is warm. Degrades silently if the skill/Linear MCP is unavailable; preserves pk-exit's no-Linear-writes guarantee (no hook, manual model unchanged).
+- **Deferred to a `/linear-hygiene` v2:** 🔗 isolated→relation linking and 🧹 stale-label stripping (both need a `mcp__linear-server__` relation / label-remove tool that no current skill references — verify on the live server first), and a `--session` mode (only this session's follow-ups). Also flagged for live verification: a SiteLine note claimed the Linear MCP exposes camelCase tool names; if true that's a repo-wide migration, not a per-skill concern.
+
+---
+
 ## v4.0.0-rc2 — 2026-06-16
 
 > **De-stale + debrand follow-up to rc1.** rc1 removed the VBW *executor* but left stale references that still routed users to it, plus cosmetic "VBW" branding that no longer matches reality. This pass fixes the wrong-routing bugs and debrands prose where the name isn't load-bearing. **No behavior change to the planning layer** — `.vbw-planning/`, `/vbw:init`, `/roadmap-create`, `/phase-plan`, `/review-plan`, `pk_vbw_*`, and the vbw plugin are all untouched. The brand necessarily persists in the plugin-owned `.vbw-planning/` directory and the `/vbw:*` commands until a separate planning-layer retirement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ The executor doesn't call skills — it reads the consuming project's CLAUDE.md 
 | `/pr-security-review` | Security-focused antagonistic PR review for migrations, RLS, SECURITY DEFINER, GRANT/REVOKE, auth, and Server Actions on privileged tables. |
 | `/pk-bug` | Bug pipeline — intake, reproduce, regression-test-first, fix, ship, postmortem. Wraps `/work` and `pk ship` with discipline gates. |
 | `/pk-express` | Idea→Draft-PR autopilot for **simple** WITs — chains `/brainstorm` → `/light-spec` (auto-cycle to Approved) → `pk branch` → `/work` (auto verify+ship), stopping only at attention gates (not-Now, tier:heavy, spec stalemate, verify flags, Draft PR). Quick/Standard tier only. |
+| `/linear-hygiene` | Fast Linear placement janitor — batch-homes orphaned / untriaged / unprioritized issues across all open states (placement, not disposition). Propose-then-apply; `--check` is read-only and is what `/pk-exit` calls. |
 | `/pipekit-help` | Reads project state, recommends the next pipeline step. |
 | `/strategy-sync` | Updates Strategy docs post-ship to match what was actually built. |
 | `/release-changelog` | Generates draft CHANGELOG entry from git commits between tags. |

--- a/skills/linear-hygiene/skill.md
+++ b/skills/linear-hygiene/skill.md
@@ -1,0 +1,121 @@
+---
+name: linear-hygiene
+description: Fast Linear placement janitor — finds orphaned / untriaged / unprioritized issues across all open states and batch-homes them. Use after pk done, before a phase, or whenever follow-ups have piled up. Propose-then-apply, importance-aware. Placement only (where does it belong?), not disposition (is it worth doing? — that's /brainstorm-review).
+---
+
+# Linear Hygiene Skill
+
+You are a Linear placement janitor. During the daily loop, `/work`, `/verify`, `pk ship`, `/pk-express`, and `/brainstorm` spin off follow-up issues mid-flow. They reliably land **orphaned** (no project), **stuck in Triage**, and **unprioritized** (priority 0), then accumulate until someone does a big manual reorg. This skill is the fast, frequent, all-states sweep that homes them before they pile up.
+
+It answers **"where does it belong?"** (placement), not **"is it worth doing?"** (disposition — that's `/brainstorm-review`) and not **"does the plan cover the requirements?"** (audit — that's `/roadmap-review`).
+
+**Run from the parent project root**, not from inside a `pk branch` worktree.
+
+## Triggers
+
+- `/linear-hygiene` · "tidy linear" · "sweep orphans" · "clean up the board"
+
+## Modes
+
+- **default** — propose + apply (Phases 1–6).
+- **`--check`** — detect-only. Run Phases 1–4, print the manifest, **make zero writes**. This is what `/pk-exit` calls; it honors the same no-Linear-writes rule.
+
+## Tooling notes (read before building against this)
+
+- Uses the pipekit house convention `mcp__linear-server__{list_issues, get_issue, save_issue, list_projects}` — the same tools every other Linear-using skill calls. **One `save_issue` carries `projectId` + `priority` + `stateId` together** (verify this on first live run in a consuming project; mirror how `/linear` and `/brainstorm-review` call `save_issue`).
+- **UNVERIFIED — flag, do not act on blindly:** a 2026-06-19 SiteLine note claimed the live Linear MCP exposes camelCase methods (`linear_searchIssues`, `linear_updateIssue`, …). Those names appear in **no** pipekit skill. If a consuming project's `mcp__linear-server__` genuinely uses camelCase, that is a **repo-wide** problem (all ~18 Linear skills would be stale) and needs its own migration — not a per-skill workaround here. Default to the snake_case house names; only revisit if a live call actually fails.
+
+## Execution Steps
+
+### Phase 1 — Fetch (payload-safe)
+
+1. Read `method.config.md` → Team ID, Workflow State IDs, and the project's **open-state set** (everything except Done / Canceled / Duplicate — typically `Triage, Backlog, Needs Spec, Approved, In Progress, In Dev, UAT`).
+2. `mcp__linear-server__list_issues` across those open states, requesting a **minimal field set** (`identifier, title, state, priority, project, labels, createdAt`). Do **not** pull descriptions board-wide.
+   > **Payload watch-out (learned the hard way):** a board-wide `list_issues` with full descriptions can exceed a single context (~158K chars on a ~48-issue board). Page by state or have a subagent digest a saved tool-result if the board is large. Only fetch bodies for the drift subset (Phase 2).
+3. `mcp__linear-server__list_projects` once → cache `{name, description, id}` for inference.
+4. **Exclude** any issue carrying the `Parked` *label* (already dispositioned "Later" by `/brainstorm-review`).
+
+### Phase 2 — Classify (an issue can hit several)
+
+- 🏚️ **Orphan** — `project == null`.
+- 🔶 **Stuck in Triage** — `state == Triage`.
+- ⚪ **Unprioritized** — `priority == 0`.
+
+Pull `mcp__linear-server__get_issue` (with `includeRelations: true`) **only for the drift subset** — the issues that hit at least one class above — to read the body (for parent-project inference) and relations.
+
+### Phase 3 — Infer the fix per issue
+
+- **Project (for orphans):**
+  1. If the body names a parent issue (`follow-up to/from POC-N`, `Source: POC-N`, `Related: POC-N`, `Split from POC-N`) → `get_issue(parent)` → use the **parent's project** (highest-confidence signal).
+  2. Else keyword-match title/body against the cached project **names + descriptions** (derive candidates dynamically — never hardcode a keyword→project map; that's what keeps it portable).
+  3. If still ambiguous → leave unhomed; present the **top-2 candidates** for a human pick in the manifest.
+- **Priority (importance ranking — the load-bearing part).** Map these label *roles* to your project's actual label names (defaults shown; override in `method.config.md` if your labels differ). Linear priority ints: Urgent 1, High 2, Normal 3, Low 4.
+
+  | Signal on the issue | Floor |
+  |---|---|
+  | `Client Request` label | **High (2)** |
+  | `Bug` + `Client Request` | **High (2)** |
+  | declares it **blocks** another open issue | inherit the blocked issue's priority, min **Normal (3)** |
+  | `Bug` (alone) | **Normal (3)** |
+  | `Feature` / `Improvement`, no urgency signal | **Low (4)** |
+  | none of the above | **Normal (3)** |
+
+  **Never lower an existing non-zero priority** — only fill `0`, or raise per a signal above.
+- **State (for Triage):** → `Backlog` by default; → `Needs Spec` if the issue is `tier:standard` / `tier:heavy` and has no spec (mirrors `/brainstorm-review` Phase 4 tier routing).
+
+### Phase 4 — Manifest (single confirm)
+
+Print ONE table, **sorted by inferred priority descending** so important follow-ups sit on top:
+
+```
+## /linear-hygiene — {N} issues drifting
+
+| Issue | Drift | → Project | → Priority | → State | Title |
+|-------|-------|-----------|-----------|---------|-------|
+| POC-232 | 🏚️🔶 | Export Improvements | Normal | Backlog | Compare removed-block… |
+| ...
+
+⚠️ Needs your pick: POC-NNN → [Export Improvements | Client Portal]
+Say "go" to apply all, or redirect any line.
+```
+
+**In `--check` mode, stop here** — print the manifest (or "✓ board is tidy — no drift") and make no writes.
+
+### Phase 5 — Apply (on `go`, default mode only)
+
+- One `mcp__linear-server__save_issue` per issue combining `projectId` + `priority` + `stateId`.
+- Batch independent calls in parallel.
+- Skip any line the user redirected to a manual pick that they didn't resolve.
+
+### Phase 6 — Summary
+
+```
+## /linear-hygiene complete
+
+Homed: {N} orphans → projects
+Prioritized: {N} (filled priority 0 / raised per signal)
+Un-triaged: {N} (Triage → Backlog / Needs Spec)
+Left for your pick: {N} (ambiguous project)
+```
+
+Suggest `/brainstorm-review` for items that need a Now/Later/Kill **verdict** — placement ≠ disposition.
+
+## Drifts to Avoid
+
+- **Don't touch `Parked`-labelled issues** — they're already dispositioned "Later."
+- **Don't lower an existing priority** — only fill `0` or raise per a signal.
+- **Don't guess a project when confidence is low** — surface the top-2 candidates instead.
+- **Don't pull full board descriptions into context** — minimal fields board-wide, bodies only for the drift subset (Phase 1/2).
+- **Don't write in `--check` mode** — it's read-only by contract (`/pk-exit` depends on this).
+
+## Deferred to v2 (not in this version)
+
+- 🔗 **Isolated → relation linking** (body references a parent but no `blocked-by`/`relates` relation exists). Needs a `mcp__linear-server__` issue-relation tool, which **no current skill references** — verify it exists on the live server before building.
+- 🧹 **Strip stale labels.** Needs a label-remove tool — same verification gap.
+- **`--session` mode** — limit to issues `createdAt >= session start`, to catch only the current session's follow-ups.
+
+## Related
+
+- `/brainstorm-review` — Now/Later/Kill **disposition** (Triage/Ideas only); this skill is placement across all open states.
+- `/roadmap-review` — full-board plan-vs-requirements audit (heavyweight; legacy, VBW-coupled).
+- `/pk-exit` — calls `/linear-hygiene --check` to surface drift while context is warm at session close.

--- a/skills/pk-exit/skill.md
+++ b/skills/pk-exit/skill.md
@@ -26,7 +26,9 @@ If you forget, you forget — no auto-trigger. The user accepted that tradeoff f
 
 2. **Write the narrative.** Use the template below. Fill from session memory + git state. Never fabricate — if a section has nothing to say, write "—" or omit it.
 
-3. **Confirm to the user** with the absolute path. Tell them to type `/exit` next.
+3. **Hygiene check (non-mutating).** Run `/linear-hygiene --check`. If it reports drift (orphaned / untriaged / unprioritized follow-ups), record them under "Outstanding / next session" in the log and tell the user: *"N follow-ups are drifting — run `/linear-hygiene` to home them."* **Detect only — never mutate Linear from `/pk-exit`** (same no-writes rule as the rest of this skill). If `/linear-hygiene` isn't installed, or the Linear MCP is unavailable/unauthed, **skip this step silently** — it must never block or error the session close.
+
+4. **Confirm to the user** with the absolute path. Tell them to type `/exit` next.
 
 ## Template
 
@@ -58,6 +60,7 @@ If the session was pure execution with no decisions, write "—".>
 ## Outstanding / next session
 
 <Bulleted list of what's left. Loose ends, deferred work, follow-ups. Be specific (issue IDs, file paths) so future-you can pick up cold.>
+- Board hygiene: <N orphaned/untriaged follow-ups from /linear-hygiene --check, or "—">
 
 ## QA / verification trail
 

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -37,6 +37,7 @@ These skills work across any project that follows the method. They read `method.
 | `/roadmap-review` | Pre-pipeline health check (Stage 0 gate) | Stage 0 → Stage 1 gate |
 | `/brainstorm` | Feature-level feasibility exploration | Stage 1: Spec |
 | `/brainstorm-review` | Triage untriaged Linear issues | Stage 1: Spec |
+| `/linear-hygiene` | Fast placement janitor — homes orphaned / untriaged / unprioritized issues across all open states (placement, not disposition). Propose-then-apply; `--check` is read-only. | Anytime (board maintenance) |
 | `/light-spec` | Structured spec generation with auto-cycled agent review (Phase 6 invokes `pk spec-cycle` + `/light-spec-revise` internally, max 3 passes). v2.7.0+: publishes to the configured `Spec ready state` (not a hardcoded `Specced`), so two-state boards (e.g. `Needs Spec → Approved`) work. | Stage 1: Spec |
 | `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detect stalemate loops. Usually invoked by `/light-spec` Phase 6, can also run standalone. | Stage 1: Spec |
 | `pk spec-cycle <ID>` | Trigger Spec Review Agent v5, poll Linear for verdict, transition to Approved on Pass. Bash-side helper used by `/light-spec`'s cycle — keeps polling out of Claude's context. | Stage 1: Spec |


### PR DESCRIPTION
## Summary

New skill **`/linear-hygiene`** — a fast, frequent Linear *placement* janitor for the follow-up issues that `/work`, `/verify`, `pk ship`, `/pk-express`, `/brainstorm` spin off mid-loop and that land orphaned / untriaged / unprioritized. Built from `temp/linear-tidy-handoff.md`, with corrections (see below).

Answers **"where does it belong?"** (placement) — distinct from `/brainstorm-review` (Now/Later/Kill disposition) and `/roadmap-review` (plan-vs-requirements audit).

## What's included (v1 = placement-only)

- **`skills/linear-hygiene/skill.md`** — scan all open states → classify (🏚️ orphan / 🔶 stuck-Triage / ⚪ unprioritized) → infer (parent-project → keyword-match → top-2 human pick; importance priority floors, never lowers existing; Triage→Backlog/Needs-Spec mirroring `/brainstorm-review`) → one manifest → apply on `go`. Modes: `default` + `--check` (read-only).
- **`skills/pk-exit/skill.md`** — new non-mutating step 3 runs `/linear-hygiene --check` at session close, surfaces drift while context is warm, **degrades silently** if unavailable, keeps the no-Linear-writes guarantee.
- Catalog: `sop/Skills_SOP.md`, `CLAUDE.md` skill table, `CHANGELOG.md` (Unreleased).

## Corrections to the handoff (verified against the repo)

- **Tool names:** handoff said build against camelCase (`linear_searchIssues`, `linear_updateIssue`…) and called existing skills stale. The opposite is true — all 18 Linear skills use `mcp__linear-server__{list_issues,get_issue,save_issue,list_projects}`. Built against that house convention. The camelCase claim is **unverified and, if real, repo-wide** — flagged in the skill + CHANGELOG, not acted on here.
- **No relation/label tool precedent** → 🔗 isolated-linking and 🧹 label-strip **deferred to v2** (need a tool no skill references; verify on the live server first).
- pk-exit degradation + payload-safety (minimal fields board-wide, bodies only for the drift subset) made explicit.

## Deferred to v2

Relation-linking, label-strip, `--session` mode.

## Notes

- This is a `feat` PR, not a release — no `PK_VERSION`/stamp bump; CHANGELOG entry sits under **Unreleased** to fold into the next cut.
- Can't live-test in pipekit (no `method.config.md`/Linear MCP here). First live test in SiteLine via `/pipekit-update`, watching it catch **POC-232** (the orphan that motivated this). Verify there that one `save_issue` carries project+priority+state together.
- Smoke suite: 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)