### PR TITLE
chore(release): v4.0.0-rc5 — gap #1 artifact rule (Database SOP + Migration Plan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Every doc below carries a `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(blurb)*` l
 | `VBW_COMMANDS.md` | VBW `/vbw:help` snapshot |
 | `method.config.template.md` | Project-config template |
 | `sop/Code_Quality.md` | SOP — coding conventions |
+| `sop/Database_SOP.md` | SOP — schema-change artifact rule, Migration Plan contract |
 | `sop/Git_and_Deployment.md` | SOP — branches, merges, release flow |
 | `sop/Hooks_SOP.md` | SOP — Claude Code hooks |
 | `sop/Linear_SOP.md` | SOP — Linear model, states, labels |
@@ -42,6 +43,18 @@ Every doc below carries a `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(blurb)*` l
 Format (copy verbatim): `**vX.Y.Z** — Last updated: YYYY-MM-DD  *(one-line release blurb)*`. The three constitutional docs additionally carry an `HH:MM` suffix on the date to disambiguate same-day patch releases (e.g., `2026-05-13 21:04`).
 
 Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` header stamps because release PRs edited prose at specific line numbers without touching the "Last updated" line. The header tells humans and AI sessions which version the doc describes — when it lies, every reader after that ships against the wrong contract.
+
+---
+
+## v4.0.0-rc5 — 2026-06-20
+
+> **gap #1 artifact rule — schema changes land as migration files.** Closes the last open piece of the highest-priority production-readiness gap. The *immutability* rule (once a migration is applied anywhere, the file is frozen) shipped earlier as `.claude/rules/pipekit-migrations.md`. This release adds the *artifact* rule upstream of it: every schema change is born as a tracked, reversible migration — never an ad-hoc `ALTER` or a hand-edited schema dump — and schema-touching specs must plan that migration before they reach planning. **The AI still does all the database work; only the artifact is constrained.** No `bin/pk` change; docs/SOP/skill/template only.
+
+- **New `sop/Database_SOP.md`** — the schema-change methodology. The One Rule (every schema change = a migration file), an explicit "the AI still does all the work" clause (the rule changes the artifact, not the workload), the six-field **Migration Plan** spec contract, a per-tool interface table (Supabase / Prisma / Drizzle / Knex / Alembic / Rails), and the three enforcement points (spec / verify / review). References `pipekit-migrations.md` for immutability and `pipekit-security.md` for the default-deny authorization rule — no duplication of the frozen-file invariant.
+- **`/light-spec` Phase 3.7 — Migration Plan gate.** On a schema-touching spec, the new `### Migration Plan` template section is mandatory and must answer six questions (schema objects; migration tool + dir from `method.config.md § Migration dir`; forward intent; rollback intent; data backfill; authorization). Non-schema specs delete the section — it's conditional, so non-DB work is unaffected. Catching it here saves a Spec Review round-trip.
+- **Spec Review Agent § Migration Rule (Critical)** (`templates/spec_review_skill.md`, bumped to v5.3) — mirrors the existing Authority Rule. A schema-touching spec with no concrete Migration Plan is a **Blocking** issue; so is an empty rollback intent (no reasoned undo, not explicitly "irreversible") or a new table/column with no stated RLS policy / GRANT.
+- **`templates/light_spec_template.md`** gains the conditional `### Migration Plan` section under Technical Context.
+- **Migration:** none for the API. Consumers re-sync (`./scripts/sync-method.sh v4.0.0-rc5`) to pick up the new SOP, template section, light-spec phase, and reviewer rule. Deferred (explicitly out of scope, per the gap's tiering): the Tier 2 drift-detection script and Tier 3 CI template.
 
 ---
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**v4.0.0-rc4** — Last updated: 2026-06-20 08:04  *(pk ship gate + pk promote hardening: (1) `pk ship` matches a `verify-complete.md` whose `sha:` == HEAD under any date dir instead of re-deriving tier + today's date (both caused false aborts); `/verify` writes the sentinel on PASS for every tier, quick included. (2) `pk promote` with no arg auto-picks the next ready hop on a 3+ env chain (never skips ahead). rc3: Linear MCP tool-name migration to `@tacticlaunch/mcp-linear` camelCase `linear_*` across all 19 interactive Linear skills. Carries rc2 de-stale+debrand, rc1 executor removal.)*
+**v4.0.0-rc5** — Last updated: 2026-06-20 09:25  *(gap #1 artifact rule: new `sop/Database_SOP.md` — every schema change lands as a tracked, reversible migration file (the AI still does all the DDL; only the artifact is constrained). `/light-spec` Phase 3.7 requires a six-field Migration Plan (schema objects, tool+dir, forward/rollback intent, backfill, authorization) on any schema-touching spec; the Spec Review Agent (§ Migration Rule) blocks one that lacks it. Companion to the immutability rule in `pipekit-migrations.md` (frozen-file). Carries rc1–rc4: executor removal, de-stale+debrand, Linear MCP migration, pk ship gate + pk promote hardening.)*
 
 ---
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v4.0.0-rc4** — Last updated: 2026-06-20 08:04  *(pk ship gate + pk promote hardening: (1) `pk ship` now matches a `verify-complete.md` whose `sha:` == HEAD under any date dir instead of re-deriving tier + today's date (both caused false aborts); `/verify` writes the sentinel on PASS for every tier, quick included. (2) `pk promote` with no arg auto-picks the next ready hop on a 3+ env chain (never skips ahead). rc3: Linear MCP tool-name migration — all 19 interactive Linear skills call `@tacticlaunch/mcp-linear` camelCase `linear_*` tools. Carries rc2 de-stale+debrand, rc1 executor removal.)*
+**v4.0.0-rc5** — Last updated: 2026-06-20 09:25  *(gap #1 artifact rule: new `sop/Database_SOP.md` — schema changes land as tracked, reversible migration files (AI does the DDL; only the artifact is constrained). `/light-spec` Phase 3.7 requires a six-field Migration Plan on schema-touching specs; the Spec Review Agent blocks one without it. Companion to the immutability rule in `pipekit-migrations.md`. Carries rc1–rc4.)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -11,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v4.0.0-rc4             (or latest tag)
+1. ./scripts/sync-method.sh v4.0.0-rc5             (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)

--- a/bin/pk
+++ b/bin/pk
@@ -30,7 +30,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="4.0.0-rc4"
+PK_VERSION="4.0.0-rc5"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null

--- a/method.md
+++ b/method.md
@@ -1,6 +1,6 @@
 # Pipekit
 
-**v4.0.0-rc4** — Last updated: 2026-06-20 08:04  *(**pk ship gate + pk promote hardening.** (1) The `pk ship` verify gate now matches a `verify-complete.md` whose `sha:` == HEAD under **any** date dir, instead of re-deriving tier (Linear flake → `standard` default) and recomputing today's date — both caused false aborts; `/verify` now writes the sentinel on PASS for **every** tier, quick included. (2) `pk promote` with no arg on a 3+ env chain **auto-picks the next ready hop** (earliest pair where the source branch is ahead of the target) instead of refusing; never skips ahead. rc3: Linear MCP tool-name migration — all 19 interactive Linear skills call `@tacticlaunch/mcp-linear` camelCase tools (`linear_*`); the old snake_case house names matched no installed server. **Carries** rc2's de-stale+debrand and rc1's executor removal; the VBW planning layer is untouched.)*
+**v4.0.0-rc5** — Last updated: 2026-06-20 09:25  *(**gap #1 artifact rule — schema changes as migration files.** New `sop/Database_SOP.md` defines the *artifact* rule: every schema change lands as a tracked, reversible migration (never an ad-hoc `ALTER` or hand-edited dump); the AI still does all the DDL work, only the artifact is constrained. `/light-spec` (Phase 3.7) now requires a six-field **Migration Plan** (schema objects, tool+dir, forward/rollback intent, backfill, authorization) on any schema-touching spec, and the Spec Review Agent (§ Migration Rule) blocks one that lacks it. Companion to the *immutability* rule in `.claude/rules/pipekit-migrations.md` (frozen-file). Carries rc1–rc4: executor removal, de-stale+debrand, Linear MCP migration, pk ship gate + pk promote hardening.)*
 
 > **v2.4.3.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >
@@ -511,6 +511,7 @@ Detailed standard operating procedures for each discipline:
 |-----|--------|
 | [Git & Deployment](sop/Git_and_Deployment.md) | Branch strategy, worktrees, release flow |
 | [Code Quality](sop/Code_Quality.md) | Pre-deploy gates, quality standards |
+| [Database](sop/Database_SOP.md) | Schema-change artifact rule, Migration Plan contract, per-tool interface |
 | [Linear Configuration](sop/Linear_SOP.md) | Issue tracking, labels, workflow states |
 | [Skills](sop/Skills_SOP.md) | Skill authoring, triggers, conventions |
 | [VBW Help](sop/VBW_Help.md) | VBW plugin reference |

--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -126,6 +126,17 @@ Print the derived tier in the Phase 4 spec re-presentation as a one-liner near t
 Derived tier: tier:heavy  (from "Complexity: High (~16-22h)")
 ```
 
+### Phase 3.7 — Migration Plan gate (schema-touching specs)
+
+If this spec changes the **database schema**, it is not planning-ready until it carries a **Migration Plan**. Phase 2's Explore already surfaced the involved tables — use that to decide.
+
+1. **Detect schema change.** The spec touches schema if it adds/alters tables, columns, types, constraints, indexes, RLS policies, functions, or triggers. Signals: the `Database:` line names a new/changed table; Requirements or AC imply persisted state that doesn't exist yet; Phase 2 found "new tables needed."
+2. **If no schema change:** delete the `### Migration Plan` section from the spec. Done — skip to Phase 4.
+3. **If schema changes:** the `### Migration Plan` section is **mandatory**. Fill all six fields (schema objects, migration tool + dir from `method.config.md § Migration dir`, forward intent, rollback intent, data backfill, authorization). The change MUST land as a **migration file** — never an ad-hoc `ALTER` or a hand-edited schema dump. The AI still writes all the DDL; only the artifact is constrained. See `sop/Database_SOP.md`.
+4. **Validate concreteness.** A Migration Plan with "TBD" on rollback or authorization that would force the planner to guess is a blocker — resolve it now or mark it in Risks & Open Questions for the Phase 4 walk-through. "Irreversible — data loss on revert" is a *valid* rollback answer; an empty one is not.
+
+This is the spec-time half of gap #1's artifact rule. The Spec Review Agent (`templates/spec_review_skill.md` § Migration Rule) independently blocks a schema-touching spec that reaches review without a concrete plan, and `/verify` runs a migration-review subagent on the diff — but catching it here, before publish, saves a review round-trip.
+
 ### Phase 4 — Present and Iterate
 
 1. Show the draft spec to the user.

--- a/sop/Database_SOP.md
+++ b/sop/Database_SOP.md
@@ -1,0 +1,84 @@
+# Database SOP
+
+> For the full development pipeline, see [method.md](../method.md).
+
+**v4.0.0-rc5** — Last updated: 2026-06-20  *(new SOP — the schema-change *artifact* rule: every schema change lands as a tracked, reversible migration; schema-touching specs must carry a Migration Plan. Companion to the immutability rule in `.claude/rules/pipekit-migrations.md`.)*
+
+**Source of truth:** Your project's CLAUDE.md and `method.config.md § Migration dir` define the migration tool and directory. This SOP provides the methodology that applies regardless of tool.
+
+> **Note on stack:** Examples use Supabase (the most common Pipekit consumer DB), but the rules are tool-agnostic. Substitute your project's tool — Prisma `migrate`, Drizzle `kit`, Knex, Alembic, Rails — and the artifact rule holds: schema changes are reversible files tracked in git, applied through the tool, never hand-edited into a schema dump.
+
+---
+
+## The One Rule
+
+**Every schema change lands as a migration file.** Not a direct `ALTER TABLE` against a live DB. Not a hand-edit of a committed schema dump. Not an MCP `apply_migration` call that races the disk chain (see `pipekit-migrations.md`). The change is authored as a reversible migration, tracked in git, and applied through the project's migration tool.
+
+This is the **artifact** rule. Its sibling — once a migration is applied to *any* environment, the file is **frozen** (no rename, no edit, no delete) — is the **immutability** rule, and lives in `.claude/rules/pipekit-migrations.md`. This SOP is upstream of that: it governs how a schema change is born; the rule governs what happens to it after. Read both.
+
+### The AI still does all the work
+
+The point of this rule is **not** "the AI stays away from the schema." Pipekit consumers explicitly want the AI to do all database work, including writing SQL. The rule changes only the **artifact**, not the workload:
+
+- The AI designs the schema change. ✅
+- The AI writes the DDL. ✅
+- The AI tests it against a local/branch DB. ✅
+- The artifact it produces is a **migration file**, not a live `ALTER` or a schema-dump edit. ✅
+
+If a session catches itself thinking *"I'll just run this one `ALTER` against dev to test the idea, then write the migration"* — that's the exact path that produces invisible schema drift (the history table has no record of the ad-hoc change). Author the migration first; apply it through the tool. The "test it live first" instinct is covered by the **MCP-applied migrations and disk drift** section of `pipekit-migrations.md` — the sanctioned way to preview a migration against a live env is `supabase db push` against a per-PR branch DB or a local reset, which uses the disk filename verbatim.
+
+---
+
+## The Migration Plan (spec contract)
+
+A spec that touches schema is not planning-ready until it carries a **Migration Plan**. This is the artifact rule's enforcement point: the plan is where the spec commits to *which* migration(s) will be authored, so the planner and executor never have to guess whether a schema change is in scope or how it's reverted.
+
+A Migration Plan must answer six questions. Anything unanswerable at spec time is a `[TBD]` that **blocks planning** if it would force the planner to guess a task boundary.
+
+| # | Question | Why it's load-bearing |
+|---|----------|----------------------|
+| 1 | **What schema objects change?** Tables, columns, types, constraints, indexes, RLS policies, functions, triggers. | Defines the migration's surface and the regression-watch set. |
+| 2 | **Which migration tool + dir?** Read from `method.config.md § Migration dir`. | The planner emits the migration to the right place with the right tool. |
+| 3 | **Forward DDL intent.** What the migration asserts (in outcome terms, not literal SQL — the planner owns the HOW). | Confirms the change is expressible as forward DDL, not a manual step. |
+| 4 | **Rollback intent.** How the change is undone — a reverting migration's DDL, or "irreversible, data-loss on revert" stated explicitly. | A migration with no reasoned rollback is a one-way door shipped silently. |
+| 5 | **Data backfill / migration.** Does existing data need transforming, defaulting, or backfilling? Nullable-vs-NOT-NULL, default values, sentinel rows. | The silent-failure patterns in `pipekit-migrations.md` (nullable FKs, stale DEFAULTs, auto-create triggers) live here. |
+| 6 | **Authorization impact.** New tables/columns: what RLS policy, GRANT, or access rule applies? Default is deny. | Per `pipekit-security.md` — every data-access path has auth at the point of query. A new table with no policy is a leak. |
+
+A Migration Plan is **conditional**: specs that touch no schema omit it entirely (and the Spec Review Agent does not demand it). The trigger is "does this spec change the shape of the database?" — if yes, the plan is mandatory; if no, it's absent.
+
+---
+
+## Per-tool interface
+
+The artifact rule is the same everywhere; the command surface differs. Read `method.config.md § Migration dir` and the project's lockfile to identify the tool, then:
+
+| Tool | Create | Apply (local/branch) | Never do |
+|------|--------|----------------------|----------|
+| **Supabase** | `supabase migration new <name>` | `supabase db push` (branch DB) / `supabase db reset` (local) | `mcp.apply_migration` for code that also lives on disk; ad-hoc SQL editor DDL on a shared env |
+| **Prisma** | `prisma migrate dev --name <name>` | `prisma migrate dev` (local) / `migrate deploy` (CI) | `prisma db push` to prod (skips the migration history) |
+| **Drizzle** | `drizzle-kit generate` | `drizzle-kit migrate` | hand-editing `schema.ts` and calling `push` against prod with no generated migration |
+| **Knex / Alembic / Rails** | `knex migrate:make` / `alembic revision` / `rails g migration` | the tool's `migrate` / `upgrade` | editing an applied migration in place |
+
+In all cases: the **migration file is the artifact that ships in the PR**. Applying it to a live env happens through the tool (locally or in CI), never by pasting DDL into a console against a shared DB.
+
+---
+
+## How this is enforced
+
+The artifact rule is enforced at three points in the pipeline, so a schema change can't slip through as an ad-hoc edit:
+
+1. **Spec time** — `/light-spec` requires the Migration Plan section on any schema-touching spec (skill Phase 3.7). The **Spec Review Agent** (`templates/spec_review_skill.md` § Migration Rule) raises a **Blocking** issue if a schema-touching spec lacks a concrete plan. A spec without it does not reach Pass.
+2. **Verify time** — `/verify` spawns a migration-review subagent when the diff touches `Migration dir`, applying the `/pr-security-review` M1–M8 rubric (+ RLS / SECURITY DEFINER / GRANT). The flag carries a **Hold/Approve verdict**, not a raw diff. A Hold pauses auto-ship.
+3. **Review time** — `/pr-security-review` is the right tool for migrations, RLS, SECURITY DEFINER, GRANT/REVOKE, and auth surface. Use it on any PR whose Migration Plan touched policies or privileged tables.
+
+The **immutability** invariant (frozen-file, hardening-during-review, parallel-branch coordination, MCP disk-drift, the three silent-failure patterns) is enforced by `.claude/rules/pipekit-migrations.md`, which auto-loads into every session. This SOP and that rule are complementary: the SOP is the *birth* of a migration (author it, plan it, apply it through the tool); the rule is its *life after apply* (it's frozen — fix forward, never edit back).
+
+---
+
+## Quick reference
+
+- **Schema change?** → migration file. Always. The AI writes it; only the artifact is constrained.
+- **Spec touches schema?** → Migration Plan section is mandatory (6 questions). No plan, no Pass.
+- **Want to test a migration live before merge?** → `supabase db push` against a branch DB or a local reset — never `mcp.apply_migration` for on-disk code, never ad-hoc SQL on a shared env.
+- **Migration already applied somewhere?** → it's frozen. Fix forward with a new migration. See `pipekit-migrations.md`.
+- **New table or column?** → it needs an explicit RLS policy / GRANT. Default deny. See `pipekit-security.md`.

--- a/templates/light_spec_template.md
+++ b/templates/light_spec_template.md
@@ -59,6 +59,16 @@
 - **Patterns to follow:** [existing patterns in the codebase to match]
 - **Authority:** [For data/calculations: where is the source of truth? DB | utils | POC | API. If multiple layers, explicitly define precedence — e.g., "DB is authoritative; utils must match DB behavior." Never leave authority ambiguous when two layers could disagree.]
 
+### Migration Plan
+[**Required only if this spec changes the database schema** (tables, columns, types, constraints, indexes, RLS policies, functions, triggers). If no schema change, delete this section. The schema change MUST land as a migration file — not an ad-hoc `ALTER` or a hand-edited schema dump. The AI still does all the DDL work; only the artifact is constrained. See `sop/Database_SOP.md`. Answer all six; a `[TBD]` that would force the planner to guess a task boundary blocks planning.]
+
+- **Schema objects:** [tables/columns/constraints/indexes/policies/functions touched]
+- **Migration tool + dir:** [from `method.config.md § Migration dir` — e.g. `supabase/migrations/`]
+- **Forward intent:** [what the migration asserts, in outcome terms — not literal SQL]
+- **Rollback intent:** [how it's undone, or "irreversible — data loss on revert" stated explicitly]
+- **Data backfill:** [existing-data transform/default/backfill needs; nullable-vs-NOT-NULL; sentinels — or "none"]
+- **Authorization:** [RLS policy / GRANT for new tables/columns; default deny — or "n/a, no new access path"]
+
 ### Risks & Open Questions
 - [risk or unknown 1 — e.g., "Unclear if RLS policy covers this case"]
 - [risk or unknown 2]

--- a/templates/spec_review_skill.md
+++ b/templates/spec_review_skill.md
@@ -1,4 +1,4 @@
-# Linear Agent Skill: Spec Review Agent (v5.2)
+# Linear Agent Skill: Spec Review Agent (v5.3)
 
 ## Context
 
@@ -92,6 +92,22 @@ It MUST define the authoritative layer:
 - POC baseline
 
 If unclear -> Blocking issue
+
+---
+
+## Migration Rule (Critical)
+
+If the spec changes the database schema (new/altered tables, columns, types, constraints, indexes, RLS policies, functions, triggers):
+
+It MUST carry a concrete **Migration Plan** — the schema change lands as a migration file, never an ad-hoc `ALTER` or a hand-edited schema dump.
+
+The plan must answer: schema objects touched, migration tool + dir, forward intent, **rollback intent**, data backfill, and **authorization** (RLS/GRANT for new access paths; default deny).
+
+- Missing Migration Plan on a schema-touching spec -> Blocking
+- Empty rollback intent (no reasoned undo, and not explicitly "irreversible") -> Blocking
+- New table/column with no stated RLS policy or GRANT -> Blocking (a data-access path with no auth is a leak)
+
+A spec that touches no schema omits the Migration Plan section entirely — do NOT demand it. See `sop/Database_SOP.md` for the artifact rule.
 
 ---
 


### PR DESCRIPTION
## v4.0.0-rc5 — gap #1 artifact rule

Closes the **last open piece** of the highest-priority production-readiness gap (gap #1, migrations). The *immutability* rule — once a migration is applied anywhere, the file is frozen — shipped earlier as `.claude/rules/pipekit-migrations.md`. This release adds the **artifact rule** upstream of it: every schema change is *born* as a tracked, reversible migration (never an ad-hoc `ALTER` or hand-edited dump), and schema-touching specs must plan that migration before they reach planning.

**The AI still does all the database work.** The rule changes only the *artifact*, not the workload. No `bin/pk` change — docs/SOP/skill/template only.

### What's in it
- **New `sop/Database_SOP.md`** — the schema-change methodology: the One Rule, the explicit "AI still does the work" clause, the six-field **Migration Plan** spec contract, a per-tool interface table (Supabase / Prisma / Drizzle / Knex / Alembic / Rails), and the three enforcement points (spec / verify / review). References `pipekit-migrations.md` (immutability) and `pipekit-security.md` (default-deny auth) — no duplication of the frozen-file invariant.
- **`/light-spec` Phase 3.7 — Migration Plan gate.** Conditional `### Migration Plan` template section, mandatory on schema-touching specs (six questions: schema objects; tool + dir; forward intent; rollback intent; backfill; authorization). Non-schema specs delete it — non-DB work is unaffected.
- **Spec Review Agent § Migration Rule (Critical)** (`templates/spec_review_skill.md` → v5.3) — mirrors the Authority Rule. Missing plan / empty rollback / new table with no RLS-or-GRANT → **Blocking**.

### Out of scope (explicitly deferred, per the gap's tiering)
- Tier 2 drift-detection script wired into the pre-deploy gate.
- Tier 3 `templates/ci/migration-drift.yml` + `sop/Migrations_SOP.md` recipes.

### Release mechanics
- `PK_VERSION` → `4.0.0-rc5`; new `## v4.0.0-rc5` CHANGELOG section.
- Constitutional stamps bumped (`method.md` / `RUNBOOK.md` / `GUIDE.md`) + RUNBOOK sync-line.
- `sop/Database_SOP.md` registered in the stamped-docs maintained list.

### Verification
- `tests/pk-smoke.sh`: **35 passed, 0 failed** (no `bin/pk` logic change).
- Template/reviewer additions are conditional — no effect on non-schema specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)