### PR TITLE
chore(release): v4.1.0 — Linear-native phase surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,32 @@ Why this list exists: v2.4.0 through v2.4.3.1 all shipped with stale `v2.3.0` he
 
 ---
 
+## v4.1.0 — 2026-06-21
+
+> **Linear-native phase surface.** The roadmap's phase order moves out of committed files and into Linear itself. An Initiative named `i{N}. label` is an ordered roadmap **phase**; a Project named `P{N}. label` is an ordered **sub-phase** that holds the issues; ordering is the integer in the name prefix, parsed numerically (`P2` before `P10`). `pk next` / `pk status` derive the current phase live; `/roadmap-create` authors the hierarchy; `/phase-plan` advances it. `.vbw-planning/PHASES.md` + `linear-map.json` are **retired** to a read-only fallback, and `/vbw:init` is dropped from the Stage 0 contract. Validated live against a production Linear workspace before shipping.
+
+**Why the name prefix, not Linear `sortOrder`:** the live probe showed `sortOrder` is an internal drag-rank that does **not** track phase sequence (it ordered one initiative's projects `P11, P8, P4, P3, P1, …`). The `i{N}.`/`P{N}.` name prefix is the only reliable order, and it doubles as the roadmap opt-in — unprefixed initiatives (strategic themes) are ignored by `pk next`. No config list of "which initiatives are phases" is needed.
+
+**`bin/pk`:**
+- New `pk_linear_initiatives_json` (one GraphQL query for initiatives + their projects) and `pk_native_phase_context` — derive `<current phase>\t<current project-id>` from the lowest non-`Completed` `i{N}.` initiative and its lowest non-`completed`/`canceled` `P{N}.` project, by numeric name prefix.
+- `pk_phase_context` dispatcher: native (Linear) wins; falls back to the legacy `.vbw-planning/` files (renamed `pk_file_current_phase_*`) so un-migrated projects keep working — no flag-day. `cmd_next` shows `Phase: X (Linear)` when native.
+- `pk status` gains a **Roadmap** section: the ordered `i{N}.` → current-`P{N}.` walk (silent until a project is migrated).
+- Issue grouping (`pk_linear_issues_in_state_project`) is reused unchanged.
+- 4 new sourced-mode smoke unit-tests guard the derivation jq (derivation, empty-input, no-prefix fallback, roadmap walk). **Suite 39/39, zero network.**
+
+**Skills:**
+- **`/roadmap-create`** rewritten to author the Linear `i{N}.`/`P{N}.` hierarchy directly (Initiatives → Projects → Issues). No `.vbw-planning/ROADMAP.md` merge dependency, no `linear-map.json`, no `/vbw:init` prerequisite. ROADMAP.md survives only as an optional human-readable narrative.
+- **`/phase-plan`** pivoted from "compose a batch into `PHASES.md`" to "derive the current phase from Linear, promote its issues to Needs Spec, and advance the pointer by flipping initiative/project state." No file writes.
+- **`/sync-linear`** reframed: reconciles strategy/requirement drift against the Linear board's `i{N}.`/`P{N}.` hierarchy; no `PHASES.md`/`linear-map.json` to sync.
+- **`/00-roadmap-review`** validates the Linear-native surface (prefix naming, ordering, issue placement, lifecycle sanity) instead of the retired files.
+- **`/startup`, `/01-light-spec`, `/review-plan`, `/pk-exit`** repointed: phase context is derived live from Linear; `/vbw:init` dropped from the Stage 0 orchestration.
+
+**Config + docs:** `method.config.template.md` gains **§ Phase Surface** — the `i{N}.`/`P{N}.` naming contract. `method.md`, `RUNBOOK.md`, `GUIDE.md` (constitutional, re-stamped `v4.1.0`), plus `CLAUDE.md`, `README.md`, `STARTUP.md`, `sop/Linear_SOP.md`, `sop/Skills_SOP.md` migrated to the Linear-native model. README flags that the phase surface needs a Linear MCP with **initiative** support (`@tacticlaunch/mcp-linear`), which the first-party `mcp.linear.app` remote lacks.
+
+**Deliberately deferred (separate, later retirement):** the broader VBW *planning layer* — `.vbw-planning/phases/*/PLAN.md`, `SUMMARY.md`, `.execution-state.json`, the `pk done` SUMMARY/PLAN lifecycle, and `/vbw:init`'s greenfield codebase analysis — is untouched. v4.1.0 migrates the **phase surface** only.
+
+---
+
 ## v4.0.0 — 2026-06-20
 
 > **Final cut of the v4.0.0 line.** Promotes `v4.0.0-rc5` to stable — no code change from rc5, only the release label, the consolidated changelog, and doc-stamp normalization (every `v4.0.0-rc*` stamp → `v4.0.0`). The five release candidates (rc1–rc5) below carry the full detail; this is the one-stop summary of what v3.2.0 → v4.0.0 delivers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**v4.0.0** — Last updated: 2026-06-20  *(**v4.0.0 — VBW executor removed.** Native-on-Workflow is now the **sole** executor; the pluggable `vbw` backend, `--backend=` selection, and the `vbw-dev`/`vbw-scout` dispatch in `/work` are gone (the `auto` router went in v3.2.0). A stale `Backend: vbw`/`auto` in `method.config.md` or a `--backend=vbw` flag now **refuses** with a migration message rather than silently routing. This makes good on the v3.2.0 deprecation promise, backed by SiteLine production evidence (0/30 recent PRs used vbw; native shipped 12/13 clean first-pass with the gate layer — not the executor — catching the one defect). **The VBW planning layer is untouched:** `.vbw-planning/`, `/vbw:init`'s roadmap scaffold, `/roadmap-create`'s phase merge, `/phase-plan`, `/review-plan`, and the `pk_vbw_*` roadmap helpers all stay — retiring the planning layer is a separate, later effort. The deep-analysis safety net remains the gate layer (`/financial-review`, `/pr-security-review`), which native runs. **Carries Pipekit 3.0–3.2:** native-on-Workflow executor; distribution-layer hardening (`bin/pk` smoke suite + CI gate, global `--help` guard, `pipekit/.local-skills` manifest, `pk doctor` upstream-staleness warning, curated-roadmap doctrine — `pk next` stays the operational truth); v2.8.0's `/financial-review` + `/security-review` substrate; and v2.7.x: `/pk-express`, `/pr-fix` pluggable engine, merge-driven Linear transition)*
+**v4.1.0** — Last updated: 2026-06-21  *(**v4.1.0 — Linear-native phase surface.** The roadmap's phase order lives in Linear: Initiatives named `i{N}.` (phases) → Projects named `P{N}.` (sub-phases) → Issues, ordered by the name-prefix number (Linear `sortOrder` is an unreliable drag-rank). `pk next`/`pk status` derive the current phase live; `/roadmap-create` authors the hierarchy and `/phase-plan` advances it; `PHASES.md`/`linear-map.json` are retired to a read-only fallback; Stage 0.5 `/vbw:init` is dropped from the contract. The `i{N}.`/`P{N}.` convention is the contract — `method.config.md § Phase Surface`. Validated live against a production Linear workspace. **The phase surface is now Linear-native; what remains of the VBW planning layer** — `.vbw-planning/` execution state, `/vbw:init`'s scaffold, `/review-plan`, and the `pk_vbw_*` PLAN/SUMMARY helpers — still stands; retiring it is a separate, later effort. **Carries v4.0.0 — VBW executor removed:** native-on-Workflow is the **sole** executor; the pluggable `vbw` backend, `--backend=` selection, and `vbw-dev`/`vbw-scout` dispatch are gone (the `auto` router went in v3.2.0); a stale `Backend: vbw`/`auto` now **refuses** with a migration message. The deep-analysis safety net remains the gate layer (`/financial-review`, `/pr-security-review`), which native runs. **Carries Pipekit 3.0–3.2:** native-on-Workflow executor; distribution-layer hardening (`bin/pk` smoke suite + CI gate, global `--help` guard, `pipekit/.local-skills` manifest, `pk doctor` upstream-staleness warning); v2.8.0's `/financial-review` + `/security-review` substrate; v2.7.x: `/pk-express`, `/pr-fix` pluggable engine, merge-driven Linear transition)*
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -18,7 +18,7 @@ Origin: extracted from the Piper production finance platform.
 
 ```
 Stage 0: Foundation (a contract — see Entry Modes)
-  /concept → /define → /strategy-create → /startup → /vbw:init → /roadmap-create → /phase-plan
+  /concept → /define → /strategy-create → /startup → /roadmap-create → /phase-plan
 
 Stages 1-5: Development — the v2 daily loop (repeats per issue)
   pk next → pk branch → /work → /verify → pk ship (Draft) → pk ready → [PR review + preview UAT] → pk done [--merge] → [dev UAT] → pk promote <env> → (PR merges) → pk promote <env> --finish
@@ -51,10 +51,10 @@ Projects pull from this repo using `sync-method.sh`. The sync copies `skills/`, 
 
 Pipekit wraps VBW — it does not replace VBW's planning layer. The boundary is explicit:
 
-- **VBW owns** `.vbw-planning/ROADMAP.md`, `PLAN.md` files, and execution state.
-- **Pipekit owns** Linear issues, `linear-map.json`, `PHASES.md`, strategy docs, and `method.config.md`. "What's next?" is read live from Linear via `pk next` (phase-aware as of v2.1.0); v2 retired the `NEXT.md` mirror file.
-- **The two merge once**, at `/roadmap-create` — Pipekit adds strategy-derived requirements into VBW's phase structure without overwriting VBW's phases, goals, or success criteria.
-- **Don't invoke VBW agents directly in Pipekit projects.** Use `/work`, not `/vbw:lead` or `/vbw:dev`. `/work` executes on the native-on-Workflow backend (the sole executor as of v4.0.0) and keeps Linear, `PHASES.md`, and the `pk *` state in sync. Direct VBW invocation bypasses Pipekit's visibility layer and causes drift.
+- **VBW (legacy) owns** `.vbw-planning/ROADMAP.md`, `PLAN.md` files, and execution state — present for direct-VBW projects, slated for a separate retirement.
+- **Pipekit owns** Linear issues, the **phase surface** (Linear Initiatives `i{N}.` → Projects `P{N}.` → Issues, v4.1.0), strategy docs, and `method.config.md`. "What's next?" is read live from Linear via `pk next` (derives the current phase from the initiative/project hierarchy); v2 retired the `NEXT.md` mirror, v4.1.0 retired `PHASES.md`/`linear-map.json` (read-only fallback only).
+- **The roadmap is authored directly into Linear**, at `/roadmap-create` — the `i{N}.`/`P{N}.` hierarchy *is* the roadmap; there is no merge into a VBW phase skeleton.
+- **Don't invoke VBW agents directly in Pipekit projects.** Use `/work`, not `/vbw:lead` or `/vbw:dev`. `/work` executes on the native-on-Workflow backend (the sole executor as of v4.0.0) and keeps Linear and the `pk *` state in sync. Direct VBW invocation bypasses Pipekit's visibility layer and causes drift.
 
 Full ownership model in `method.md` (§ VBW / Pipekit Ownership Model).
 
@@ -89,7 +89,7 @@ The executor doesn't call skills — it reads the consuming project's CLAUDE.md 
 
 | Command | Purpose |
 |---------|---------|
-| `pk next` | Phase-aware: reads `## Current Phase:` from `PHASES.md`, queries Linear, groups by status (In Progress / Approved / Needs Spec) with per-group hints. Replaces v1's `cat NEXT.md`. |
+| `pk next` | Phase-aware: derives the current phase live from the Linear-native surface (`i{N}.` initiative → `P{N}.` project, by numeric name prefix; legacy `PHASES.md`/`linear-map.json` fall back), queries Linear, groups by status (In Progress / Approved / Needs Spec) with per-group hints. Replaces v1's `cat NEXT.md`. |
 | `pk branch <ID>` | Worktree + branch + Linear → In Progress (idempotent). |
 | `/work <ID>` | Plan + execute in-session. `/work` plans inline (parallel `Agent` grounding), then materializes a task DAG to `.pk-work/<ID>-PLAN.md` and executes on the **Workflow primitive** — atomic commit per task with verify-before-integrate. Native-on-Workflow is the **sole executor** as of v4.0.0; the pluggable `vbw` backend and `--backend=` flag were removed (a stale `Backend: vbw`/`--backend=vbw` now refuses with a migration message). |
 | `/verify` | Pre-deploy gate. |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 A complete guide to using Pipekit from project inception through production delivery. This document covers every stage, every skill, and every decision point in the pipeline.
 
-**v4.0.0** — Last updated: 2026-06-20 09:50  *(Final cut — VBW executor removed; native-on-Workflow is the sole executor (the `vbw` backend, `--backend=` flag, and `vbw-dev`/`vbw-scout` dispatch are gone; a stale `Backend: vbw`/`auto` refuses with a migration message). The VBW planning layer is untouched. Folds in the rc train: Linear MCP camelCase migration to `@tacticlaunch/mcp-linear` across 19 skills (rc3); `pk ship` sha-matched verify gate + `pk promote` auto-pick-next-hop (rc4); gap #1's artifact rule — `sop/Database_SOP.md` + `/light-spec` Phase 3.7 Migration Plan gate + Spec Review Agent § Migration Rule (rc5).)*
+**v4.1.0** — Last updated: 2026-06-21 10:30  *(Linear-native phase surface — `i{N}.`/`P{N}.` naming replaces `PHASES.md`/`linear-map.json`; `/vbw:init` dropped from Stage 0; carries v4.0.0 (VBW executor removed). The roadmap's phase order now lives in Linear: an `i{N}.` Initiative is an ordered phase, a `P{N}.` Project is an ordered sub-phase that holds the issues, and `pk next`/`pk status` derive the current phase live by numeric name prefix (legacy `PHASES.md`/`linear-map.json` fall back for un-migrated projects). Carries v4.0.0: VBW executor removed — native-on-Workflow is the sole executor (the `vbw` backend, `--backend=` flag, and `vbw-dev`/`vbw-scout` dispatch are gone; a stale `Backend: vbw`/`auto` refuses with a migration message). The VBW planning-layer artifacts (`.vbw-planning/` PLAN/SUMMARY/state files) are untouched — a separate, later retirement. Folds in the rc train: Linear MCP camelCase migration to `@tacticlaunch/mcp-linear` across 19 skills (rc3); `pk ship` sha-matched verify gate + `pk promote` auto-pick-next-hop (rc4); gap #1's artifact rule — `sop/Database_SOP.md` + `/light-spec` Phase 3.7 Migration Plan gate + Spec Review Agent § Migration Rule (rc5).)*
 
 ---
 
@@ -16,9 +16,8 @@ A complete guide to using Pipekit from project inception through production deli
    - [Step 0.2: Define](#step-02-define)
    - [Step 0.3: Strategy Create](#step-03-strategy-create)
    - [Step 0.4: Infrastructure Setup](#step-04-infrastructure-setup)
-   - [Step 0.5: VBW Init](#step-05-vbw-init)
-   - [Step 0.6: Roadmap Create](#step-06-roadmap-create)
-   - [Step 0.7: Phase Plan](#step-07-phase-plan)
+   - [Step 0.5: Roadmap Create](#step-05-roadmap-create)
+   - [Step 0.6: Phase Plan](#step-06-phase-plan)
 5. [Stage 0 Gate: Roadmap Review](#stage-0-gate-roadmap-review)
 6. [Stage 1: Spec](#stage-1-spec)
    - [Light Spec](#light-spec)
@@ -78,16 +77,17 @@ When ambiguity is detected, the pipeline sends work **backward** — not forward
 STAGE 0: FOUNDATION (a contract — greenfield path shown below)
 ──────────────────────────────────────────────────────────────────────
 
-  /concept ──→ /define ──→ /strategy-create ──→ /startup ──→ /vbw:init
-      │            │               │                │            │
-  concept-     project-       Strategy/         repo, DB,    .vbw-planning/
-  brief.md    definition.md    docs           deploy, MCP     scaffold
+  /concept ──→ /define ──→ /strategy-create ──→ /startup
+      │            │               │                │
+  concept-     project-       Strategy/         repo, DB,
+  brief.md    definition.md    docs           deploy, MCP
 
       ──→ /roadmap-create ──→ /phase-plan ──→ /roadmap-review (GATE)
                 │                   │                │
-          ROADMAP.md +          PHASES.md        Stage 0
-          Linear board      (first phase in    validated ✓
-          populated         "Needs Spec")
+          Linear hierarchy      current phase    Stage 0
+          (i{N}. → P{N}. →     derived live;     validated ✓
+          Issue) authored      first sub-phase
+          in Linear            issues → "Needs Spec"
 
 
 STAGES 1-5: DEVELOPMENT PIPELINE (repeats per issue)
@@ -154,7 +154,7 @@ Pick the mode that matches your situation. Full description in [method.md § Ent
 | Mode | Who | Skills run | Skills skipped |
 |---|---|---|---|
 | **Greenfield** | Founder, fresh idea, no code yet | Full Stage 0 chain | None |
-| **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield`, `/vbw:init`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` |
+| **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` |
 | **Inherited** | New contributor joining a Pipekit project | None — verify foundation, jump to dev pipeline | All of Stage 0 |
 
 `/startup` auto-detects the mode and confirms with you before proceeding (same pattern as tier resolution in `/work`). `/strategy-from-code` (auto-audit for brownfield) is deferred — originally promised for v1.4.0 but never built; brownfield currently routes through `/strategy-create` with a manual-edit note.
@@ -336,44 +336,27 @@ This is where you set up the actual infrastructure. The `/startup` orchestrator 
 
 ---
 
-### Step 0.5: VBW Init
-
-**Skill:** `/vbw:init`
-**Input:** —
-**Output:** `.vbw-planning/` directory scaffold
-
-VBW is no longer an execution backend — native-on-Workflow is the sole executor as of v4.0.0 — but `/vbw:init` still scaffolds the `.vbw-planning/` directory Pipekit uses to track the roadmap and state. The directory is created here because the roadmap lives in it; `/work` writes its per-issue plan to `.pk-work/<ID>-PLAN.md` instead.
-
-This step is simple — run `/vbw:init` and it scaffolds:
-```
-.vbw-planning/
-├── ROADMAP.md        ← populated by /roadmap-create (next step)
-├── STATE.md          ← tracks progress
-├── linear-map.json   ← Linear ID mappings
-└── phases/           ← PLAN.md files go here during execution
-```
-
----
-
-### Step 0.6: Roadmap Create
+### Step 0.5: Roadmap Create
 
 **Skill:** `/roadmap-create`
 **Input:** Strategy docs + `project-definition.md`
-**Output:** `.vbw-planning/ROADMAP.md` + populated Linear board + `.vbw-planning/linear-map.json`
+**Output:** The Linear Initiative→Project→Issue hierarchy (`i{N}.`/`P{N}.`), populated directly in Linear
 
-This is where strategy becomes work items. The skill reads your strategy docs and project definition, extracts requirements, groups them into feature clusters, identifies dependencies, and populates both ROADMAP.md and Linear.
+This is where strategy becomes work items. The skill reads your strategy docs and project definition, extracts requirements, groups them into feature clusters, identifies dependencies, and authors the phase hierarchy **directly in Linear** — no `.vbw-planning/ROADMAP.md` merge dependency and no `linear-map.json`.
 
 **What it produces:**
 
-1. **ROADMAP.md** — requirements organized by stage, grouped into feature clusters, with dependency mapping and strategy doc traceability
-2. **Linear Issues** — one issue per requirement, with:
+1. **Linear Initiatives** named `i{N}. label` — one per roadmap phase, ordered by the numeric prefix (`i1.`, `i2.`, …). This is the phase surface `pk next`/`pk status` read live.
+2. **Linear Projects** named `P{N}. label` — ordered sub-phases (execution batches) within a phase; the issues live here.
+3. **Linear Issues** — one issue per requirement, with:
    - Correct status (On Deck for Stage 1, Future Phases for Stage 2+, Ideas for parking lot)
    - Dependency relations (`blocked_by`)
    - Type and domain labels
    - Milestone (Work Package) assignment
-3. **linear-map.json** — ID mappings between roadmap and Linear
 
-**Feature clusters become Linear Projects.** A feature cluster is a logical grouping of related requirements — "Data Foundation", "Search & CRUD", "Auth & Permissions." Each becomes a Linear Project under its stage's Initiative.
+A narrative `ROADMAP.md` may still be written as an optional legacy/handoff artifact, but it is no longer a required output or a state file the pipeline reads.
+
+**Feature clusters become `P{N}.` Linear Projects.** A feature cluster is a logical grouping of related requirements — "Data Foundation", "Search & CRUD", "Auth & Permissions." Each becomes a `P{N}.` Project (sub-phase) under its phase's `i{N}.` Initiative.
 
 **Manual vs. automated:** The skill automates issue creation, relations, and labels via MCP. For things that require the Linear UI (initiatives, workflow states), it gives explicit step-by-step instructions.
 
@@ -381,13 +364,13 @@ This is where strategy becomes work items. The skill reads your strategy docs an
 
 ---
 
-### Step 0.7: Phase Plan
+### Step 0.6: Phase Plan
 
 **Skill:** `/phase-plan`
-**Input:** Populated Linear board + `.vbw-planning/ROADMAP.md`
-**Output:** `.vbw-planning/PHASES.md` + issues promoted to "Needs Spec"
+**Input:** The populated Linear hierarchy (`i{N}.` Initiatives → `P{N}.` Projects → Issues)
+**Output:** Current phase derived live from Linear + issues in the current sub-phase promoted to "Needs Spec"
 
-A phase is a batch of issues selected for the current execution cycle. This skill selects which issues to work on next, validates dependencies, and promotes them so the spec pipeline can begin.
+A phase is a batch of issues selected for the current execution cycle. This skill selects which issues to work on next, validates dependencies, and promotes them so the spec pipeline can begin. It **derives and advances phase state via Linear initiative/project status** — there is no `PHASES.md` registry to write.
 
 **Phase composition guidelines:**
 
@@ -403,22 +386,8 @@ A phase is a batch of issues selected for the current execution cycle. This skil
 1. Selected issues move from "On Deck" → "Needs Spec"
 2. If On Deck is now empty, issues from "Future Phases" get promoted to On Deck
 3. A Linear comment is posted on each issue noting its phase assignment
-4. `.vbw-planning/PHASES.md` is created/updated with the phase registry
 
-**PHASES.md tracks phase history:**
-```markdown
-## Current Phase: Phase 1
-- Started: 2026-04-08
-- Theme: Foundation
-- Milestone(s): WP-1 Data Foundation, WP-2 Search
-- Issues:
-  - PROJ-1 — Core data model [Needs Spec]
-  - PROJ-2 — Basic search [Needs Spec]
-  - PROJ-3 — User authentication [Needs Spec]
-
-## Completed Phases
-- (none yet)
-```
+**Phase state is derived from Linear, not a file.** The current phase is the lowest-numbered `i{N}.` Initiative whose status is not `Completed`; the current sub-phase is the lowest-numbered `P{N}.` Project in it whose state is not `completed`/`canceled`. `/phase-plan` advances the phase by transitioning that initiative/project state in Linear — `pk next`/`pk status` then read the new current phase live. (Projects not yet migrated to `i{N}.`-prefixed initiatives fall back to the legacy `.vbw-planning/PHASES.md` automatically.)
 
 ---
 
@@ -430,15 +399,14 @@ Before the spec pipeline begins, `/roadmap-review` validates that Stage 0 is com
 
 **Stage 0 checks:**
 
-| Check | File | If Missing |
-|-------|------|-----------|
+| Check | Surface | If Missing |
+|-------|---------|-----------|
 | Concept brief | `concept-brief.md` | Run `/concept` |
 | Project definition | `project-definition.md` | Run `/define` |
 | Strategy docs | `Strategy/` matching config | Run `/strategy-create` |
-| VBW scaffold | `.vbw-planning/` | Run `/vbw:init` |
-| Roadmap | `.vbw-planning/ROADMAP.md` | Run `/roadmap-create` |
+| Roadmap | Linear `i{N}.` Initiatives + `P{N}.` Projects exist | Run `/roadmap-create` |
 | Linear board | Issues exist for requirements | Run `/roadmap-create` |
-| Phase defined | `.vbw-planning/PHASES.md` | Run `/phase-plan` |
+| Phase defined | A non-`Completed` `i{N}.` Initiative with a current `P{N}.` Project | Run `/phase-plan` |
 
 **Ongoing health checks** (run every phase):
 
@@ -531,7 +499,7 @@ After agent review passes, you review the spec in Linear. This is where product 
 **Input:** Approved spec
 **Output:** Worktree + feature branch + Linear → In Progress
 
-`pk next` is phase-aware (v2.1.0+): it reads `## Current Phase:` from `.vbw-planning/PHASES.md`, matches to `linear-map.json`, and groups Linear results by status (In Progress / Approved / Needs Spec) with per-group hints. Falls back to global "next Approved" when no phase context.
+`pk next` is phase-aware (v2.1.0+): it **derives the current phase live from the Linear hierarchy** — the lowest-numbered `i{N}.` Initiative that isn't `Completed`, then its lowest-numbered open `P{N}.` Project (by numeric name prefix, `P2` before `P10`; Linear's `sortOrder` is never used) — and groups that phase's Linear results by status (In Progress / Approved / Needs Spec) with per-group hints. Legacy `.vbw-planning/PHASES.md` + `linear-map.json` fall back automatically for un-migrated projects. Falls back to global "next Approved" when no phase context.
 
 `pk branch <ID>` is mechanical setup — idempotent against Linear+git ground truth. It creates the worktree, the branch, and transitions Linear:
 
@@ -798,8 +766,9 @@ Phases, milestones, and cycles serve different purposes. Understanding their rel
 
 | Concept | What It Is | Linear Construct | Lifespan |
 |---------|-----------|-----------------|----------|
-| **Milestone (Work Package)** | A feature cluster — groups related issues for gating | Linear Milestone | Permanent within a stage |
-| **Phase** | An execution batch — what we're building right now | `.vbw-planning/PHASES.md` | Temporary (one cycle) |
+| **Phase** | An ordered roadmap phase | Linear **Initiative** named `i{N}. label` | Permanent (ordered by `{N}`) |
+| **Sub-phase** | An execution batch — what we're building right now; holds the issues | Linear **Project** named `P{N}. label` | Ordered within its phase by `{N}` |
+| **Milestone (Work Package)** (optional) | A feature cluster — groups related issues for gating; orthogonal to phases | Linear Milestone | Intra-project grouping |
 | **Cycle** (optional) | A time-boxed sprint — capacity planning | Linear Cycle | Configurable duration |
 
 ### How They Relate
@@ -835,7 +804,7 @@ If you want time-boxed sprints with capacity tracking, map phases to Linear Cycl
 
 ### Phase State Tracking
 
-Phases are tracked in `.vbw-planning/PHASES.md`, not in Linear. Linear tracks individual issue status (Needs Spec, Building, UAT, In Dev, In Beta, Done — env-mapped per `Ship environments`). PHASES.md tracks which issues belong to which phase and the phase's overall progress.
+Phases are tracked **live in Linear**, not in a committed file. A phase is a `i{N}.` Initiative; its sub-phases are `P{N}.` Projects that hold the issues. The current phase is derived on demand — the lowest-numbered `i{N}.` Initiative not yet `Completed`, then its lowest-numbered open `P{N}.` Project (ordered by the numeric name prefix, never Linear's `sortOrder`). Linear also tracks individual issue status (Needs Spec, Building, UAT, In Dev, In Beta, Done — env-mapped per `Ship environments`). `pk next`/`pk status` read which issues belong to the current phase and the phase's overall progress straight from this hierarchy. (Un-migrated projects fall back to the legacy `.vbw-planning/PHASES.md` automatically.)
 
 ---
 
@@ -889,11 +858,13 @@ Linear is the view layer. The executor (`/work`, native by default) plans and bu
 ### Hierarchy
 
 ```
-Initiative = Stage              "What stage does this ship in?"
-  └── Project = Feature Cluster   "What area of the product?"
-       └── Issue = Feature/Task     "What work needs to happen?"
-            └── Milestone = Work Package  "What execution batch?"
+Initiative `i{N}. label` = Phase          "Which ordered roadmap phase?"
+  └── Project `P{N}. label` = Sub-phase      "Which ordered execution batch? (issues live here)"
+       └── Issue = Feature/Task                "What work needs to happen?"
+            └── Milestone = Work Package (opt)   "Optional feature-cluster grouping, orthogonal to phases"
 ```
+
+Ordering is the integer in the `i{N}.`/`P{N}.` name prefix, parsed numerically (`P2` before `P10`). Linear's `sortOrder` is never used. Unprefixed initiatives are strategic themes — `pk next`/`pk status` ignore them.
 
 ### Workflow States
 
@@ -944,7 +915,7 @@ Terminal:
 | Task decomposition | `.vbw-planning/` PLAN files | Linear |
 | Execution status | Both (synced via `/sync-linear`) | — |
 | Code | Git | Linear or VBW |
-| Phase composition | `.vbw-planning/PHASES.md` | Linear |
+| Phase composition | Linear `i{N}.` Initiatives + `P{N}.` Projects (derived live) | a committed file |
 
 **Never create Linear issues for VBW tasks.** Features are the bridge between Linear and VBW.
 
@@ -952,13 +923,12 @@ Terminal:
 
 ## VBW Integration (roadmap scaffold — executor removed v4.0.0)
 
-Native-on-Workflow is the sole executor — `/work` plans the issue inline and executes on Claude Code's Workflow primitive. **VBW is no longer an execution backend**: the pluggable `vbw` executor and `--backend=` flag were removed in v4.0.0 (the `auto` router in v3.2.0), and a stale `Backend: vbw`/`--backend=vbw` now refuses with a migration message. The removal is evidence-driven: 0/30 recent production PRs used vbw, and native matched-or-beat VBW-the-full-system on first-pass correctness in the POC-48 head-to-head. What VBW still provides is the **roadmap scaffold**: `/vbw:init` creates `.vbw-planning/`, and Pipekit owns the roadmap there. Everything below is about that scaffold, not an executor.
+Native-on-Workflow is the sole executor — `/work` plans the issue inline and executes on Claude Code's Workflow primitive. **VBW is no longer an execution backend**: the pluggable `vbw` executor and `--backend=` flag were removed in v4.0.0 (the `auto` router in v3.2.0), and a stale `Backend: vbw`/`--backend=vbw` now refuses with a migration message. The removal is evidence-driven: 0/30 recent production PRs used vbw, and native matched-or-beat VBW-the-full-system on first-pass correctness in the POC-48 head-to-head. The roadmap's phase order now lives in **Linear** (`i{N}.` Initiatives → `P{N}.` Projects, derived live), not a scaffolded file — `/vbw:init` is dropped from Stage 0 and `/roadmap-create` authors the Linear hierarchy directly. What VBW still provides is the **planning-layer scaffold** that holds per-issue PLAN/SUMMARY/state artifacts under `.vbw-planning/`; everything below is about that scaffold, not an executor and not the phase surface.
 
 | Pipeline Stage | Tool | Used when | Purpose |
 |---------------|------|-----------|---------|
-| Stage 0.5 | `/vbw:init` | Always | Scaffold `.vbw-planning/` |
-| Stage 0.6 | `/roadmap-create` writes to `.vbw-planning/ROADMAP.md` | Always | Populate roadmap |
-| Stage 0.7 (optional) | `/vbw:discuss` | Optional | Discuss first phase before speccing |
+| Stage 0.5 | `/roadmap-create` authors the Linear `i{N}.`/`P{N}.` hierarchy | Always | Populate roadmap in Linear |
+| Stage 0.6 (optional) | `/vbw:discuss` | Optional | Discuss first phase before speccing |
 | Stage 2 (planning) | `/work` inline planning | Always | Generate the plan from the spec — **native and vbw both plan here; `/work` has no separate "VBW Lead" step** |
 | Stage 3 (execute) | native-on-Workflow | Always | Execute tasks on the Workflow primitive — atomic commit per task, verify-before-integrate (the `vbw-dev` executor was removed in v4.0.0) |
 | Anytime | `/vbw:status` | If VBW installed | Project progress dashboard |
@@ -1146,7 +1116,7 @@ Add to `.git/hooks/post-commit` or your project's hook system:
 | Define | `/define` | Concept → project definition |
 | Strategy Create | `/strategy-create` | Definition → strategy docs |
 | Startup | `/startup` | Full orchestrator (chains everything) |
-| Roadmap Create | `/roadmap-create` | Strategy → ROADMAP.md + Linear |
+| Roadmap Create | `/roadmap-create` | Strategy → Linear `i{N}.`/`P{N}.` hierarchy (authored directly in Linear) |
 | Roadmap Verify | `/roadmap-create --verify` | Check Linear matches roadmap |
 | Phase Plan | `/phase-plan` | Select first/next phase |
 | Phase Status | `/phase-plan --status` | Current phase progress |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pipekit
 
-**v4.0.0** — Last updated: 2026-06-20  *(Pipekit 4.0: native-on-Workflow is the **sole** executor — the pluggable `vbw` backend and `--backend=` flag are removed (the `auto` router went in v3.2.0); a stale `Backend: vbw`/`--backend=vbw` now refuses with a migration message. The VBW **planning layer** (`.vbw-planning/`, `/vbw:init` roadmap scaffold) is untouched. Carries 3.0's "wraps VBW" → "native default" reframe + ownership split, 3.1's distribution-layer hardening, 3.2's deprecation, and the v2.8.x substrate)*
+**v4.1.0** — Last updated: 2026-06-21  *(Pipekit 4.1: **Linear-native phase surface.** The roadmap's phase order lives in Linear — Initiatives named `i{N}.` (phases) → Projects named `P{N}.` (sub-phases) → Issues, ordered by the name-prefix number. `pk next`/`pk status` derive the current phase live; `/roadmap-create` authors the hierarchy and `/phase-plan` advances it; `PHASES.md`/`linear-map.json` are retired (read-only fallback); `/vbw:init` is dropped from Stage 0. Carries 4.0: native-on-Workflow is the **sole** executor (the `vbw` backend and `--backend=` flag are removed; a stale `Backend: vbw` refuses with a migration message). Plus 3.x's ownership split + distribution-layer hardening and the v2.8.x substrate)*
 
 A structured AI-assisted software delivery system — from idea to production with quality gates at every stage. The executor is **native-on-Workflow** (Claude Code's first-party orchestration primitive); the pluggable VBW execution backend was removed in v4.0.0 ([VBW](https://github.com/yidakee/vibe-better-with-claude-code-vbw) remains only as Stage 0's roadmap-scaffolding tool).
 
@@ -8,7 +8,7 @@ A structured AI-assisted software delivery system — from idea to production wi
 
 Pipekit is the **structure around an executor** — spec creation, independent review, human sign-off, quality gates, Linear visibility, and promotion. It is **not** itself a planner or code executor: it runs the build step on the native-on-Workflow executor and owns everything around it.
 
-As of **3.0**, the executor is **native-on-Workflow** — `/work` plans the issue inline (parallel codebase grounding), then executes on Claude Code's first-party Workflow primitive: a task DAG, an atomic commit per task, verify-before-integrate. As of **4.0**, it is the **sole** executor: the pluggable `vbw` backend was removed (deprecated in v3.2.0 after carrying 0/30 of recent production work). [VBW](https://github.com/yidakee/vibe-better-with-claude-code-vbw) is no longer an execution dependency — it survives only as the Stage 0 roadmap scaffold (`/vbw:init`).
+As of **3.0**, the executor is **native-on-Workflow** — `/work` plans the issue inline (parallel codebase grounding), then executes on Claude Code's first-party Workflow primitive: a task DAG, an atomic commit per task, verify-before-integrate. As of **4.0**, it is the **sole** executor: the pluggable `vbw` backend was removed (deprecated in v3.2.0 after carrying 0/30 of recent production work). As of **4.1**, [VBW](https://github.com/yidakee/vibe-better-with-claude-code-vbw) is no longer part of Stage 0 either — `/roadmap-create` authors the roadmap directly into Linear as the native phase surface (`i{N}.` Initiatives → `P{N}.` Projects → Issues). VBW survives only as an optional direct-use planning layer, slated for a separate retirement.
 
 | Stage | What Pipekit handles |
 |-------|----------------------|
@@ -25,7 +25,7 @@ The deep-analysis safety net is the **gate layer** — `/financial-review`, `/pr
 To avoid drift between the two systems, the boundaries are explicit:
 
 - **VBW owns the `.vbw-planning/` directory** — `ROADMAP.md` (the roadmap, written at Stage 0) plus the `PLAN.md` files produced in direct VBW planning use. `/work` (native) writes its per-issue plan to `.pk-work/<ID>-PLAN.md` instead. Pipekit reads these but does not overwrite them.
-- **Pipekit owns the visibility layer** — Linear issues, `linear-map.json`, `PHASES.md`, strategy docs, and `method.config.md`. VBW does not touch these. "What's next?" is read live from Linear via `pk next` (phase-aware as of v2.1.0); v2 retired the old `NEXT.md` mirror file.
+- **Pipekit owns the visibility layer** — Linear issues, the **phase surface** (Linear Initiatives `i{N}.` → Projects `P{N}.` → Issues), strategy docs, and `method.config.md`. VBW does not touch these. "What's next?" is read live from Linear via `pk next` (derives the current phase from the initiative/project hierarchy); v2 retired the `NEXT.md` mirror, v4.1.0 retired `PHASES.md`/`linear-map.json`.
 - **The merge happens once**, at `/roadmap-create`. Strategy-derived requirements are added **into** VBW's phase structure; VBW's phases, goals, and success criteria are preserved.
 - **Don't invoke VBW agents directly.** Use `/work`, not `/vbw:lead` or `/vbw:dev`. `/work` executes on the native-on-Workflow backend (the sole executor as of v4.0.0) and keeps Linear and the `pk *` state machine in sync. Direct VBW invocation bypasses the visibility layer.
 
@@ -55,9 +55,8 @@ A bigger context window changes how much an agent can hold. It does not change w
 | Define | `/define` | `project-definition.md` |
 | Strategy | `/strategy-create` | `Strategy/` docs (incl. Design Direction) |
 | Setup | `/startup` | Repo, DB, deploy, Linear workspace |
-| VBW Init | `/vbw:init` | `.vbw-planning/` scaffold |
-| Roadmap | `/roadmap-create` | `ROADMAP.md` + Linear issues |
-| Phase Plan | `/phase-plan` | First phase in "Needs Spec" |
+| Roadmap | `/roadmap-create` | Linear `i{N}.`/`P{N}.` hierarchy (Initiatives → Projects → Issues) |
+| Phase Plan | `/phase-plan` | First sub-phase's issues in "Needs Spec" |
 
 **Development Pipeline — the v2 daily loop** (repeats per issue)
 
@@ -144,7 +143,7 @@ The sync script creates a `method.config.md` file in your project — this is wh
 
 Open Claude Code **in your project directory** and install the dependencies:
 
-**VBW** — the Stage 0 roadmap-scaffolding tool (no longer an execution backend; the `vbw` executor was removed in v4.0.0). Pipekit's executor is native-on-Workflow (built into Claude Code, nothing to install), but Stage 0's `/vbw:init` uses VBW to scaffold the `.vbw-planning/` roadmap directory — so install it once during setup. Run these as two separate commands (don't paste them together):
+**VBW (optional)** — As of **v4.1.0**, VBW is **not required** for the standard Pipekit flow. Stage 0 authors the roadmap directly into Linear (`/roadmap-create` — no `/vbw:init` scaffold), and the executor is native-on-Workflow (built into Claude Code, nothing to install). Install VBW only if you want its optional direct-use planning layer (`/vbw:*` agents, `.vbw-planning/` PLAN/SUMMARY artifacts) — slated for a separate retirement. If you do, run these as two separate commands (don't paste them together):
 
 ```
 /plugin marketplace add yidakee/vibe-better-with-claude-code-vbw
@@ -156,11 +155,13 @@ Open Claude Code **in your project directory** and install the dependencies:
 
 To update later: `/vbw:update`. See the [VBW repo](https://github.com/yidakee/vibe-better-with-claude-code-vbw) for details.
 
-**Linear** — the issue tracker Pipekit uses for visibility. Close Claude Code, then run in your terminal:
+**Linear** — the issue tracker Pipekit uses for visibility **and the phase surface** (Initiatives `i{N}.` → Projects `P{N}.`). Close Claude Code, then run in your terminal:
 
 ```bash
 claude mcp add --transport http --scope user linear-server https://mcp.linear.app/mcp
 ```
+
+> **Initiative support required (v4.1.0).** The native phase surface reads Linear **Initiatives**. Pipekit's interactive skills target `@tacticlaunch/mcp-linear` (registered as `linear-server`, camelCase `linear_*` tools), which exposes initiative + relation tools the first-party `mcp.linear.app` remote lacks. If `pk status` shows no Roadmap section on a project that has `i{N}.` initiatives, you're likely on the first-party remote — switch `linear-server` to `@tacticlaunch/mcp-linear`. (`bin/pk` itself uses the Linear GraphQL API directly via `LINEAR_API_KEY` and is unaffected.)
 
 Reopen Claude Code and run `/mcp` to complete the OAuth authorization flow. If you don't have a Linear workspace yet, create a free one at [linear.app](https://linear.app/) first.
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,6 @@
 # Pipekit Runbook
 
-**v4.0.0** — Last updated: 2026-06-20 09:50  *(Final cut — VBW executor removed; native-on-Workflow is the sole executor (planning layer untouched). Folds in the rc train: Linear MCP camelCase migration (rc3); `pk ship` sha-matched verify gate + `pk promote` auto-pick-next-hop (rc4); gap #1 artifact rule — `sop/Database_SOP.md` + `/light-spec` Phase 3.7 Migration Plan gate (rc5).)*
+**v4.1.0** — Last updated: 2026-06-21 10:30  *(Linear-native phase surface — `pk next`/`pk status` derive the current phase from Linear Initiatives (`i{N}.`) → Projects (`P{N}.`), ordered by name-prefix; `PHASES.md`/`linear-map.json` retired to read-only fallback. Carries v4.0.0: VBW executor removed (native-on-Workflow sole executor); Linear MCP camelCase; `pk ship` sha-matched verify gate + `pk promote` auto-pick-next-hop; gap #1 artifact rule.)*
 
 > **North star:** safe and frictionless. Helps, never adds work.
 
@@ -11,7 +11,7 @@ The v2 daily loop on one page. Read top-to-bottom. v1 commands are retired — p
 ## One-time setup (per consuming project)
 
 ```
-1. ./scripts/sync-method.sh v4.0.0                 (or latest tag)
+1. ./scripts/sync-method.sh v4.1.0                 (or latest tag)
 2. Fill in method.config.md from method.config.template.md (V2 keys: integration_branch, ship_environments, …)
 3. Add LINEAR_API_KEY=lin_api_xxx to .env.local    (gitignored, project-local)
 4. ./bin/pk init                                   (seeds notepad.md, Logs/Sessions/, checks config)
@@ -39,7 +39,7 @@ Run from the parent repo. No worktree needed — specs are Linear-side artifacts
   │ [S1] Find next spec target                               │
   │     pk next                                              │
   │     • look for the "Needs Spec" group in the output      │
-  │     • phase-aware (reads PHASES.md + linear-map.json)    │
+  │     • phase-aware (Linear i{N}./P{N}. surface)           │
   │                                                          │
   │     For a brand-new idea:                                │
   │     /brainstorm <idea>                                   │
@@ -109,17 +109,17 @@ Consumes Approved issues from the spec loop. Each pass produces a merged PR and 
        │
        ▼
   ┌──────────────────────────────────────────────────────────┐
-  │ [1] Find next issue   (phase-aware as of v2.1.0)         │
+  │ [1] Find next issue   (phase-aware, Linear-native)       │
   │     pk next                                              │
-  │     • reads "## Current Phase:" from PHASES.md           │
-  │     • matches to linear-map.json project entry           │
+  │     • derives current phase from Linear initiatives      │
+  │       (i{N}. initiative → P{N}. project, by prefix)      │
   │     • groups Linear results by status:                   │
   │         In Progress  (with /work hint)                   │
   │         Approved     (with pk branch hint)               │
   │         Needs Spec   (with /light-spec hint)             │
   │     • surfaces "Other phases: N Approved outside" footer │
   │     • falls back to global "next Approved" when no       │
-  │       PHASES.md or linear-map.json present               │
+  │       i{N}. initiatives present (PHASES.md fallback)     │
   │     • optional: pk status   (full unscoped board view)   │
   └──────────────────────────────────────────────────────────┘
        │
@@ -375,7 +375,7 @@ Consumes Approved issues from the spec loop. Each pass produces a merged PR and 
 
 | # | Step | Command (global) | Command (repo-local) | Where | Auth |
 |---|---|---|---|---|---|
-| 1 | Find next (phase-aware) | `pk next` | `./bin/pk next` | parent, dev | reads PHASES.md + Linear |
+| 1 | Find next (phase-aware) | `pk next` | `./bin/pk next` | parent, dev | derives phase from Linear (`i{N}.`/`P{N}.`) |
 | 1 | Quick status | `pk status` | `./bin/pk status` | parent | reads Linear (full board, unscoped) |
 | 2 | Branch | `pk branch <ID>` | `./bin/pk branch <ID>` | parent, dev | writes Linear (In Progress) |
 | 3 | Plan + execute | `/work <ID>` | — (skill) | worktree | reads Linear |

--- a/STARTUP.md
+++ b/STARTUP.md
@@ -1,6 +1,6 @@
 # Project Startup Guide
 
-**v4.0.0** — Last updated: 2026-06-20  *(Backend row → native-only; the `vbw` executor was removed in v4.0.0. Otherwise carries the v2.7.0 Step 3 `method.config.md` key reference — `Spec ready state` / `Spec approved state` as the `/light-spec` ↔ `pk spec-cycle` interlock)*
+**v4.1.0** — Last updated: 2026-06-21  *(Linear-native phase surface; `/vbw:init` dropped from Stage 0. The roadmap's phase order lives in Linear — `i{N}.` initiatives are PHASES, `P{N}.` projects are SUB-PHASES, issues live in projects, ordering is by the integer name prefix. Carries v4.0.0's native-only Backend row — the `vbw` executor was removed — and the v2.7.0 Step 3 `method.config.md` key reference: `Spec ready state` / `Spec approved state` as the `/light-spec` ↔ `pk spec-cycle` interlock)*
 
 > **Reference document.** For the interactive flow, use `/startup` — it orchestrates the full bootstrap process, chaining `/concept`, `/define`, `/strategy-create`, `/roadmap-create`, `/phase-plan`, and infrastructure setup. This document provides background context and detailed checklists that the skills reference.
 
@@ -47,8 +47,10 @@ Break the build into stages. Each stage should be independently deployable and t
 | **Team name** | e.g., `MyProject`, `Acme` | Determines issue prefix (PROJ-1, ACME-1) |
 | **Issue prefix** | e.g., `PROJ`, `ACME` | Short, unique, used in commit messages and branch names |
 | **Workflow states** | Use the method standard (13 states) or simplify | Recommendation: start with the full set. You can always skip states, but adding them later means migrating issues. |
-| **Initiatives** | One per stage | Maps 1:1 to VBW phases |
-| **Projects** | Feature clusters within each stage | e.g., "Data Foundation", "Search & CRUD", "Reports" |
+| **Initiatives** | `i{N}.`-prefixed PHASES | Each initiative is an ordered roadmap phase (e.g., `i1. Foundation`, `i2. Search`). Ordering is the integer in the name prefix, parsed numerically (`i2` before `i10`); Linear `sortOrder` is never used. |
+| **Projects** | `P{N}.`-prefixed SUB-PHASES within a phase | Issues live in projects (e.g., `P1. Data Foundation`, `P2. Search & CRUD`). Same prefix-integer ordering. |
+
+This `i{N}.` initiative → `P{N}.` project → issue hierarchy **is** the phase surface — `pk next` / `pk status` derive the current phase live from it, not from a committed file.
 | **Labels** | Domain, Type, Flag, Tier | Domain labels are project-specific. Type/Flag labels are standard. |
 
 **Action:** Create the workspace/team, set up states, create initial initiatives and projects.
@@ -341,8 +343,8 @@ If all steps work, the pipeline is ready. Start building.
 - [ ] Workspace/team created
 - [ ] Workflow states configured (13 standard states)
 - [ ] Issue prefix chosen
-- [ ] Initial initiatives (stages) created
-- [ ] Initial projects (feature clusters) created
+- [ ] Initial initiatives created (`i{N}.`-prefixed PHASES)
+- [ ] Initial projects created (`P{N}.`-prefixed SUB-PHASES; issues live in projects)
 - [ ] Labels configured (Domain, Type, Flag)
 - [ ] State IDs copied into method.config.md
 

--- a/bin/pk
+++ b/bin/pk
@@ -30,7 +30,7 @@ set -euo pipefail
 # Discovery & configuration
 # ─────────────────────────────────────────────────────────────────────────────
 
-PK_VERSION="4.0.0"
+PK_VERSION="4.1.0"
 
 pk_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null
@@ -216,10 +216,72 @@ pk_linear_issue() {
   pk_linear_gql "$q" "$(jq -n --arg id "$id" '{id:$id}')" | jq -r '.data.issue // empty'
 }
 
-# Read the current phase name from .vbw-planning/PHASES.md by extracting
-# the heading text after "## Current Phase:". Returns empty if no PHASES.md
-# or no current-phase heading. Used by phase-aware pk next.
-pk_current_phase_name() {
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase context — Linear-native (Initiatives → Projects), file fallback
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Phase order lives in Linear, not a committed file. Initiatives named with an
+# `i<N>.` prefix are the ordered roadmap phases; Projects named `P<N>.` are the
+# ordered sub-phases within them. Order comes from the NAME PREFIX, not Linear's
+# `sortOrder` (an internal drag-rank that does NOT track phase sequence — verified
+# live, Piper 2026-06-21: sortOrder ordered projects P11,P8,P4,P3,P1,...).
+# Lifecycle comes from status/state:
+#   current phase   = lowest i<N> initiative whose status != "Completed"
+#   current project = lowest P<N> project whose state ∉ {completed, canceled}
+# Unprefixed initiatives (strategic themes) are ignored, so no config list is
+# needed. When no i<N>. initiatives exist (un-migrated project, or no Linear
+# key), this falls back to the legacy .vbw-planning/ files.
+
+# Raw initiatives query. Empty on no-key / error (so callers fall back cleanly).
+pk_linear_initiatives_json() {
+  local q='query { initiatives(first: 50) { nodes { id name status projects(first: 50) { nodes { id name state } } } } }'
+  pk_linear_gql "$q" '{}' 2>/dev/null
+}
+
+# Derive "<phase-name>\t<project-id>" from a Linear initiatives response.
+# Emits nothing when there is no roadmap initiative with a live P<N>. project.
+pk_native_phase_context() {
+  local json="$1"
+  [ -z "$json" ] && return 0
+  printf '%s' "$json" | jq -r '
+    (.data.initiatives.nodes // [])
+    | map(select(.name | test("^[iI][0-9]+\\.")))
+    | sort_by(.name | capture("^[iI](?<n>[0-9]+)\\.") | .n | tonumber)
+    | map(select(.status != "Completed"))
+    | .[0]
+    | if . == null then empty else . end
+    | .name as $pname
+    | (.projects.nodes
+       | map(select(.name | test("^[pP][0-9]+\\.")))
+       | sort_by(.name | capture("^[pP](?<n>[0-9]+)\\.") | .n | tonumber)
+       | map(select(.state != "completed" and .state != "canceled"))
+       | .[0]) as $proj
+    | if $proj == null then empty else [$pname, $proj.id] | @tsv end
+  ' 2>/dev/null
+}
+
+# Ordered roadmap walk for `pk status`: one line per i<N>. initiative with its
+# status and current (first non-done) P<N>. project. Silent when none exist.
+pk_native_roadmap_summary() {
+  local json="$1"
+  [ -z "$json" ] && return 0
+  printf '%s' "$json" | jq -r '
+    (.data.initiatives.nodes // [])
+    | map(select(.name | test("^[iI][0-9]+\\.")))
+    | sort_by(.name | capture("^[iI](?<n>[0-9]+)\\.") | .n | tonumber)
+    | .[]
+    | .name as $n | .status as $s
+    | (.projects.nodes
+       | map(select(.name | test("^[pP][0-9]+\\.")))
+       | sort_by(.name | capture("^[pP](?<n>[0-9]+)\\.") | .n | tonumber)
+       | map(select(.state != "completed" and .state != "canceled"))
+       | .[0].name // "all projects done") as $cur
+    | "  \($n)  [\($s)]  → \($cur)"
+  ' 2>/dev/null
+}
+
+# Legacy file-based phase name — .vbw-planning/PHASES.md "## Current Phase:".
+pk_file_current_phase_name() {
   local root phases
   root=$(pk_repo_root)
   phases="$root/.vbw-planning/PHASES.md"
@@ -228,21 +290,16 @@ pk_current_phase_name() {
     | sed -E 's/^## Current Phase:[[:space:]]*//; s/[[:space:]]+$//'
 }
 
-# Match the current phase name to a linear-map.json project entry and return
-# its Linear project ID (UUID). Returns empty if no match.
-#
-# Matching is fuzzy because PHASES.md and linear-map.json may use different
-# separators ("Phase 2.5 — Vault Redesign" vs "Phase 2.5: Vault Redesign").
-# Strategy: normalize both sides to a "phase-key" by extracting the leading
-# "Phase X.Y" or "Phase X" token and lowercasing the rest for substring match.
-pk_current_phase_project_id() {
+# Legacy file-based phase → Linear project UUID via .vbw-planning/linear-map.json.
+# Fuzzy match: PHASES.md and the map may differ on separators ("Phase 2.5 — Foo"
+# vs "Phase 2.5: Foo"); fall back to the leading "Phase X.Y" token.
+pk_file_current_phase_project_id() {
   local root map name
   root=$(pk_repo_root)
   map="$root/.vbw-planning/linear-map.json"
   [ -f "$map" ] || return 0
-  name=$(pk_current_phase_name)
+  name=$(pk_file_current_phase_name)
   [ -z "$name" ] && return 0
-  # Extract leading phase token (e.g. "Phase 2.5" from "Phase 2.5 — Foo")
   local phase_token
   phase_token=$(echo "$name" | grep -oE '^Phase [0-9]+(\.[0-9]+)?' | head -1)
   jq -r --arg name "$name" --arg token "$phase_token" '
@@ -254,6 +311,29 @@ pk_current_phase_project_id() {
     | .[0].id // empty
   ' "$map" 2>/dev/null
 }
+
+# Unified phase context. Emits "<name>\t<project-id>\t<source>" (source =
+# native|file) or nothing. Native (Linear initiatives) wins; falls back to the
+# legacy .vbw-planning/ files during the migration window.
+pk_phase_context() {
+  local native
+  native=$(pk_native_phase_context "$(pk_linear_initiatives_json)")
+  if [ -n "$native" ]; then
+    printf '%s\tnative\n' "$native"
+    return 0
+  fi
+  local fname fproj
+  fname=$(pk_file_current_phase_name)
+  fproj=$(pk_file_current_phase_project_id)
+  if [ -n "$fname" ] && [ -n "$fproj" ]; then
+    printf '%s\t%s\tfile\n' "$fname" "$fproj"
+  fi
+}
+
+# Back-compat thin wrappers (older code paths / external callers). The hot path
+# (cmd_next) calls pk_phase_context once directly to avoid double-querying.
+pk_current_phase_name() { pk_phase_context | cut -f1; }
+pk_current_phase_project_id() { pk_phase_context | cut -f2; }
 
 # Get issues in a state for the current team, scoped to a Linear project ID.
 # Same shape as pk_linear_issues_in_state but adds project filter. Empty
@@ -910,15 +990,21 @@ cmd_next() {
     echo "Switch to $integration first:  git checkout $integration"
     return 0
   fi
-  # Phase-aware mode if PHASES.md + linear-map.json are present and a
-  # current phase is defined. Falls back to the global "next Approved
-  # anywhere" behaviour when no phase context is available.
-  local phase_name phase_project
-  phase_name=$(pk_current_phase_name)
-  phase_project=$(pk_current_phase_project_id)
+  # Phase-aware mode: Linear initiatives (i<N>./P<N>.) when available, else the
+  # legacy .vbw-planning/ files. One fetch via pk_phase_context. Falls back to
+  # "next Approved anywhere" when no phase context exists at all.
+  local phase_ctx phase_name phase_project phase_src
+  phase_ctx=$(pk_phase_context)
+  phase_name=$(printf '%s' "$phase_ctx" | cut -f1)
+  phase_project=$(printf '%s' "$phase_ctx" | cut -f2)
+  phase_src=$(printf '%s' "$phase_ctx" | cut -f3)
 
   if [ -n "$phase_name" ] && [ -n "$phase_project" ]; then
-    echo "On $current — Phase: $phase_name"
+    if [ "$phase_src" = "native" ]; then
+      echo "On $current — Phase: $phase_name (Linear)"
+    else
+      echo "On $current — Phase: $phase_name"
+    fi
     echo ""
     local in_progress approved needs_spec ip_count ap_count ns_count
     in_progress=$(pk_linear_issues_in_state_project "In Progress" "$phase_project" 2>/dev/null || echo "[]")
@@ -955,7 +1041,11 @@ cmd_next() {
     fi
     if [ "$ip_count" = "0" ] && [ "$ap_count" = "0" ] && [ "$ns_count" = "0" ]; then
       echo "Phase $phase_name has no In Progress / Approved / Needs Spec issues."
-      echo "Check  pk status  for the full board, or update PHASES.md to the next phase."
+      if [ "$phase_src" = "native" ]; then
+        echo "Check  pk status  for the full board, or advance the phase in Linear (initiative/project state)."
+      else
+        echo "Check  pk status  for the full board, or update PHASES.md to the next phase."
+      fi
     fi
 
     # Other phases — surface Approved work outside current phase
@@ -998,6 +1088,15 @@ cmd_status() {
     return 1
   fi
   echo "── Linear: $team ──"
+  # Roadmap walk (Linear initiatives) when migrated to the native phase surface.
+  # Silent when no i<N>. initiatives exist (un-migrated project / no Linear key).
+  local roadmap
+  roadmap=$(pk_native_roadmap_summary "$(pk_linear_initiatives_json)")
+  if [ -n "$roadmap" ]; then
+    echo ""
+    echo "Roadmap (i<N>. initiatives → current P<N>. project):"
+    printf '%s\n' "$roadmap"
+  fi
   # Pre-deploy + UAT buckets are universal.
   local states=("In Progress" "Building" "UAT" "Approved")
   # Append "In <env>" buckets for every non-final env in Ship environments

--- a/method.config.template.md
+++ b/method.config.template.md
@@ -1,6 +1,6 @@
 # Method Configuration
 
-**v2.4.0** — Last updated: 2026-05-13  *(Phase 3.6 project signal probes; latest template revision)*
+**v4.1.0** — Last updated: 2026-06-21  *(Linear-native phase surface — added § Phase Surface: `i{N}.`/`P{N}.` naming convention replaces `PHASES.md`/`linear-map.json`; legacy files fall back automatically)*
 
 Project-specific values that portable skills read at runtime. Copy this file to your project root as `method.config.md` and fill in your values.
 
@@ -44,6 +44,33 @@ Skills use these IDs to transition issues. Get them from Linear API or the Linea
 | Done | `` |
 | Canceled | `` |
 | Duplicate | `` |
+
+## Phase Surface (Linear-native)
+
+The roadmap's phase order lives in **Linear**, not a committed file. `pk next` and `pk status`
+derive the current phase live from the Linear hierarchy; `/roadmap-create` authors it and
+`/phase-plan` advances it. There is no `PHASES.md` or `linear-map.json` to keep in sync.
+
+**The naming convention is the contract** (ordering comes from the name prefix, never Linear's
+`sortOrder` — that field is an internal drag-rank and does not track phase sequence):
+
+| Level | Linear construct | Naming | Meaning |
+|-------|-----------------|--------|---------|
+| Phase | **Initiative** | `i{N}. label` (e.g. `i1. Foundation`) | An ordered roadmap phase. `pk next` walks these by `{N}`. |
+| Sub-phase | **Project** | `P{N}. label` (e.g. `P2. Budget Editor`) | An ordered batch within a phase. Issues live here. |
+| Work item | **Issue** | (Linear identifier) | The unit `/work` builds. |
+
+- **Order** = the integer in the prefix, parsed numerically (`P2` before `P10`).
+- **Current phase** = lowest `i{N}` initiative whose status ≠ `Completed`.
+- **Current sub-phase** = lowest `P{N}` project in it whose state ∉ {`completed`, `canceled`}.
+- **Roadmap opt-in** = the `i{N}.` prefix. Unprefixed initiatives (strategic themes) are ignored
+  by `pk next`/`pk status` — no config list needed.
+- **Milestones** (Work Packages) remain an optional intra-project grouping, orthogonal to phases.
+
+> **Transitional:** projects not yet migrated to `i{N}.`-prefixed initiatives fall back to the
+> legacy `.vbw-planning/PHASES.md` + `linear-map.json` automatically. Rename your delivery
+> initiatives with `i{N}.` prefixes to switch a project to the native surface, then the files can be
+> deleted. New projects are native from `/roadmap-create`.
 
 ## Slack (optional)
 

--- a/method.md
+++ b/method.md
@@ -1,10 +1,10 @@
 # Pipekit
 
-**v4.0.0** — Last updated: 2026-06-20 09:50  *(**Final cut — VBW executor removed; native-on-Workflow is the sole executor.** The pluggable `vbw` backend, `--backend=` flag, and `vbw-dev`/`vbw-scout` dispatch are gone (the `auto` router went in v3.2.0); a stale `Backend: vbw`/`auto` now refuses with a migration message. The VBW **planning** layer is untouched. Folds in the rc train: Linear MCP tool-name migration to `@tacticlaunch/mcp-linear` camelCase across 19 skills (rc3); `pk ship` sha-matched verify gate + `pk promote` auto-pick-next-hop (rc4); and gap #1's **artifact rule** — `sop/Database_SOP.md` + `/light-spec` Phase 3.7 Migration Plan gate + Spec Review Agent § Migration Rule, companion to the immutability rule in `.claude/rules/pipekit-migrations.md` (rc5).)*
+**v4.1.0** — Last updated: 2026-06-21 10:30  *(**Linear-native phase surface.** The roadmap's phase order now lives in Linear — Initiatives (`i{N}.` phases) → Projects (`P{N}.` sub-phases) → Issues, ordered by the name-prefix number (Linear `sortOrder` is an unreliable drag-rank). `.vbw-planning/PHASES.md` + `linear-map.json` are retired (read-only fallback only); `pk next`/`pk status` derive the current phase live; `/roadmap-create` authors it, `/phase-plan` advances it; Stage 0.5 `/vbw:init` is dropped from the contract. The `i{N}.`/`P{N}.` convention is the contract — `method.config.md § Phase Surface`. Validated live against a production Linear workspace. Carries v4.0.0: VBW executor removed (native-on-Workflow is the sole executor); Linear MCP `@tacticlaunch/mcp-linear` camelCase; `pk ship` sha-matched verify gate + `pk promote` auto-pick-next-hop; gap #1 migration artifact rule (`sop/Database_SOP.md`).)*
 
 > **v2.4.3.2 status.** Pipekit's daily loop is `bin/pk` + `/work` + `/verify` + `/pk-exit`. The canonical **one-page** operational doc is [`RUNBOOK.md`](./RUNBOOK.md). This document is the **deeper methodology** — pipeline contract, ownership model, fresh-chat discipline, and tooling reference. Read RUNBOOK first if you only need the daily flow; read this if you're onboarding to the system, tuning gates, or reasoning about why a stage exists.
 >
-> **The machine-readable NEXT.md is retired; a curated roadmap file is legitimate.** v1 used `NEXT.md` at the project root as a machine-readable "what to do next" pointer that skills auto-wrote. That artifact is retired — `pk next` (reads Linear directly + scopes to the current phase via `PHASES.md` as of v2.1.0) is the canonical "what's next?" answer, and **skills never write a roadmap file**.
+> **The machine-readable NEXT.md is retired; a curated roadmap file is legitimate.** v1 used `NEXT.md` at the project root as a machine-readable "what to do next" pointer that skills auto-wrote. That artifact is retired — `pk next` (reads Linear directly + scopes to the current phase via the **Linear-native phase surface** — `i{N}.` initiatives / `P{N}.` projects, v4.1.0; the legacy `PHASES.md` + `linear-map.json` fall back automatically for un-migrated projects) is the canonical "what's next?" answer, and **skills never write a roadmap file**.
 >
 > What v2's retirement over-rotated on (corrected in v3.1.0): a **hand-curated visual roadmap** at the project root — phases, themes, standing backlogs, the orientation picture Linear's board view doesn't give — is a first-class *optional* artifact. Keep one if you like seeing the whole arc in a file (`NEXT.md` or `ROADMAP.md` by convention). Two rules keep it safe:
 > - **Human-owned.** Skills and agents never write it, and never read it as operational state. It can go stale without breaking anything — it's narrative, not state.
@@ -65,9 +65,8 @@ Per session (not per issue): /pk-exit          (last command of every Claude Cod
 | 0.2 | **Define** | `/define` | Concept brief | `project-definition.md` | Definition supports tech stack + strategy decisions |
 | 0.3 | **Strategy Create** | `/strategy-create` | Project definition | `Strategy/` docs (incl. Design Direction) | Docs describe a coherent product |
 | 0.4 | **Infra Setup** | `/startup` (Steps 3-6) | Tech stack decisions | Working repo, DB, deploy, MCP | Pre-deploy gate passes |
-| 0.5 | **VBW Init** | `/vbw:init` | — | `.vbw-planning/` scaffold | Directory exists |
-| 0.6 | **Roadmap** | `/roadmap-create` | Strategy docs + definition | `ROADMAP.md` + populated Linear | Every requirement has an issue |
-| 0.7 | **Phase Plan** | `/phase-plan` | Populated Linear board | First phase in "Needs Spec" | Dependencies clear, phase sized |
+| 0.5 | **Roadmap** | `/roadmap-create` | Strategy docs + definition | Linear Initiative→Project→Issue hierarchy (`i{N}.`/`P{N}.`) | Every requirement has an issue |
+| 0.6 | **Phase Plan** | `/phase-plan` | Populated Linear board | First sub-phase's issues in "Needs Spec" | Dependencies clear, phase sized |
 
 Stage 0 is the foundation contract — a set of artifacts, not a script. The greenfield flow above is one of three entry modes (see [Entry Modes](#entry-modes)). `/startup` orchestrates whichever mode applies.
 
@@ -113,9 +112,7 @@ The development pipeline (Stages 1-5) is **contract-strict**: every skill in it 
 | Project definition | `project-definition.md` | `/strategy-create`, `/roadmap-create` |
 | Strategy docs | `Strategy/*.md` | `/light-spec`, `/strategy-sync` |
 | Project config | `method.config.md` | All Pipekit skills, `bin/pk` |
-| VBW scaffold | `.vbw-planning/` | Pipekit roadmap state; VBW agents (direct use) |
-| Linear-VBW map | `.vbw-planning/linear-map.json` | `pk next`, `/work`, `/sync-linear` |
-| Phase plan | `.vbw-planning/PHASES.md` | `pk next` (phase-aware as of v2.1.0), `/phase-plan` |
+| Phase surface | Linear Initiatives (`i{N}.`) → Projects (`P{N}.`) → Issues | `pk next`, `pk status`, `/phase-plan`, `/roadmap-create` (live in Linear; no committed file — see `method.config.md § Phase Surface`) |
 
 `/roadmap-review` is the gate that verifies the contract before the dev pipeline begins. `/pipekit-help` and `/startup --mode=inherited` (see [Entry Modes](#entry-modes)) inspect the contract on demand and recommend retrofits when artifacts are missing.
 
@@ -129,8 +126,8 @@ A project can enter the dev pipeline through three legitimate paths. They differ
 
 | Mode | Who | Skills run | Skills skipped |
 |---|---|---|---|
-| **Greenfield** | Founder, fresh idea, no code yet | Full Stage 0 chain (`/concept` → `/define` → `/strategy-create` → `/startup` → `/vbw:init` → `/roadmap-create` → `/phase-plan`) | None |
-| **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield` (stub for now), `/vbw:init`, `/roadmap-create`, `/phase-plan` | `/concept`, `/define` (the project already exists; concept/definition are reverse-engineered manually until the deferred `/strategy-from-code` auto-audit skill ships) |
+| **Greenfield** | Founder, fresh idea, no code yet | Full Stage 0 chain (`/concept` → `/define` → `/strategy-create` → `/startup` → `/roadmap-create` → `/phase-plan`) | None |
+| **Brownfield** | Team adopting Pipekit on an existing codebase | `/startup --mode=brownfield` (stub for now), `/roadmap-create`, `/phase-plan` | `/concept`, `/define` (the project already exists; concept/definition are reverse-engineered manually until the deferred `/strategy-from-code` auto-audit skill ships) |
 | **Inherited** | New contributor joining a Pipekit project | None — `/startup --mode=inherited` verifies the contract is intact and points to the dev pipeline | All of Stage 0 (artifacts are already on disk) |
 
 `/startup` auto-detects the mode by inspecting project state (no concept-brief + no code → greenfield; code present, no Strategy/ → brownfield; everything present → inherited) and **always confirms with the user** before proceeding — same pattern as tier resolution in `/work`. Mode is never picked silently.
@@ -141,21 +138,20 @@ A project can enter the dev pipeline through three legitimate paths. They differ
 
 ## Stage 0: Foundation
 
-**Steps:** 0.1–0.7 (Concept → Define → Strategy → Setup → VBW Init → Roadmap → Phase Plan)
+**Steps:** 0.1–0.6 (Concept → Define → Strategy → Setup → Roadmap → Phase Plan)
 
-**Tools:** `/concept`, `/define`, `/strategy-create`, `/startup`, `/vbw:init`, `/roadmap-create`, `/phase-plan`
+**Tools:** `/concept`, `/define`, `/strategy-create`, `/startup`, `/roadmap-create`, `/phase-plan`
 
-Stage 0 is the contract above (Foundation Contract), not a script. The greenfield path runs all seven skills in order. Brownfield skips the first two. Inherited skips the entire stage and just verifies the artifacts. See [Entry Modes](#entry-modes) for which path applies to your project. This section documents the greenfield flow; the others are variations on it.
+Stage 0 is the contract above (Foundation Contract), not a script. The greenfield path runs all six skills in order. Brownfield skips the first two. Inherited skips the entire stage and just verifies the artifacts. See [Entry Modes](#entry-modes) for which path applies to your project. This section documents the greenfield flow; the others are variations on it.
 
 - `/concept` captures the idea and assesses viability — supports ingesting existing documents (proposals, research, notes)
 - `/define` distills the concept into stages, roles, workflows, and success criteria
 - `/strategy-create` generates configurable strategy docs (doc set defined in `method.config.md`)
 - `/startup` orchestrates the full flow and handles infrastructure (repo, DB, deploy, MCP, Linear)
-- `/vbw:init` scaffolds `.vbw-planning/` for the planning engine
-- `/roadmap-create` extracts requirements from strategy docs and populates both ROADMAP.md and Linear
-- `/phase-plan` selects 3-8 issues for the first execution phase
+- `/roadmap-create` extracts requirements from strategy docs and authors the **Linear-native phase surface** — Initiatives (`i{N}.` phases) → Projects (`P{N}.` sub-phases) → Issues
+- `/phase-plan` confirms the current phase and promotes its first sub-phase's issues to "Needs Spec"
 
-**Output:** `concept-brief.md`, `project-definition.md`, `Strategy/` docs, working infrastructure, `.vbw-planning/ROADMAP.md`, populated Linear board, `.vbw-planning/PHASES.md` with first phase defined.
+**Output:** `concept-brief.md`, `project-definition.md`, `Strategy/` docs, working infrastructure, and a populated Linear board structured as the native phase surface (`i{N}.` initiatives → `P{N}.` projects → issues), with the first sub-phase's issues in "Needs Spec". (No `.vbw-planning/` scaffold — the phase surface lives in Linear; see `method.config.md § Phase Surface`.)
 
 **Gate:** `/roadmap-review` validates all Stage 0 outputs before the spec pipeline begins.
 
@@ -353,17 +349,22 @@ Skills are convenience wrappers. They automate the same conventions documented i
 
 ## VBW / Pipekit Ownership Model
 
-Pipekit wraps VBW — it does not replace VBW's planning layer. The two systems must not compete for the same source of truth, or you'll spend more time reconciling than building. The boundaries below make ownership explicit.
+**The phase surface is Linear-native (v4.1.0).** The roadmap's phase order — Initiatives (`i{N}.`) →
+Projects (`P{N}.`) → Issues — lives in Linear, owned by Pipekit. The retired `.vbw-planning/PHASES.md`
+and `linear-map.json` are no longer written (legacy files fall back automatically until a project is
+migrated). What remains of VBW is its **planning layer** (`ROADMAP.md`, `PLAN.md`, execution state) —
+still present, slated for a separate retirement; the two systems must not compete for the same source of
+truth. The boundaries below make ownership explicit.
 
 ### Ownership Table
 
 | File / System | Owned by | Writers | Readers |
 |---|---|---|---|
-| `.vbw-planning/ROADMAP.md` | VBW | `/vbw:init` creates it; `/roadmap-create` merges strategy-derived requirements **into** it (never overwrites) | All Pipekit skills, VBW agents |
-| `.vbw-planning/phases/*/PLAN.md` | VBW | `vbw-lead` (direct VBW use / `/vbw:vibe --plan`). **Pipekit's `/work` does not spawn `vbw-lead`** — it plans inline to `.pk-work/<ID>-PLAN.md` | `/work`, `/review-plan`, `/phase-plan --status`; `vbw-dev`/`vbw-qa` in direct VBW use |
-| `.vbw-planning/.execution-state.json` | VBW | vbw-dev / vbw-qa agents (direct VBW use) | `/phase-plan --status` |
-| `.vbw-planning/linear-map.json` | Pipekit | `/roadmap-create`, `/sync-linear` | `pk next`, `pk *`, all Pipekit skills |
-| `.vbw-planning/PHASES.md` | Pipekit | `/phase-plan` | `pk next` (phase-aware), all Pipekit skills |
+| **Phase surface** — Linear Initiatives (`i{N}.`) → Projects (`P{N}.`) → Issues | Pipekit | `/roadmap-create` (authors), `/phase-plan` (advances) | `pk next`, `pk status`, all Pipekit skills. The naming convention is the contract (`method.config.md § Phase Surface`); ordering is the prefix number, never Linear `sortOrder`. |
+| `.vbw-planning/ROADMAP.md` | VBW (legacy) | Legacy `/vbw:init`. No longer required — `/roadmap-create` authors Linear directly | Read-only, legacy projects |
+| `.vbw-planning/phases/*/PLAN.md` | VBW (legacy) | `vbw-lead` (direct VBW use only). **Pipekit's `/work` plans inline to `.pk-work/<ID>-PLAN.md`** | `/review-plan` (legacy); slated for retirement |
+| `.vbw-planning/.execution-state.json` | VBW (legacy) | vbw-dev / vbw-qa agents (direct VBW use only) | legacy; slated for retirement |
+| `.vbw-planning/PHASES.md`, `linear-map.json` | **Retired** | Nothing — no skill writes them | `bin/pk` reads them only as a **fallback** when a project has no `i{N}.` initiatives yet |
 | `notepad.md` (project root, gitignored) | Human | Whoever's typing | Whoever's reading. v2 retired the auto-written `NEXT.md` mirror — `pk next` reads "what's next?" live from Linear instead. |
 | Curated roadmap (optional — `NEXT.md` / `ROADMAP.md` at project root, committed) | Human | Human only — skills and agents never write it | Humans and stakeholders. Narrative orientation (phases, themes, standing backlogs), never read by skills as operational state. |
 | Linear issues | Pipekit | `/light-spec`, `pk branch`, `pk ship`, `pk done`, `/roadmap-create`, `/phase-plan` | Everyone |
@@ -372,16 +373,16 @@ Pipekit wraps VBW — it does not replace VBW's planning layer. The two systems 
 
 ### Rules of Engagement
 
-1. **VBW owns the planning layer.** `.vbw-planning/ROADMAP.md`, `PLAN.md` files, and execution state are VBW's. Pipekit reads them but does not overwrite them.
-2. **Pipekit owns the visibility layer.** Linear issues, `linear-map.json`, `PHASES.md`, strategy docs, and project config are Pipekit's. VBW does not write to these. (v2 retired the `NEXT.md` mirror — `pk next` reads "what's next?" live from Linear.)
-3. **Initial merge happens once** — at `/roadmap-create`. Strategy-derived requirements are added **into** VBW's existing phase structure. VBW's phases, goals, and success criteria are preserved verbatim.
-4. **After the merge, the split is one-way.** Pipekit reads VBW state (plan progress, execution state) to update Linear. VBW does not read Linear — its source of truth is its own files.
+1. **The phase surface is Linear-native and Pipekit-owned.** Initiatives (`i{N}.`) → Projects (`P{N}.`) → Issues live in Linear. `/roadmap-create` authors them; `/phase-plan` advances them; `pk next`/`pk status` derive the current phase live. No committed phase file — the legacy `PHASES.md`/`linear-map.json` are a read-only fallback only.
+2. **Pipekit owns the visibility layer.** Linear issues, the phase surface, strategy docs, and project config are Pipekit's. (v2 retired the `NEXT.md` mirror; v4.1.0 retired `PHASES.md`/`linear-map.json` — `pk next` reads "what's next?" live from Linear.)
+3. **The roadmap is authored directly into Linear** — at `/roadmap-create`. There is no merge into a VBW phase skeleton; the Linear Initiative→Project hierarchy *is* the roadmap, named by the `i{N}.`/`P{N}.` convention.
+4. **VBW's remaining planning layer is legacy.** `.vbw-planning/ROADMAP.md`, `PLAN.md`, and execution state still exist for projects that used direct VBW, but no Pipekit skill depends on them for the phase surface; they are slated for a separate retirement.
 5. **Pipekit owns gates; native-on-Workflow owns build.** `pk branch` opens Linear → In Progress; `/work` plans inline and executes on the native-on-Workflow backend; `/verify` runs the pre-deploy gate; `pk ship` transitions Linear → UAT (PR open on preview); `pk done` verifies merge, transitions Linear UAT → `In <FirstEnv>` (e.g. `In Dev`), cleans up the worktree; `pk promote <env>` walks `Ship environments` one hop at a time and transitions issues → `In <Env>` (intermediate) or → Done (final). The plan-review gate lives in the standalone `/review-plan` skill, which spawns the `plan-reviewer` agent at `model: opus` between `/work`'s inline plan and execution.
 
    **Pipekit's VBW-steering surface:**
    1. **One direct agent spawn** — `plan-reviewer` in `/review-plan`. Not a VBW agent; Pipekit-shipped.
    2. **`/work` executes inline on the native-on-Workflow backend** — the sole executor as of v4.0.0. No VBW executor dispatch.
-   3. **Read-only state observation** — `.vbw-planning/{ROADMAP,STATE,PHASES,linear-map}.md` reads from `/sync-linear`, `/phase-plan`, `/00-roadmap-review`, `/01-light-spec`, `/10-strategy-sync`, `pk next`, `pk status`.
+   3. **Phase surface read live from Linear** — `pk next`, `pk status`, `/phase-plan`, `/00-roadmap-review`, `/01-light-spec`, `/sync-linear`, `/10-strategy-sync` derive phase context from the Linear Initiative/Project hierarchy. (Legacy `.vbw-planning/{ROADMAP,STATE}.md` reads remain only for projects still on direct VBW.)
    4. **One lifecycle hook** — `scripts/pipekit-post-archive.sh` fires on `/vbw:vibe --archive`, writes a `pending-strategy-sync` marker into Pipekit's machine-local state directory.
    5. **Pipekit-side ephemeral state** lives **outside the repo** at `${XDG_CACHE_HOME:-$HOME/.cache}/pipekit/<repo-basename>/`, resolved by `scripts/pipekit-state-dir.sh`. It holds the `pending-strategy-sync` marker and per-issue pipeline-state records consumed by `pk *` commands. Out-of-repo by design — v1.6.0 placed these at `.pipekit/`, but VBW's file-guard hook silently blocked writes during active-plan scope (#13). The relocation made writes succeed unconditionally.
 
@@ -446,7 +447,7 @@ VBW resolves the path relative to the project root. The hook is fail-open — if
 | `/light-spec-revise` | Apply Spec Review Agent feedback surgically; detects stalemate loops. Usually invoked by `/light-spec` Phase 6, but can be run standalone. |
 | `pk spec-cycle <ID>` | Post the Spec Review Agent v5 trigger, poll Linear for the verdict, transition state to Approved on Pass. Owns the `@linear` trigger format and polling — Claude doesn't wait. |
 | `/spec-preflight {ISSUE}` | Empirical pre-flight on a specced issue — verifies file paths, line refs, phase-detect baseline, Linear status against reality. Read-only. Run between Spec Review Agent and `pk branch`. |
-| `pk next` | Phase-aware: groups Linear results by status with per-group hints |
+| `pk next` | Phase-aware: derives the current phase from the Linear-native surface (`i{N}.` initiative → `P{N}.` project; legacy `PHASES.md` falls back), groups Linear results by status with per-group hints |
 | `pk branch <ID>` | Worktree + branch + Linear → In Progress (idempotent) |
 | `/work <ID>` | Plan + execute on native-on-Workflow (the sole executor as of v4.0.0). |
 | `/pk-express <ISSUE-ID>` | Express lane — idea→Draft-PR autopilot for **simple** WITs (Quick/Standard only). Chains `/brainstorm` → `/light-spec` (auto-cycle to Approved) → `pk branch` → `/work` (auto verify + ship); stops at 5 gates (not-Now, tier:heavy, spec stalemate, verify flag, Draft PR). Resumes from Linear state. Skill, not a Workflow. |

--- a/skills/00-roadmap-review/skill.md
+++ b/skills/00-roadmap-review/skill.md
@@ -5,7 +5,9 @@ description: Audit roadmap health — issues, dependency order, spec coverage, d
 
 # Roadmap Review Skill
 
-You are a roadmap health auditor. Your job is to run a comprehensive health check of the overall plan. Read `method.config.md` for project context. Run this before speccing a new phase to ensure the roadmap is coherent and complete.
+**v4.1.0** — Last updated: 2026-06-21 *(validate the Linear-native phase surface — phase order lives in Linear `i{N}.` initiatives / `P{N}.` projects per `method.config.md` § Phase Surface, not in `.vbw-planning/PHASES.md` or `linear-map.json`)*
+
+You are a roadmap health auditor. Your job is to run a comprehensive health check of the overall plan. Read `method.config.md` for project context — including the **§ Phase Surface** contract that defines the Linear-native phase model this skill validates. Run this before speccing a new phase to ensure the roadmap is coherent and complete.
 
 ## Triggers
 
@@ -17,9 +19,9 @@ You are a roadmap health auditor. Your job is to run a comprehensive health chec
 ## Purpose
 
 Validate that:
-1. **Stage 0 outputs exist** — concept, definition, strategy docs, roadmap, phase
-2. Every ROADMAP requirement has corresponding Linear issues
-3. Issues are in the correct stage/project
+1. **Stage 0 outputs exist** — concept, definition, strategy docs, roadmap, Linear phase hierarchy
+2. The **Linear-native phase surface is well-formed** — `i{N}.` initiatives and `P{N}.` projects are correctly named, ordered, and placed (see § Phase Surface in `method.config.md`)
+3. Every requirement is placed in a `P{N}.` project — no orphan issues that should live in a phase
 4. Dependencies and blockers are set correctly
 5. Workflow states are consistent with dependency ordering
 6. Spec coverage is adequate for the next planned phase
@@ -33,15 +35,17 @@ This is the **gate between Stage 0 (Foundation) and Stage 1 (Definition)** in th
 
 Validate that pre-pipeline outputs exist. If any are missing, report which skill to run.
 
-| Check | File | If Missing |
-|-------|------|-----------|
+| Check | Surface | If Missing |
+|-------|---------|-----------|
 | Concept brief | `concept-brief.md` | Run `/concept` |
 | Project definition | `project-definition.md` | Run `/define` |
 | Strategy docs | `Strategy/` matching `method.config.md` manifest | Run `/strategy-create` |
-| VBW scaffold | `.vbw-planning/` directory | Run `/vbw:init` |
-| Roadmap | `.vbw-planning/ROADMAP.md` with content | Run `/roadmap-create` |
-| Linear board | Issues exist for roadmap requirements | Run `/roadmap-create` |
-| Phase defined | `.vbw-planning/PHASES.md` with current phase | Run `/phase-plan` |
+| Roadmap source | `.vbw-planning/ROADMAP.md` with content (optional legacy — strategy docs are the live source) | Run `/roadmap-create` |
+| Phase initiatives | At least one Linear delivery initiative named `i{N}.` exists | Run `/roadmap-create` |
+| Phase projects | The current initiative has at least one `P{N}.` project | Run `/roadmap-create` |
+| Linear board | Issues exist, placed in `P{N}.` projects | Run `/roadmap-create` |
+
+The phase surface lives in **Linear**, not in a file: an initiative named `i{N}. label` is an ordered PHASE; a project named `P{N}. label` is an ordered SUB-PHASE; issues live in projects. `.vbw-planning/PHASES.md` and `linear-map.json` are **retired** — do not assert they exist or are consistent (a stale copy may linger as a `bin/pk` fallback, but no skill writes them).
 
 If any Stage 0 check fails, report it prominently at the top of the health report:
 
@@ -50,7 +54,7 @@ If any Stage 0 check fails, report it prominently at the top of the health repor
 
 Missing:
   - concept-brief.md → run /concept
-  - .vbw-planning/PHASES.md → run /phase-plan
+  - no `i{N}.` delivery initiatives in Linear → run /roadmap-create
 
 Complete Stage 0 before entering the spec pipeline.
 ```
@@ -59,37 +63,65 @@ If all Stage 0 checks pass, continue to the next check.
 
 ### Phase 1 — Gather State
 
-1. Read `.vbw-planning/ROADMAP.md` for requirements by stage
-2. Read `.vbw-planning/linear-map.json` for ID mappings
-3. Read `.vbw-planning/STATE.md` for current progress
-4. Read `.vbw-planning/PHASES.md` for current phase composition
-5. Fetch all initiatives via `mcp__linear-server__linear_getInitiatives`
-6. For each active and next-up initiative, fetch projects via `mcp__linear-server__linear_getProjects`
-7. For each project, fetch issues via `mcp__linear-server__linear_searchIssues`
+Linear is the source of truth for the phase surface. Read it live; the retired `.vbw-planning/PHASES.md` and `linear-map.json` are not consulted.
+
+1. (Optional legacy) Read `.vbw-planning/ROADMAP.md` for the strategy-derived requirements list, if present. Strategy docs are the live requirement source; ROADMAP.md is a legacy mirror.
+2. Fetch all initiatives via `mcp__linear-server__linear_getInitiatives`. Partition them:
+   - **Delivery initiatives** = names matching `^i(\d+)\.` — these are the ordered PHASES.
+   - **Strategic initiatives** = unprefixed names — themes, not phases; carried into Phase 2's strategic-initiative check.
+3. Determine the **current phase** = the lowest `i{N}` delivery initiative whose status is not `Completed`.
+4. For each delivery initiative (current + next-up), fetch projects via `mcp__linear-server__linear_getProjects`. Projects named `^P(\d+)\.` are the ordered SUB-PHASES; `{N}` orders them within the initiative.
+5. Determine the **current sub-phase** = the lowest `P{N}` project (within the current initiative) whose state is not in {`completed`, `canceled`}.
+6. For each project, fetch issues via `mcp__linear-server__linear_searchIssues`.
+
+Throughout: order comes from the integer in the `i{N}.` / `P{N}.` name prefix (numeric), **never** from Linear's `sortOrder` field.
 
 ### Phase 2 — Completeness Check
 
-For each stage in ROADMAP.md:
+Source the requirements list from the strategy docs (the live source) or, if present, the legacy `.vbw-planning/ROADMAP.md`. For each phase (`i{N}.` initiative):
 
-1. Extract the requirements list from the stage section
+1. Extract the requirements that map to this phase
 2. Match each requirement to Linear issues by:
    - Title keyword matching
-   - Project assignment (requirement area → project cluster)
+   - Project assignment (requirement area → `P{N}.` project)
    - Description cross-references
 3. **Gaps:** Requirements with NO matching issue → these need issues created
 4. **Orphans:** Issues with NO matching requirement → flag for review (may be valid additions from brainstorming, or may be misassigned)
 
-Output: Completeness table per stage.
+Output: Completeness table per phase (`i{N}.`).
 
-### Phase 3 — Assignment Validation
+### Phase 3 — Phase Surface Well-Formedness
 
-For each issue in the active and upcoming stages:
+This is the core Linear-native validation. The phase surface (per `method.config.md` § Phase Surface) is: delivery initiative `i{N}. label` = ordered PHASE; project `P{N}. label` = ordered SUB-PHASE within its initiative; issues live in `P{N}.` projects. Validate that this structure is well-formed:
 
-1. Verify it belongs to the correct initiative (stage)
-2. Verify it belongs to a project within that initiative
-3. Verify it has a milestone (work package) if applicable
-4. Verify labels are consistent (Tier label matches Initiative, Domain label matches Project)
-5. Flag misassignments
+**Initiative naming & order:**
+
+1. Every delivery initiative is named `i{N}.` where `{N}` is an integer. Flag any initiative that looks like a phase (has delivery projects/issues under it) but is missing the `i{N}.` prefix — it would be silently treated as a strategic theme and dropped from the phase walk.
+2. The `{N}` values are **unique** across delivery initiatives (no two `i2.` initiatives) and ordered (contiguous `i1, i2, i3…` is ideal; a gap is a warning, a duplicate is an error).
+
+**Project naming & order:**
+
+3. Every project under a delivery initiative is named `P{N}.` where `{N}` is an integer.
+4. The `{N}` values are **unique within their initiative** (no two `P3.` projects in the same `i{N}.`). Duplicates are an error; gaps are a warning.
+
+**Issue placement:**
+
+5. Every requirement/issue that belongs to a phase is placed in a `P{N}.` project. Flag **orphan issues** — issues attached directly to a delivery initiative with no project, or issues in an unprefixed project under a delivery initiative — that should live in a `P{N}.` phase project.
+
+**Lifecycle sanity:**
+
+6. The **earliest non-`Completed` delivery initiative** (the current phase, by lowest `{N}`) has status `Active`. Flag if it is still `Planned`/`Backlog` (work has nowhere to land) or if multiple delivery initiatives are simultaneously `Active`.
+7. Within that current initiative, its **earliest live project** (lowest `P{N}` whose state is not `completed`/`canceled`) is `started`. Flag if the current sub-phase is still `planned`/`backlog`.
+
+**Strategic-initiative intent:**
+
+8. For each **unprefixed** (strategic) initiative, confirm it is *intentionally* a theme, not an accidentally-unprefixed phase. Heuristic: a strategic initiative with active delivery projects/issues under it is suspicious — surface it and ask the user to confirm it should be ignored by the phase walk, or rename it `i{N}.`.
+
+**Within-issue assignment (secondary):**
+
+9. For issues in the current and upcoming phases, verify labels are consistent (Tier label matches phase intent, Domain label matches the `P{N}.` project cluster) and flag misassignments.
+
+Output: a Phase Surface section listing any naming/order/placement/lifecycle violations, each with the exact rename or re-parent to apply.
 
 ### Phase 4 — Dependency Validation
 
@@ -114,7 +146,7 @@ For each issue that has blockers:
 
 ### Phase 6 — Spec Coverage
 
-For the next planned phase (issues in On Deck/Needs Spec/Specced for the active stage):
+For the next planned phase (issues in On Deck/Needs Spec/Specced in the current `i{N}.` initiative's live `P{N}.` projects):
 
 1. List all issues that would enter the pipeline
 2. For each issue, check spec status:
@@ -147,23 +179,39 @@ Present a summary dashboard:
 ```markdown
 ## Roadmap Health — YYYY-MM-DD
 
+### Phase Surface (Linear-native)
+| Check | Result |
+|-------|--------|
+| Delivery initiatives named `i{N}.` | X/Y |
+| Initiative `{N}` unique & ordered | OK / gaps / DUPLICATE |
+| Projects named `P{N}.` | X/Y |
+| Project `{N}` unique within initiative | OK / DUPLICATE |
+| Orphan issues (not in a `P{N}.` project) | X |
+| Current initiative `i{N}.` is `Active` | OK / FLAG |
+| Current sub-phase `P{N}.` is `started` | OK / FLAG |
+| Unprefixed initiatives confirmed strategic | X (Y need confirmation) |
+
+**Violations:**
+- Initiative "Onboarding" has delivery issues but no `i{N}.` prefix → rename to `i4. Onboarding` or confirm it is a strategic theme
+- PROJ-176: attached to initiative `i2.` with no project → re-parent into a `P{N}.` project
+
 ### Completeness
-| Stage | Requirements | Issues | Gaps | Orphans |
+| Phase | Requirements | Issues | Gaps | Orphans |
 |-------|-------------|--------|------|---------|
-| 01    | 3           | 3      | 0    | 0       |
-| 02    | 18          | 81     | 2    | 5       |
-| 03    | 22          | 0      | 22   | 0       |
+| i1    | 3           | 3      | 0    | 0       |
+| i2    | 18          | 81     | 2    | 5       |
+| i3    | 22          | 0      | 22   | 0       |
 | ...   |             |        |      |         |
 
 **Gaps (requirements without issues):**
-- Stage 02: "Persistent AI Memory (mem0)" — no matching issue
-- Stage 02: "Slash Command Palette" — no matching issue
+- i2: "Persistent AI Memory (mem0)" — no matching issue
+- i2: "Slash Command Palette" — no matching issue
 
 **Orphans (issues without matching requirements):**
-- PROJ-176: "Entities blocked from 2 budgets with same name" — bug, not in ROADMAP
+- PROJ-176: "Entities blocked from 2 budgets with same name" — bug, not in roadmap
 
 ### Assignment
-- X issues verified in correct stage/project
+- X issues verified in correct `i{N}.` → `P{N}.` placement
 - Y misassignments found (list with corrections)
 
 ### Dependencies
@@ -239,19 +287,30 @@ Use `mcp__linear-server__linear_searchIssues` filtered by the `Parked` label. Fo
 | ... | | | |
 - **Recommendation:** Run `/strategy-sync` if any doc has >3 unsynced features
 
+### End-to-End Check — `pk status` Roadmap walk
+
+Run `pk status` and confirm its **Roadmap** section renders the `i{N}.` → current `P{N}.` walk correctly (current phase initiative, current sub-phase project, and the next issues underneath). This is the integration test for the whole phase surface: if `pk status` resolves the current phase to a different `i{N}.`/`P{N}.` than this audit computed, the naming/order/lifecycle is inconsistent somewhere above — reconcile before proceeding.
+
+| Source | Current phase | Current sub-phase |
+|--------|---------------|-------------------|
+| This audit (lowest non-Completed `i{N}.` / lowest live `P{N}.`) | i2 | P3 |
+| `pk status` Roadmap section | i2 | P3 |
+
+A mismatch is a hard flag — fix the surface, don't proceed to spec.
+
 ### Action Items (Priority Order)
 1. [Most critical action]
 2. [Next action]
 ...
 ```
 
-Ask the user: _"Want me to fix any of these issues now? I can create missing issues, set dependency links, or flag items for spec generation."_
+Ask the user: _"Want me to fix any of these issues now? I can create missing issues, rename/re-parent phase initiatives and projects, set dependency links, or flag items for spec generation."_
 
 ## Cadence
 
 Run at these moments:
 - **Before speccing a new phase** — ensures the plan is sound before you invest in specs
-- **At the start of a new stage** — validates stage setup is complete
+- **At the start of a new phase (`i{N}.` / `P{N}.`)** — validates the Linear phase surface is well-formed before work lands
 - **Monthly** — routine health check
 - **After major scope changes** — re-validate after adding/removing features
 

--- a/skills/01-light-spec/skill.md
+++ b/skills/01-light-spec/skill.md
@@ -57,8 +57,7 @@ Do NOT inline the exploration into the main session even if you think "I can jus
    - What patterns does the codebase already use for similar features?
    - What database tables, APIs, or UI components are involved?
    - Are there any obvious constraints or blockers?
-2. Read `.vbw-planning/linear-map.json` to identify which VBW phase and Linear project this work aligns with.
-3. Check `.vbw-planning/.execution-state.json` for current phase context.
+2. Identify the issue's **phase context** from Linear: which `i{N}.` initiative (phase) and `P{N}.` project (sub-phase) its Linear project belongs to. Derive it live (the issue's Linear project, or `pk next`) — there is no `linear-map.json` or `PHASES.md` to read. This anchors the spec to the right phase without guessing.
 
 ### Phase 3 — Draft Light Spec
 

--- a/skills/phase-plan/skill.md
+++ b/skills/phase-plan/skill.md
@@ -1,11 +1,13 @@
 ---
 name: phase-plan
-description: Compose the next execution phase from the roadmap, track phase state, promote to Needs Spec. Use when current phase is closing and you need to pick the next batch. Use when PHASES.md needs a fresh Current Phase entry.
+description: Confirm and advance the current execution phase on the Linear-native surface — derive the active i{N}. initiative / P{N}. project, promote its issues to Needs Spec, and roll the phase pointer forward by flipping Linear initiative/project state. Use when a phase is closing and you need to open the next one.
 ---
 
 # Phase Plan Skill
 
-You are a phase composition planner. Your job is to define, track, and manage execution phases. Read `method.config.md` for project context. A phase is a batch of issues selected for the current execution cycle — pulled from the roadmap, validated for dependencies, and promoted to "Needs Spec" so the spec pipeline can begin.
+You are a phase manager. Your job is to confirm which phase is current, promote its issues into the spec
+pipeline, and advance the phase pointer when it closes. Read `method.config.md § Phase Surface` for the
+naming-convention contract. **Phase state lives in Linear, not a file** — there is no `PHASES.md`.
 
 ## Triggers
 
@@ -18,240 +20,169 @@ You are a phase composition planner. Your job is to define, track, and manage ex
 
 | Argument | What it does |
 |----------|--------------|
-| (none) | Plan the next phase (or first phase if none exists) |
-| `--next` | Propose the next phase after the current one ships |
-| `--status` | Show current phase progress dashboard |
-| `--rebalance` | Adjust current phase composition (add/remove issues) |
-| `--dry-run` | Show proposed phase without promoting issues |
+| (none) | Confirm the current phase; promote its issues to Needs Spec |
+| `--next` | Advance the phase pointer: close the current sub-phase, open the next |
+| `--status` | Current-phase progress dashboard (derived live from Linear) |
+| `--rebalance` | Move issues between projects (re-scope the current sub-phase) |
+| `--dry-run` | Show what would change without writing to Linear |
 
 ## Prerequisites
 
-- `.vbw-planning/ROADMAP.md` must exist (output of `/roadmap-create`)
-- Linear board must be populated with issues
-- `method.config.md` must have Linear state IDs configured
+- Linear board populated with the native phase surface (run `/roadmap-create` first)
+- `method.config.md` with Linear state IDs and `§ Phase Surface`
 
-## Phase Model
+## Phase Model (Linear-native)
 
-### How Phases Relate to Milestones and Cycles
+| Concept | Linear construct | Naming | Role |
+|---------|-----------------|--------|------|
+| **Phase / wave** | Initiative | `i{N}. label` | Ordered roadmap phase. Status `Active`/`Planned`/`Completed`. |
+| **Sub-phase / execution batch** | Project | `P{N}. label` | The batch you're building now. State `started`/`planned`/`completed`. Issues live here. |
+| **Work item** | Issue | identifier | Moves On Deck → Needs Spec → … → Done. |
+| **Milestone** (optional) | Milestone | free | Intra-project gating, orthogonal to phases. |
 
-| Concept | Purpose | Linear Construct | Relationship to Phases |
-|---------|---------|-----------------|----------------------|
-| **Milestone (Work Package)** | Feature cluster — groups related issues for gating | Linear Milestone | A phase may pull from multiple milestones. A large milestone may span multiple phases. |
-| **Phase** | Execution batch — what we're building right now | Tracked in `.vbw-planning/PHASES.md` | The unit of work between `/phase-plan` and `/phase-plan --next`. |
-| **Cycle** (optional) | Time-boxed sprint — capacity planning and velocity tracking | Linear Cycle | Optional overlay. If used, a phase maps to a cycle for time-boxing. Not required. |
-
-**Milestones group by feature. Phases group by execution order.** These are different dimensions — milestones are permanent structure, phases are temporal.
-
-### Phase State
-
-Phases are tracked in `.vbw-planning/PHASES.md`, not in Linear. Linear tracks individual issue status; PHASES.md tracks which issues belong to which phase.
+**The current phase is *derived*, not declared.** Current phase = lowest `i{N}` initiative whose status
+≠ `Completed`; current sub-phase = lowest `P{N}` project in it whose state ∉ {`completed`,`canceled`}.
+This is exactly what `pk next` / `pk status` compute — this skill is the human-facing tool for the same
+surface. Order is the prefix number (numeric), never Linear `sortOrder`.
 
 ---
 
 ## Execution Steps
 
-### Default: Plan a Phase
+### Default: Confirm the current phase and promote its issues
 
-#### Step 1 — Assess Current State
+#### Step 1 — Derive current state from Linear
 
-1. Read `.vbw-planning/PHASES.md` if it exists
-2. Read `.vbw-planning/ROADMAP.md` for phase priorities
-3. Read `method.config.md` for Linear state IDs
-4. Fetch all issues in the current phase from Linear:
-   - Issues in On Deck, Needs Spec, Specced, Approved, Building, UAT
-   - Group by status to understand pipeline state
-
-If a current phase exists and has unfinished issues, warn:
-_"Phase {N} is still in progress ({M} issues not yet Done). Plan the next phase anyway, or check status with `--status`?"_
-
-#### Step 2 — Identify Candidates
-
-1. Fetch issues in "On Deck" status (next phase candidates)
-2. If On Deck is empty, check "Future Phases" for promotable issues
-3. For each candidate:
-   - Check dependencies via `mcp__linear-server__linear_getIssueById` with `includeRelations: true`
-   - Classify as **ready** (no unresolved blockers) or **blocked** (list blockers)
-   - Note milestone membership
-   - Note complexity if available from existing description
-
-#### Step 3 — Compose the Phase
-
-Propose a phase following these guidelines:
-
-| Guideline | Target |
-|-----------|--------|
-| Phase size | 3-8 issues |
-| Complexity mix | At least 1 Low for quick wins, no more than 2 High |
-| Dependency safety | No issue blocked by another issue outside the phase (unless the blocker is Done) |
-| Milestone coverage | Prefer completing milestones over splitting them |
-| Phase progress | Prioritize issues that unblock downstream work |
-
-Present the proposal:
+1. Fetch initiatives + their projects (with `status`/`state`). The current phase/sub-phase fall out of
+   the rule above. Cross-check with `pk status` (its Roadmap section shows the same walk).
+2. Fetch the current project's issues from Linear, grouped by status (On Deck, Needs Spec, Specced,
+   Approved, Building, UAT, Done).
+3. Report the derived position:
 
 ```
-## Proposed Phase {N}: {Theme or Phase Name}
-
-Issues (6):
-  1. PROJ-1  — User authentication [Low] (WP-1: Foundation)
-  2. PROJ-2  — Core data model [Medium] (WP-1: Foundation)
-  3. PROJ-3  — Basic search [Medium] (WP-2: Search)
-  4. PROJ-4  — Search filters [Low] (WP-2: Search)
-  5. PROJ-5  — Record detail view [Medium] (WP-2: Search)
-  6. PROJ-6  — Admin dashboard [Low] (WP-3: Admin)
-
-Milestones touched: WP-1 (2/4 issues), WP-2 (3/5 issues), WP-3 (1/6 issues)
-Complexity: 3 Low, 3 Medium, 0 High
-Dependencies: PROJ-3 depends on PROJ-2 (both in phase — OK)
-
-Not included (blocked):
-  - PROJ-7 — Advanced search (blocked by PROJ-3)
-  - PROJ-8 — Export reports (blocked by PROJ-5)
-
-Remaining On Deck: 4 issues for future phases
-
-Approve this phase? (y/n/edit)
+Current phase:     i1. Foundation   [Active]
+Current sub-phase: P2. Auth & Permissions   [started]
+  On Deck:     PROJ-3, PROJ-4, PROJ-5
+  Needs Spec:  PROJ-6
+  In flight:   PROJ-2 (Building)
+  Done:        PROJ-1
 ```
 
-#### Step 4 — Promote Issues
+If the current project's issues are **all Done**, this sub-phase is complete — recommend `--next`.
 
-On approval:
+#### Step 2 — Promote this sub-phase's issues to Needs Spec
 
-1. Move selected issues from "On Deck" to "Needs Spec" via `mcp__linear-server__linear_updateIssue`:
-   - `stateId`: Needs Spec state ID from `method.config.md`
-2. If On Deck is now depleted, promote issues from "Future Phases" to "On Deck" for the next phase pipeline
-3. Post a Linear comment on each promoted issue: `"Assigned to Phase {N}. Ready for /light-spec."`
+The project membership *is* the batch (set at `/roadmap-create`). This skill moves that batch into the
+spec pipeline. On confirmation:
 
-#### Step 5 — Write PHASES.md
+1. Move the current project's `On Deck` issues → `Needs Spec` via `mcp__linear-server__linear_updateIssue`
+   (`stateId` from `method.config.md`). Skip issues blocked by an unfinished issue outside the project.
+2. Post a Linear comment on each: `"Promoted in {i{N}. phase} / {P{N}. sub-phase}. Ready for /light-spec."`
+3. Do **not** write any file. The Linear state change *is* the record.
 
-Create or update `.vbw-planning/PHASES.md`:
-
-```markdown
-# Phases
-
-## Current Phase: Phase {N}
-- **Started:** {date}
-- **Theme:** {theme or phase name}
-- **Milestone(s):** {list}
-- **Issues:**
-  - PROJ-1 — User authentication [Needs Spec]
-  - PROJ-2 — Core data model [Needs Spec]
-  - PROJ-3 — Basic search [Needs Spec]
-  - PROJ-4 — Search filters [Needs Spec]
-  - PROJ-5 — Record detail view [Needs Spec]
-  - PROJ-6 — Admin dashboard [Needs Spec]
-
-## Next Phase (proposed)
-- **Issues (On Deck):** PROJ-9, PROJ-10, PROJ-11, PROJ-12
-- **Blocked until Phase {N} completes:** PROJ-7, PROJ-8
-
-## Completed Phases
-(none yet)
-```
-
-#### Step 6 — Summary
+#### Step 3 — Summary
 
 ```
-## Phase {N} Planned
+## Phase confirmed: i1. Foundation / P2. Auth & Permissions
 
-Issues promoted to "Needs Spec": {N}
-On Deck refilled: {N} issues promoted from Future Phases
+Promoted to Needs Spec: {N}
+Held (blocked):         {M}  — {ids + blockers}
 
 Next steps:
-  - /roadmap-review — validate the phase before speccing
-  - /light-spec PROJ-1 — start speccing the first issue
-  - /phase-plan --status — check progress anytime
+  - /roadmap-review   — validate before speccing
+  - /light-spec PROJ-3 — start the first issue
+  - pk next            — same view, anytime
 ```
 
 ---
 
-### `--status`: Phase Progress Dashboard
+### `--next`: Advance the phase pointer
 
-1. Read `.vbw-planning/PHASES.md` for current phase composition
-2. Fetch current status of each phase issue from Linear
+Close the current sub-phase and open the next. Order is by `P{N}.`, then by `i{N}.` at a phase boundary.
+
+1. **Confirm the current sub-phase is done** (all its issues Done/Canceled). If not, warn and require
+   explicit confirmation to advance anyway.
+2. Set the current project's state → `completed` (`linear_updateProject`).
+3. **Find the next live sub-phase:**
+   - Next `P{N}.` project in the same initiative (by number) that isn't completed → set it `started`.
+   - If none remain, the **phase** is done: set the current initiative `Completed`, set the next `i{N}.`
+     initiative `Active`, and `started` on its first `P{N}.` project.
+4. Run the default flow (Steps 1–3) on the newly-current sub-phase to promote its issues.
+5. Brief retrospective:
+
+```
+## i1.P1 (Data Foundation) closed
+Issues: {done}/{total} Done   ({failed} returned to Approved)
+Advanced to: i1. Foundation / P2. Auth & Permissions
+```
+
+---
+
+### `--status`: Phase Progress Dashboard (derived from Linear)
+
+1. Derive current phase/sub-phase from Linear (the rule above).
+2. Fetch each current-project issue's status.
 3. Display:
 
 ```
-## Phase {N} Status — {date}
+## i1. Foundation / P2. Auth & Permissions — {date}
 
-| Issue | Title | Status | Days in Status |
-|-------|-------|--------|---------------|
-| PROJ-1 | User authentication | Done | — |
-| PROJ-2 | Core data model | Building | 2d |
-| PROJ-3 | Basic search | Specced | 1d |
-| PROJ-4 | Search filters | Needs Spec | 3d |
-| PROJ-5 | Record detail view | UAT | 0d |
-| PROJ-6 | Admin dashboard | Approved | 1d |
+| Issue  | Title               | Status     | Days in status |
+|--------|---------------------|------------|----------------|
+| PROJ-1 | Login / session     | Done       | —              |
+| PROJ-2 | Roles + RLS         | Building   | 2d             |
+| PROJ-3 | Permission UI       | Needs Spec | 3d             |
 
-Progress: 1/6 Done (17%)
-Pipeline: 1 Needs Spec → 1 Specced → 1 Approved → 1 Building → 1 UAT → 1 Done
+Sub-phase progress: 1/3 Done
+Roadmap:  i1[Active] → P2(current) → P3 …   |   i2[Planned] …
 
 Alerts:
-  - PROJ-4 has been in "Needs Spec" for 3 days — run /light-spec PROJ-4
-  - PROJ-2 has been in "Building" for 2 days — check progress
-
-Phase started: {date} ({N} days ago)
+  - PROJ-3 in "Needs Spec" 3d — run /light-spec PROJ-3
 ```
+
+(`pk status` shows the cross-phase roadmap walk; `--status` zooms into the current sub-phase.)
 
 ---
 
-### `--next`: Plan the Next Phase
+### `--rebalance`: Re-scope the current sub-phase
 
-1. Archive the current phase to "Completed Phases" in PHASES.md
-2. Run the default phase planning flow (Steps 1-6)
-3. Include a brief retrospective:
+Move issues between projects in Linear (the membership *is* the batch):
 
-```
-## Phase {N-1} Retrospective
-
-Completed: {date} ({N} days)
-Issues: {done}/{total} completed
-  - {failed} failed (returned to Approved)
-
-Complexity accuracy:
-  - Low estimates: averaged {X}h (target: 2-4h)
-  - Medium estimates: averaged {X}h (target: 6-10h)
-```
-
----
-
-### `--rebalance`: Adjust Current Phase
-
-1. Show current phase composition
-2. Options:
-   - **Add issues:** Move from On Deck → Needs Spec, add to PHASES.md
-   - **Remove issues:** Move from Needs Spec → On Deck (only if not yet started), remove from PHASES.md
-   - **Replace:** Remove one, add another
-3. Validate dependencies after rebalance
-4. Update PHASES.md
+1. Show the current project's issues + adjacent projects' On Deck issues.
+2. **Add:** reassign an issue's `projectId` to the current project (`linear_updateIssue`), then promote.
+3. **Remove:** reassign an issue out to a later `P{N}.` project (only if not yet started).
+4. Validate dependencies after the move (no issue left blocked by one outside its phase).
 
 ---
 
 ## Rules
 
-- **Target 3-8 issues per phase.** Fewer is fine for a first phase or complex work. More than 8 creates coordination overhead.
-- **Dependencies within the phase should be satisfiable.** If PROJ-3 depends on PROJ-2, both should be in the phase (or PROJ-2 should already be Done).
-- **Prefer completing milestones over splitting them.** Split only when the WP is too large (>8 issues) or has mixed priorities.
-- **On Deck is the staging area.** Issues move: Future Phases → On Deck → Needs Spec. `/phase-plan` manages the On Deck → Needs Spec promotion. Refilling On Deck from Future Phases happens automatically.
-- **PHASES.md is the phase registry.** Linear tracks individual issue status. PHASES.md tracks phase composition and history.
-- **Human decides phase composition.** Present a recommendation with rationale, but the user approves.
+- **The current phase is derived, never declared.** Don't write a "Current Phase" anywhere — read it
+  from Linear initiative/project state.
+- **Order is the prefix number.** `P2` before `P10`; `i1` before `i2`. Never Linear `sortOrder`.
+- **A project is the execution batch.** Roadmap-create sets membership; phase-plan promotes and advances.
+  Keep projects to ~3–8 issues; if a `P{N}.` is too big, split it into `P{N}a`/renumber in `/roadmap-create`.
+- **Dependencies within the sub-phase should be satisfiable** (blocker Done, or in the same project).
+- **Advance deliberately.** `--next` only closes a sub-phase the human confirms is done.
+- **No files.** Phase state is Linear state. Never write `PHASES.md` / `linear-map.json`.
 
 ## Common Drifts to Avoid
 
-When you encounter these situations, take the safer path:
-
-- **Overloading a phase** → Keep to 3-8 issues. Larger phases create coordination overhead and hide priorities.
-- **Including blocked issues optimistically** → Only include issues whose blockers are Done. Planning on hope leads to stalled phases.
-- **Splitting a milestone across many phases** → If you're splitting across 4+ phases, the milestone itself may be too big — consider breaking it up in Linear.
-- **Stale issues in "Needs Spec"** → If an issue has been in "Needs Spec" for >3 days, investigate. Either spec it or swap it out for something ready.
+- **Declaring a "current phase"** → it's derived. If `pk next` and this skill disagree, a prefix is
+  malformed or a Linear state is stale — fix the Linear state, don't add a pointer file.
+- **Advancing with issues unfinished** → only `--next` past a sub-phase whose issues are Done. Planning
+  on hope leaves stalled phases.
+- **Over-stuffing a project** → keep ~3–8 issues. Re-scope via `--rebalance` or split in `/roadmap-create`.
 
 ## Next-step output
 
-After phase planning completes, emit an inline `➜ Next:` line in your terminal output pointing to the highest-leverage first `/01-light-spec` call. Include why that issue was picked, what parallelizes after it, and what's blocked until it lands. Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
+After phase work, emit an inline `➜ Next:` line pointing to the highest-leverage first `/01-light-spec`
+call. Do **not** write a `NEXT.md` — `pk next` reads "what's next?" live from Linear.
 
 ## Related
 
-- `/roadmap-create` — previous step: creates the roadmap and populates Linear
-- `/roadmap-review` — run after phase planning to validate before speccing
-- `/light-spec` — next step: spec the first issue in the phase
-- `/work` — executes specced issues (uses milestones for gating, not phases)
-- `pk status` / `pk next` — quick board view (complementary to `--status`)
+- `/roadmap-create` — previous step: authors the Linear Initiative→Project→Issue hierarchy
+- `/roadmap-review` — validate the hierarchy before speccing
+- `/light-spec` — next step: spec the first promoted issue
+- `pk status` / `pk next` — the same derived phase surface, from the CLI
+- `method.config.md § Phase Surface` — the naming-convention contract

--- a/skills/pk-exit/skill.md
+++ b/skills/pk-exit/skill.md
@@ -94,7 +94,7 @@ If the session was pure execution with no decisions, write "—".>
 
 - The v1 `/end-session` skill (now archived) was the prior art. This skill restores its core function (narrative session log) without the v1 baggage (NEXT.md updates, branch-status orchestration — those moved to `pk next` / `pk done`).
 - The bash Stop hook was retired because: (a) Stop fires on every assistant turn, producing duplicate commit-list entries; (b) bash can't write narrative; (c) `pk done` doesn't need a journal cache — it reads `git log` directly.
-- This skill writes one file per session. It does not update Linear (that's `pk done`'s job at issue-close) and does not update PHASES.md (that's `phase-plan`'s job).
+- This skill writes one file per session. It does not update Linear (that's `pk done`'s job at issue-close) and does not advance the phase surface (that's `/phase-plan`'s job, via Linear initiative/project state).
 
 ## What this skill does NOT do
 

--- a/skills/review-plan/skill.md
+++ b/skills/review-plan/skill.md
@@ -45,7 +45,7 @@ The `plan-reviewer` agent fills that gap. This skill orchestrates the call.
 Determine which `PLAN.md`(s) to review:
 
 1. **Explicit phase slug** (`/review-plan phase-1-data-foundation`) — use directly
-2. **Linear issue ID** (`/review-plan PROJ-123`) — resolve via `.vbw-planning/linear-map.json` or by reading the current git branch (`feature/proj-123-*` → look up phase containing this plan)
+2. **Linear issue ID** (`/review-plan PROJ-123`) — resolve by reading the current git branch (`feature/proj-123-*` → look up the phase directory containing this plan)
 3. **No argument** — auto-detect: read `.vbw-planning/STATE.md` for the active phase; if ambiguous, list phases with un-reviewed PLAN.md and ask the user to pick
 
 Find every `*-PLAN.md` in the phase dir:

--- a/skills/roadmap-create/skill.md
+++ b/skills/roadmap-create/skill.md
@@ -1,11 +1,11 @@
 ---
 name: roadmap-create
-description: Build a staged roadmap from strategy docs and populate Linear with issues, projects, milestones. Use as Stage 0 step 6 after /strategy-create. Use when bootstrapping the Linear hierarchy for a new project. Merges with VBW phases without overwriting.
+description: Build a staged roadmap from strategy docs and author it directly into Linear as the native phase surface — Initiatives (i{N}. phases), Projects (P{N}. sub-phases), and Issues. Use as Stage 0 step 6 after /strategy-create, when bootstrapping the Linear hierarchy for a new project.
 ---
 
 # Roadmap Create Skill
 
-You are a roadmap builder. Your job is to extract requirements from strategy docs and the project definition, create a structured ROADMAP.md, and populate Linear with the initial issue hierarchy. Read `method.config.md` for project context.
+You are a roadmap builder. Your job is to extract requirements from strategy docs and the project definition and author them into **Linear** as the native phase surface. Read `method.config.md` for project context — especially **§ Phase Surface**, which defines the naming convention this skill must apply.
 
 ## Triggers
 
@@ -17,255 +17,128 @@ You are a roadmap builder. Your job is to extract requirements from strategy doc
 
 - `project-definition.md` must exist (output of `/define`)
 - `Strategy/` docs should exist (output of `/strategy-create`)
-- `.vbw-planning/` directory should be scaffolded (run `/vbw:init` first)
-- `method.config.md` should exist with Linear configuration
+- `method.config.md` should exist with Linear configuration (and `§ Phase Surface`)
 - Linear MCP server must be connected (`mcp__linear-server__*` tools available)
 
-If `.vbw-planning/` doesn't exist, warn: _"Run `/vbw:init` first to scaffold the planning directory."_
+> **No `/vbw:init` step.** The phase surface is now Linear itself — there is no `.vbw-planning/`
+> scaffold, `PHASES.md`, or `linear-map.json` to create. The Linear Initiative→Project→Issue
+> hierarchy *is* the roadmap. (Existing projects with legacy `.vbw-planning/` files keep working via
+> bin/pk's fallback; this skill no longer writes them.)
 
 ## Purpose
 
-Bridge the gap between "here's what the product does" (strategy docs) and "here are the work items" (Linear board). Every requirement in the roadmap traces back to a strategy doc section. Every Linear issue traces to a roadmap requirement.
+Bridge "here's what the product does" (strategy docs) and "here are the work items" (Linear board).
+Every requirement traces to a strategy doc section; every Linear issue traces to a requirement. The
+output is a **live, ordered Linear hierarchy** that `pk next` / `pk status` read directly — no mirror
+file to drift.
+
+## The phase surface (read `method.config.md § Phase Surface` first)
+
+| Roadmap concept | Linear construct | Naming | Ordering |
+|-----------------|-----------------|--------|----------|
+| Stage / phase | **Initiative** | `i{N}. label` (e.g. `i1. Foundation`) | by `{N}`, numeric |
+| Feature cluster / sub-phase | **Project** | `P{N}. label` (e.g. `P2. Search`) | by `{N}`, numeric, within its initiative |
+| Requirement | **Issue** | (Linear identifier) | priority / state |
+| Work Package (optional) | **Milestone** | (free) | orthogonal grouping inside a project |
+
+- **The `i{N}.` / `P{N}.` prefixes are mandatory** — they carry order *and* mark which initiatives are
+  delivery phases. Linear's `sortOrder` is NOT used (it's an unreliable drag-rank).
+- Number phases and sub-phases by execution order. Leave gaps if useful (`i1, i2, i3`).
+- Strategic / north-star initiatives that aren't delivery phases: **do not** give them an `i{N}.`
+  prefix — they'll be correctly ignored by the roadmap walk.
 
 ## Execution Steps
 
-### Phase 0 — Reconcile with VBW Roadmap
-
-VBW's `/vbw:init` generates `.vbw-planning/ROADMAP.md` with phases derived from codebase analysis. If this file already exists, **reconcile — don't overwrite**.
-
-1. Check if `.vbw-planning/ROADMAP.md` exists and has content.
-2. If it does:
-   - Read the existing VBW roadmap — note its phases, structure, and any requirements already captured
-   - Tell the user: _"VBW has already drafted a roadmap with {N} phases from codebase analysis. I'll merge strategy-derived requirements into those phases rather than replace them. Proceed?"_
-   - Use VBW's phases as the canonical phase structure
-   - Add strategy-derived requirements to the appropriate phases
-   - Preserve any VBW-specific notes or structure
-3. If it doesn't exist (fresh project, no VBW init yet):
-   - Proceed with full generation from scratch
-   - Recommend the user run `/vbw:init` first for a richer starting point
-
 ### Phase 1 — Extract Requirements
 
-1. Read `project-definition.md` for stage breakdown, exit criteria, and workflows
-2. Read all Strategy docs listed in `method.config.md`'s Strategy Docs table
-3. **If VBW roadmap exists**: map its phases to the project definition stages. They should align — if they don't, flag the discrepancy to the user and resolve before proceeding.
-4. For each stage/phase:
-   - Extract features, capabilities, and requirements from the strategy docs
-   - Each requirement should be:
-     - **Concrete** — "User can search properties by criteria" not "search functionality"
-     - **Independent** — can be specced and built as a single Linear issue
-     - **Traceable** — references the strategy doc section it comes from
-   - Identify dependencies between requirements
+1. Read `project-definition.md` for stage breakdown, exit criteria, and workflows.
+2. Read all Strategy docs listed in `method.config.md`'s Strategy Docs table.
+3. Map the project-definition **stages → Initiatives** (`i{N}.`). Stage 1 = `i1.`, Stage 2 = `i2.`, etc.
+4. For each stage, extract requirements. Each requirement should be:
+   - **Concrete** — "User can search properties by criteria", not "search functionality"
+   - **Independent** — buildable as a single Linear issue
+   - **Traceable** — references the strategy doc section it comes from
+   - Note dependencies between requirements.
+5. Group each stage's requirements into **feature clusters → Projects** (`P{N}.`), ordered by execution
+   priority within the stage. Each cluster is cohesive (related features) and focused (not a catch-all):
+   - e.g. `i1.` Foundation → `P1. Data Foundation`, `P2. Auth & Permissions`, `P3. Search & CRUD`.
 
-5. Group requirements into **feature clusters** — logical groupings that will become Linear Projects:
-   - e.g., "Data Foundation", "Search & CRUD", "Auth & Permissions", "Reports"
-   - Each cluster should be cohesive (related features) and focused (not a catch-all)
+### Phase 2 — Draft the roadmap for approval
 
-### Phase 2 — Draft ROADMAP.md
+Present the proposed hierarchy as a tree for the human to approve **before** creating anything in Linear:
 
-**Important:** VBW's `/vbw:init` uses a different schema than Pipekit's original format:
-- **VBW schema:** phase-based with `goal`, `requirements` (free-text), `success_criteria`
-- **Pipekit schema:** stage-based with `REQ-IDs`, `feature clusters`, `dependencies`
+```
+i1. Foundation (Stage 1 — MVP)
+  P1. Data Foundation
+    - REQ-001 Core data model            ← Strategy/DataModel §2
+    - REQ-002 Migrations + RLS baseline   ← Strategy/Permissions §1
+  P2. Auth & Permissions
+    - REQ-003 Login / session             ← Strategy/Permissions §3  (blocked by REQ-001)
+  P3. Search & CRUD
+    - REQ-004 Record list + detail        ← Strategy/UXReference §4
 
-These overlap but aren't identical. The canonical merged format below keeps both.
-
-**If merging with a VBW-generated roadmap (most common):**
-
-Preserve VBW's phase names, goals, and success criteria. Add Pipekit's requirement detail as subsections within each phase. Use the merged schema:
-
-```markdown
-# Roadmap
-
-**Project:** {project name}
-**Last updated:** {date}
-**Source:** VBW codebase analysis + project-definition.md + Strategy/ docs
-
-## Phase 1: {VBW's phase name}
-
-**Goal:** {VBW's phase goal}
-**Success Criteria:** {VBW's success criteria — preserve as-is}
-
-### Requirements
-- REQ-001: {requirement from strategy docs} — ref: {Strategy doc §section}
-- REQ-002: {requirement} — ref: {Strategy doc §section}
-
-### Feature Clusters
-- Data Foundation: REQ-001, REQ-002
-- Auth & Permissions: REQ-003
-
-### Dependencies
-- REQ-003 blocked by REQ-001 (needs data model before CRUD)
-
-## Phase 2: {VBW's phase name}
-...
+i2. Reporting (Stage 2)
+  P1. Dashboards
+    - REQ-010 ...
 ```
 
-**If writing from scratch (no VBW roadmap yet — rare):**
+Optionally also write a human-readable narrative `ROADMAP.md` at the project root (per the curated-roadmap
+doctrine in `method.md` — a legitimate *optional* artifact). **Do not** write `linear-map.json` or
+`.vbw-planning/PHASES.md` — those are retired; the Linear hierarchy is the source of truth. Tell the user:
 
-Use the same merged schema but fill in phase names/goals from `project-definition.md` stages. Recommend running `/vbw:init` first next time.
+_"Proposed {K} phases (i1–i{K}) with {M} sub-phases (projects) and {N} requirements. Approve before I
+create them in Linear? (y/n/edit)"_
 
-```markdown
-# Roadmap
+### Phase 3 — Author the hierarchy in Linear
 
-**Project:** {project name}
-**Last updated:** {date}
-**Source:** project-definition.md + Strategy/ docs
+**Preflight: check the Linear MCP connection** (`mcp__linear-server__linear_getTeams` or `linear_getProjects`). If it fails, tell the user how to reconnect and stop — **do not fabricate IDs**.
 
-## Phase 1: {Stage Name} (MVP)
+On approval, create top-down. Apply the naming convention exactly.
 
-**Goal:** {from project definition}
-**Success Criteria:** {from project definition exit criteria}
-
-### Requirements
-- REQ-001: {requirement} — ref: {Strategy doc §section}
-
-### Feature Clusters
-- {cluster name}: REQ-001, REQ-002
-
-### Dependencies
-- REQ-003 blocked by REQ-001
-
-## Future (Parking Lot)
-- REQ-100: {deferred item} — target: later phase
-```
-
-**Write the file to `.vbw-planning/ROADMAP.md` and point the user to it** (per the "Documents, not terminal walls" rule from `/startup`). Tell them:
-
-_"Written merged roadmap to `.vbw-planning/ROADMAP.md`. Preserved VBW's N phases, added M requirements across K feature clusters with D dependencies. Review in your editor and let me know what to change."_
-
-### Phase 3 — Linear Setup
-
-**Preflight: check Linear MCP connection.** Try calling `mcp__linear-server__linear_getTeams` or `linear_getIssues`. If it fails:
-
-_"Linear MCP isn't connected. I can't create issues without it. Options:"_
-1. _"Reconnect now — run `claude mcp add --transport http --scope user linear-server https://mcp.linear.app/mcp` in terminal, restart Claude Code, then resume with `/roadmap-create --verify` to pick up where we stopped."_
-2. _"Continue without Linear — I'll write the roadmap and skip Linear population. You can re-run `/roadmap-create` later once Linear is connected."_
-
-**Do not fabricate Linear IDs.** If MCP is down, set all `linear_id` fields in `linear-map.json` to `null` and note "Linear population pending" in the final summary.
-
-Once Linear MCP is confirmed working, determine what can be automated vs. what needs manual setup.
-
-**Automate via MCP (do these):**
-
-1. **Create Issues** — for each requirement, via `mcp__linear-server__linear_createIssue`:
-   - `team`: from `method.config.md`
-   - `title`: requirement title
-   - `description`: requirement detail + strategy doc reference
-   - `state`: Stage 1 → "On Deck" | Stage 2+ → "Future Phases" | Parking lot → "Ideas"
+1. **Initiatives** (the phases) — one per stage, named `i{N}. label`:
+   - If your MCP exposes an initiative-create tool (e.g. `mcp__linear-server__linear_createInitiative`),
+     use it. Otherwise create them in the Linear UI (Settings → Initiatives) with the `i{N}.` prefix and
+     tell the user exactly which to make. Set initiative status: current stage → `Active`, later stages →
+     `Planned`.
+   - **Verify the tool name against your installed MCP** — initiative create/update support varies by
+     server. Naming carries the order regardless, so manual UI creation is always a valid fallback.
+2. **Projects** (sub-phases) — within each initiative, named `P{N}. label`, via `linear_createProject`
+   (set its `initiativeId`/parent initiative, and `state`: current → `started`, else `planned`/`backlog`).
+3. **Issues** — for each requirement, via `mcp__linear-server__linear_createIssue`:
+   - `team`: from `method.config.md`; `project`: the `P{N}.` project it belongs to
+   - `title`, `description` (+ strategy doc reference)
+   - `state`: Stage 1 → `On Deck` | later stages → `Future Phases`
    - `priority`: 0 (None) — triage sets real priority
+4. **Dependency relations** — `linear_createIssueRelation` for each `blocked_by`.
+5. **Labels** — type label (Feature/Improvement/Research) + domain label per feature cluster.
+6. **Milestones (optional)** — only for a project with >6 issues that benefits from intra-project gating.
 
-2. **Set Dependency Relations** — for each dependency in the roadmap:
-   - Use `mcp__linear-server__linear_createIssueRelation` to set `blocked_by` relations
+### Phase 4 — Verify the surface
 
-3. **Apply Labels** — for each issue:
-   - Type label (Feature, Improvement, Research, etc.)
-   - Domain label (project-specific, based on feature cluster)
+Confirm the native phase surface is well-formed (this is what `pk next` will read):
 
-4. **Create Milestones (Work Packages)** — for each feature cluster that has >3 issues:
-   - Group issues into work packages of 3-8 issues
-   - Assign issues to their milestone
+1. Every delivery initiative is named `i{N}.` with a unique, ordered `{N}`.
+2. Every project is named `P{N}.` with a unique `{N}` within its initiative.
+3. Every requirement has an issue, placed in the right `P{N}.` project.
+4. The earliest non-`Completed` initiative is `Active`; its earliest live project is `started`.
+5. Run `pk status` — the **Roadmap** section should list your `i{N}.` initiatives in order with the
+   current `P{N}.` project for each. If it's empty, a prefix is missing or malformed.
 
-**Instruct manually (tell the user to do these):**
-
-Some Linear operations may not be available via MCP. For each, give explicit instructions:
-
-```
-## Manual Linear Setup Required
-
-The following must be done in the Linear UI:
-
-1. **Create Initiatives** (Settings → Initiatives):
-   - "{Stage 1 Name}" — maps to Stage 1
-   - "{Stage 2 Name}" — maps to Stage 2
-
-2. **Create Projects** (within each Initiative):
-   Stage 1:
-     - "{Feature Cluster 1}" — contains: {issue list}
-     - "{Feature Cluster 2}" — contains: {issue list}
-   Stage 2:
-     - "{Feature Cluster 3}" — contains: {issue list}
-
-3. **Verify Workflow States** match method.config.md:
-   - If states are not yet configured, follow sop/Linear_SOP.md
-
-After completing manual setup, run `/roadmap-create --verify` to check everything.
-```
-
-### Phase 4 — Write linear-map.json
-
-Create `.vbw-planning/linear-map.json` mapping roadmap IDs to Linear IDs:
-
-```json
-{
-  "stages": {
-    "stage-1": {
-      "name": "Stage 1: MVP",
-      "initiative_id": null,
-      "clusters": {
-        "data-foundation": {
-          "project_id": null,
-          "issues": {
-            "REQ-001": { "linear_id": "XXX-1", "title": "..." },
-            "REQ-002": { "linear_id": "XXX-2", "title": "..." }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-Fields with `null` are populated after manual Linear setup or on subsequent runs.
-
-### Phase 5 — Verify (also available as `--verify`)
-
-Run a completeness check:
-
-1. Every roadmap requirement has a Linear issue
-2. Every Linear issue has the correct state for its stage
-3. Dependency relations are set in Linear
-4. Labels are applied
-5. Milestones are assigned
-6. `linear-map.json` has no null IDs (if manual setup is done)
-
-Report:
+### Phase 5 — Summary
 
 ```
-## Roadmap Verification
+## Roadmap Created (Linear-native)
 
-Requirements: {N} total
-Linear issues created: {N}
-Dependencies set: {N}
-Milestones created: {N}
+Phases (initiatives):   i1–i{K}
+Sub-phases (projects):  {M}
+Requirements (issues):  {N}  ({Stage 1} → On Deck, later → Future Phases)
+Dependencies:           {N} relations
 
-Gaps:
-  - {N} Initiative IDs missing (manual setup needed)
-  - {N} Project assignments missing (manual setup needed)
-
-Run /roadmap-review for a full health check.
-```
-
-### Phase 6 — Summary
-
-```
-## Roadmap Created
-
-File: .vbw-planning/ROADMAP.md
-Issues created: {N} across {M} feature clusters
-
-Stage 1: {N} requirements → {M} issues (On Deck)
-Stage 2: {N} requirements → {M} issues (Future Phases)
-Parking lot: {N} items (Ideas)
-
-Dependencies: {N} relations set
-Milestones: {N} work packages created
-
-Manual setup needed: {list of manual steps}
+Verify:  pk status   (Roadmap section shows i1 → current P{N}.)
 
 Next steps:
-  - Complete manual Linear setup (see instructions above)
-  - /phase-plan — select the first execution phase
-  - /roadmap-review — validate everything before speccing
+  - /roadmap-review — validate the hierarchy before speccing
+  - /phase-plan     — confirm the current phase and promote its first issues to Needs Spec
 ```
 
 ## Arguments
@@ -273,35 +146,37 @@ Next steps:
 | Argument | What it does |
 |----------|--------------|
 | (none) | Full roadmap creation flow |
-| `--verify` | Run verification only (Phase 5) — useful after manual Linear setup |
-| `--dry-run` | Draft the roadmap without creating Linear issues |
+| `--verify` | Run Phase 4 only — re-check the Linear surface (useful after manual initiative creation) |
+| `--dry-run` | Draft + present the tree (Phases 1–2) without creating anything in Linear |
 
 ## Rules
 
-- **Requirements, not tasks.** Each roadmap item is a feature or capability (WHAT), not an implementation step (HOW). Implementation decomposition happens in `/light-spec` and VBW planning.
-- **Trace everything.** Every requirement references a strategy doc section. Untraced requirements are orphans — they need a strategy doc home or they shouldn't be in the roadmap.
-- **Automate what you can.** Create issues, set relations, apply labels via MCP. Give clear manual instructions for the rest.
-- **Human approves the roadmap before Linear population.** Don't create issues until the roadmap structure is approved.
-- **Stage 1 issues go to On Deck.** Not "Needs Spec" — that happens when `/phase-plan` selects them for the first phase.
+- **The naming convention is non-negotiable.** `i{N}.` initiatives, `P{N}.` projects, numeric order.
+  A delivery initiative without an `i{N}.` prefix is invisible to `pk next`.
+- **Requirements, not tasks.** Each issue is a feature/capability (WHAT), not an implementation step.
+  Decomposition happens in `/light-spec` and `/work`.
+- **Trace everything.** Every requirement references a strategy doc section. Untraced = orphan.
+- **Human approves the tree before Linear population.** Don't create issues until the structure is approved.
+- **Stage 1 issues go to On Deck** — not "Needs Spec" (that's `/phase-plan`'s job).
+- **No mirror files.** Never write `linear-map.json` or `.vbw-planning/PHASES.md`. The Linear hierarchy is the truth.
 
 ## Common Drifts to Avoid
 
-When you encounter these situations, take the safer path:
-
-- **Vague requirements** → If a requirement is too vague to be an issue, it's too vague for the roadmap. Push it back to strategy docs or split it into concrete deliverables.
-- **Deferring dependencies** → Map dependencies during roadmap creation, not after. Dependencies set after the fact tend to miss relationships that were obvious during planning.
-- **Untraceable requirements** → Every requirement should trace to a strategy doc section. If it doesn't, either the strategy docs need updating or the requirement is an orphan.
-- **Flat issue lists** → Create the full Linear hierarchy (Initiatives/Projects/Milestones). Issues without structure become unsortable quickly.
+- **Unprefixed delivery initiatives** → if it's a phase, it gets an `i{N}.`; if it's a strategic theme, it doesn't. Mixing them up makes `pk next` either skip a phase or surface a non-phase.
+- **Relying on Linear `sortOrder`** → never. Order is the prefix number, parsed numerically. Drag-order in the UI is cosmetic.
+- **Vague requirements** → too vague to be an issue = too vague for the roadmap. Push back to strategy docs.
+- **Flat issue lists** → create the full Initiative→Project hierarchy so `pk next`/`pk status` can scope.
 
 ## Next-step output
 
-After roadmap creation completes, emit an inline `➜ Next:` line in your terminal output pointing to `/roadmap-review` (for validation) or `/phase-plan` (if validation already passed). Do **not** write a `NEXT.md` file — v2 retired the mirror; `pk next` reads "what's next?" live from Linear.
+After roadmap creation, emit an inline `➜ Next:` line pointing to `/roadmap-review` (validation) or
+`/phase-plan`. Do **not** write a `NEXT.md` or `linear-map.json` — `pk next` reads "what's next?" live
+from Linear.
 
 ## Related
 
 - `/define` — previous step: creates the project definition
 - `/strategy-create` — creates the strategy docs this skill reads
-- `/vbw:init` — scaffolds `.vbw-planning/` (run before this skill)
-- `/phase-plan` — next step: select issues for the first execution phase
-- `/roadmap-review` — validates the roadmap after creation
-- This skill IS the Linear seeding step (no separate seed skill needed)
+- `/phase-plan` — next step: confirm the current phase, promote its first issues to Needs Spec
+- `/roadmap-review` — validates the Linear hierarchy after creation
+- `method.config.md § Phase Surface` — the naming-convention contract this skill applies

--- a/skills/startup/skill.md
+++ b/skills/startup/skill.md
@@ -46,12 +46,11 @@ The first thing `/startup` does is create (or read) a **`{folder-name}-startup.m
 | 5 | Strategy Docs | ⬜ Not started | — |
 | 5.5 | Design Direction | ⬜ Not started | — |
 | 6 | Method Sync | ⬜ Not started | — |
-| 7 | VBW Init | ⬜ Not started | — |
-| 8 | Roadmap | ⬜ Not started | — |
-| 9 | Project Skills | ⬜ Not started | — |
-| 10 | CLAUDE.md & Rules | ⬜ Not started | — |
-| 11 | Validate | ⬜ Not started | — |
-| 12 | Phase Plan | ⬜ Not started | — |
+| 7 | Roadmap | ⬜ Not started | — |
+| 8 | Project Skills | ⬜ Not started | — |
+| 9 | CLAUDE.md & Rules | ⬜ Not started | — |
+| 10 | Validate | ⬜ Not started | — |
+| 11 | Phase Plan | ⬜ Not started | — |
 
 ## Project Summary
 
@@ -121,9 +120,8 @@ For each artifact in the foundation contract (see `method.md` § Foundation Cont
 | Project definition | `project-definition.md` | Run `/define` to retrofit |
 | Strategy docs | `Strategy/*.md` (matching `method.config.md` manifest) | Run `/strategy-create` to retrofit, or wait for `/strategy-from-code` in v1.4.0 |
 | Project config | `method.config.md` | Run `/startup --mode=brownfield` (it populates config from existing project state) |
-| VBW scaffold | `.vbw-planning/` | Run `/vbw:init` |
-| Linear-VBW map | `.vbw-planning/linear-map.json` | Run `/roadmap-create` (creates the map) |
-| Phase plan | `.vbw-planning/PHASES.md` | Run `/phase-plan` |
+| Phase hierarchy | Linear `i{N}.` initiatives with `P{N}.` projects | Run `/roadmap-create` (authors the `i{N}.`/`P{N}.` hierarchy directly in Linear) |
+| Phase plan | Current phase derivable live from Linear (`pk next` / `pk status`) | Run `/phase-plan` |
 
 For the Strategy docs check, read `method.config.md` § Strategy Docs to get the manifest, then verify each listed file exists. If `method.config.md` itself is missing, treat the manifest check as deferred — flag the config gap as the blocker.
 
@@ -134,14 +132,14 @@ For the Strategy docs check, read `method.config.md` § Strategy Docs to get the
 ```
 Foundation OK.
 
-  Current phase: {phase name from PHASES.md}
-  Issues in flight: {N from PHASES.md current phase}
+  Current phase: {phase name derived live from Linear}
+  Issues in flight: {N in the current phase's projects}
 
 ➜ Next: pk next  (phase-aware: groups Linear by status with per-group hints)
    or:   /light-spec PROJ-XXX  (begin speccing an issue from the current phase)
 ```
 
-Read `.vbw-planning/PHASES.md` to extract the current phase name and issue list. If multiple issues are in flight (status In Progress / Building), recommend `pk status` instead so the user sees the full board.
+Derive the current phase live from Linear (`i{N}.` initiative → `P{N}.` project, ordered by the integer in each name prefix) — e.g. via `pk next` — to extract the current phase name and issue list. If multiple issues are in flight (status In Progress / Building), recommend `pk status` instead so the user sees the full board.
 
 **If anything is missing:**
 
@@ -197,9 +195,9 @@ When `--mode=` is passed explicitly, skip auto-detection entirely. Do **not** co
 
 | Mode | What runs |
 |---|---|
-| **greenfield** | The existing 12-step flow in [Execution](#execution) below. No behavioral change from prior versions. |
-| **brownfield** | Skip Step 1 (Concept) and Step 2 (Define). Prompt for project metadata (name, one-liner, audience) and write a minimal `project-definition.md` from the answers — enough for `/strategy-create` to consume. Route to Step 5 (Strategy Docs) via `/strategy-create` with this banner: _"The generated strategy docs reflect the project definition you just provided, not the existing code. You'll likely want to edit them against reality before the first `/light-spec`. Auto-audit via `/strategy-from-code` is planned for v1.4.0."_ Then continue with Step 7 (VBW Init) → Step 8 (Roadmap) → Step 9 → 10 → 11 → 12 (Phase Plan). Skip Steps 3, 4 (Tech Stack, Infrastructure) since the codebase already has these — instead, populate the relevant `method.config.md` sections (Stack, Environments, Pre-Deploy Gate) by inspecting the existing project (`package.json`, deployment config, CI files). |
-| **inherited** | Run the [Foundation Check](#foundation-check-inherited-mode-subroutine) subroutine above. Do not run any of the 12 steps. Exit with the next-step recommendation from the check's output. |
+| **greenfield** | The full step flow in [Execution](#execution) below. No behavioral change from prior versions. |
+| **brownfield** | Skip Step 1 (Concept) and Step 2 (Define). Prompt for project metadata (name, one-liner, audience) and write a minimal `project-definition.md` from the answers — enough for `/strategy-create` to consume. Route to Step 5 (Strategy Docs) via `/strategy-create` with this banner: _"The generated strategy docs reflect the project definition you just provided, not the existing code. You'll likely want to edit them against reality before the first `/light-spec`. Auto-audit via `/strategy-from-code` is planned for v1.4.0."_ Then continue with Step 7 (Roadmap) → Step 8 → 9 → 10 → 11 (Phase Plan). Skip Steps 3, 4 (Tech Stack, Infrastructure) since the codebase already has these — instead, populate the relevant `method.config.md` sections (Stack, Environments, Pre-Deploy Gate) by inspecting the existing project (`package.json`, deployment config, CI files). |
+| **inherited** | Run the [Foundation Check](#foundation-check-inherited-mode-subroutine) subroutine above. Do not run any of the 11 steps. Exit with the next-step recommendation from the check's output. |
 
 ### Tracker handling
 
@@ -216,6 +214,8 @@ For **inherited** mode, the tracker is read-only — the foundation check produc
 ## Execution
 
 The steps below describe the **greenfield** flow in full. Brownfield skips Steps 1-2 (and Steps 3-4, since the codebase already exists) and adapts the others as noted in [Mode Routing](#mode-routing) above. Inherited mode does not execute these steps — it runs the Foundation Check and exits.
+
+Stage 0 chain (greenfield): `/concept → /define → /strategy-create → /startup → /roadmap-create → /phase-plan`. `/vbw:init` is **not** part of this chain — the Linear `i{N}.`/`P{N}.` hierarchy that `/roadmap-create` authors is the phase surface; there is no `.vbw-planning/` scaffold step.
 
 Each step checks if its output already exists and offers to skip — making `/startup` resumable. If you stop after Step 4, re-running picks up at Step 5.
 
@@ -559,40 +559,25 @@ Fill in `method.config.md` with any remaining project-specific values.
 
 **Output:** Method synced, config complete
 
-### Step 7 — VBW Init
+### Step 7 — Roadmap
 
-**Check:** Does `.vbw-planning/` exist?
-- If yes: _"VBW already initialized. Skip or reinit?"_
-- If no: Run `/vbw:init`
+**Check:** Does the Linear board already have an `i{N}.`/`P{N}.` phase hierarchy?
 
-**What VBW creates:** `/vbw:init` scaffolds `.vbw-planning/` with several files including `ROADMAP.md` — a skeleton roadmap derived from codebase analysis (usually 4 phases from `.vbw-planning/codebase/` mapping docs). This is a first-pass outline, **not the final roadmap**. Step 8 will merge strategy-derived requirements into it.
-
-**After `/vbw:init` finishes, VBW prints its own "Next steps" message that suggests two options:** `/roadmap-create` (Pipekit path) **or** `/vbw:vibe` (VBW-only path). **Always choose `/roadmap-create`.** Ignore the `/vbw:vibe` suggestion — it bypasses Linear, which defeats Pipekit's purpose. Tell the user explicitly:
-
-_"VBW suggests either `/roadmap-create` or `/vbw:vibe`. In Pipekit you always use `/roadmap-create` — `/vbw:vibe` skips Linear entirely, which breaks the pipeline."_
-
-**Output:** `.vbw-planning/` scaffolded (includes a skeleton ROADMAP.md from VBW that Step 8 will enrich)
-
-### Step 8 — Roadmap
-
-**Check:** Does `.vbw-planning/ROADMAP.md` have content?
-
-Three possible states:
-1. **VBW-generated skeleton only** (most common after Step 7) → Run `/roadmap-create`. It will **merge** strategy-derived requirements into VBW's existing phase structure, preserving VBW's phases and adding Requirements subsections. This is the expected flow for new projects.
+Two possible states:
+1. **No phase hierarchy yet** (most common — fresh project) → Run `/roadmap-create`. It authors the Linear `i{N}.` initiative / `P{N}.` project hierarchy directly from the strategy docs and seeds the issues underneath. This is the expected flow for new projects.
 2. **Already populated by `/roadmap-create`** (re-running `/startup`) → Ask: _"Roadmap appears fully populated. Skip, or redo?"_
-3. **Doesn't exist** (skipped Step 7 somehow) → Run `/vbw:init` first, then `/roadmap-create`.
 
-To tell skeleton vs. populated: check for Linear issue IDs or strategy doc references in the Requirements sections. VBW's skeleton has phases but no Linear-traced requirements.
+To tell empty vs. populated: check whether the Linear board has any `i{N}.` initiatives with `P{N}.` projects and Linear-traced issues underneath. An optional legacy `.vbw-planning/ROADMAP.md` may exist from a prior version, but the Linear hierarchy is the authoritative phase surface.
 
-**Critical reminder:** Do NOT run `/vbw:vibe` as an alternative to `/roadmap-create`. VBW's own output after `/vbw:init` suggests it as a path — but in Pipekit it's a dead end. The Pipekit flow is:
+The Pipekit flow is:
 
 ```
-/vbw:init (skeleton) → /roadmap-create (merges + populates Linear) → /phase-plan → /light-spec → pk branch → /work (native-on-Workflow)
+/roadmap-create (authors the Linear i{N}./P{N}. hierarchy + seeds issues) → /phase-plan → /light-spec → pk branch → /work (native-on-Workflow)
 ```
 
-**Output:** ROADMAP.md populated (merged with VBW's phase structure), Linear board seeded with initiatives, projects, milestones, and issues
+**Output:** Linear board seeded with the `i{N}.` initiative / `P{N}.` project hierarchy and the issues underneath. The phase order lives in Linear (the integer prefix in each `i{N}.`/`P{N}.` name) — `pk next` / `pk status` derive the current phase live from it.
 
-### Step 9 — Project-Specific Skills
+### Step 8 — Project-Specific Skills
 
 Based on the tech stack chosen in Step 3, identify which project-specific skills are needed (see `STARTUP.md` Step 4 for the mapping).
 
@@ -608,9 +593,9 @@ Create each skill with the user's input. Test after creation.
 
 **Output:** Project-specific skills created and working
 
-### Step 10 — CLAUDE.md & Rules
+### Step 9 — CLAUDE.md & Rules
 
-#### Step 10a — Scaffold from templates
+#### Step 9a — Scaffold from templates
 
 `sync-method.sh` should have already copied Pipekit's canonical rule templates into `.claude/rules/`. Canonical files use a `pipekit-` prefix so they never collide with project-specific rule filenames:
 
@@ -635,9 +620,9 @@ Then fill in:
 - **Environments & Branch Strategy** — from `method.config.md` → `## Git Architecture`
 - **Working Style** step 3 — project-specific reference reading (e.g., "Read POC in `src_poc/`") or delete the bullet if not applicable
 - **Decision-Making Protocol** — start with the two baseline rules; add project-specific rules here as feedback patterns emerge
-- **Routing Pointers table** — keep the three canonical rules rows; add rows for project-specific rules as they're created in Step 10b
+- **Routing Pointers table** — keep the three canonical rules rows; add rows for project-specific rules as they're created in Step 9b
 
-#### Step 10b — Project-specific rules
+#### Step 9b — Project-specific rules
 
 Based on the stack and domain, create project-specific `.claude/rules/*.md` files as needed. These sit alongside the canonical files and cover what the portable rules cannot:
 
@@ -654,13 +639,13 @@ Keep each file under ~100 lines. Add a row to CLAUDE.md's Routing Pointers table
 
 **Do not duplicate what's in the canonical files.** If the canonical `security.md` already covers RLS baseline, extend it with project-specific RLS patterns in a dedicated `security-rls.md` or append to the canonical (the sync script won't clobber additions; it only overwrites lines it knows about — verify this behavior per your sync tooling).
 
-#### Step 10c — Final review
+#### Step 9c — Final review
 
 Read `method.config.md` back to the user, confirm all fields populated, flag TBD values.
 
 **Output:** CLAUDE.md filled in from template; `.claude/rules/` contains the three canonical files plus any project-specific additions; Routing Pointers table reflects all rules.
 
-### Step 11 — Validate
+### Step 10 — Validate
 
 Before selecting an execution phase, validate the full setup. Catching gaps here prevents starting execution on a broken foundation.
 
@@ -668,23 +653,23 @@ Run `/roadmap-review` to validate:
 - Concept brief exists
 - Project definition exists
 - Strategy docs match config
-- ROADMAP.md populated
+- Linear `i{N}.`/`P{N}.` phase hierarchy populated
 - Linear board seeded (initiatives, projects, milestones, issues)
 - Dependencies correctly set
 - All method.config.md fields populated (no TBDs)
 - Linear MCP connected and workflow states configured
 
-If any check fails, diagnose and fix before proceeding to Step 12. Do not move issues into "Needs Spec" (Step 12's job) until validation passes.
+If any check fails, diagnose and fix before proceeding to Step 11. Do not move issues into "Needs Spec" (Step 11's job) until validation passes.
 
 **Output:** All validation checks pass — pipeline is ready for execution
 
-### Step 12 — Phase Plan
+### Step 11 — Phase Plan
 
-**Check:** Does `.vbw-planning/PHASES.md` exist?
+**Check:** Is a current phase already derivable live from Linear (`pk next` / `pk status` resolve a phase)?
 - If yes: _"Phase already planned. Skip or replan?"_
 - If no: Run `/phase-plan`
 
-`/phase-plan` selects 3-8 issues for the first execution phase and promotes them from "On Deck" → "Needs Spec" in Linear. This is the point where execution begins — the first issues become actionable.
+`/phase-plan` selects 3-8 issues for the first execution phase and promotes them from "On Deck" → "Needs Spec" in Linear. It derives/advances phase state via Linear (`i{N}.` initiative → `P{N}.` project). This is the point where execution begins — the first issues become actionable.
 
 **Output:** First phase defined, issues in "Needs Spec", ready for `/light-spec`
 

--- a/skills/sync-linear/skill.md
+++ b/skills/sync-linear/skill.md
@@ -1,106 +1,104 @@
 ---
 name: sync-linear
-description: Bidirectional sync between VBW planning files and Linear. Use when .vbw-planning/ and Linear have drifted. Use after manual edits to either side. Keeps planning state coherent between the two surfaces.
+description: Reconcile strategy-doc / requirement drift against the Linear board's i{N}./P{N}. phase hierarchy. Use when issues are mis-placed across P{N}. projects, or initiatives/projects drift from the naming convention. Linear is the source of truth; there is no PHASES.md/linear-map.json to sync.
 ---
 
 # Sync Linear Skill
 
-You are a planning synchronization coordinator. Your job is to maintain bidirectional sync between VBW planning files (`.vbw-planning/`) and the Linear workspace. Read `method.config.md` for project context. VBW is the planning engine; Linear is the view layer where the user reviews and edits plans.
+**v4.1.0** — Last updated: 2026-06-21 *(Linear-native phase surface — no PHASES.md/linear-map.json to sync. The phase order and Initiative→Project→Issue hierarchy live entirely in Linear; this skill reconciles strategy-doc and requirement drift against that board, not against committed phase files.)*
+
+You are a Linear hierarchy reconciliation coordinator. Your job is to keep the Linear board's phase hierarchy coherent with the project's strategy docs and requirements. Read `method.config.md` for project context — specifically `## Phase Surface`, which defines the canonical model.
+
+**Linear is the source of truth for the phase surface.** There is no planning-file mirror to push to or pull from. Phase order is encoded directly in Linear object names, not in a file and not in Linear's `sortOrder`.
+
+## Canonical Model (Phase Surface)
+
+Per `method.config.md` § Phase Surface:
+
+| Linear object | Role | Order |
+|---------------|------|-------|
+| **Initiative** `i{N}. label` | ordered **PHASE** | integer `{N}` in the name prefix |
+| **Project** `P{N}. label` | ordered **SUB-PHASE** | integer `{N}` in the name prefix |
+| **Issue** | individual requirement/task | lives inside the right `P{N}.` project |
+
+Order is the **numeric prefix** in the object name (`i1.`, `i2.`, … / `P1.`, `P2.`, …). Linear's `sortOrder` is **never** used to determine phase order — always parse the name prefix.
+
+**Retired surfaces** — this skill never reads or writes them; they exist only as a `bin/pk` fallback for un-migrated projects:
+- `.vbw-planning/PHASES.md`
+- `.vbw-planning/linear-map.json`
+
+`.vbw-planning/ROADMAP.md` may still exist as **optional legacy narrative**. It is not synced state — treat it as a human-readable reference only, never as a source or target of reconciliation.
 
 ## Triggers
 
 This skill is invoked when the user says:
 - `/sync-linear`
 - "sync linear"
-- "update linear"
-- "pull from linear"
-- "push to linear"
+- "reconcile linear"
+- "check linear hierarchy"
+- "are issues in the right phase?"
+
+## What This Skill Reconciles
+
+It detects and proposes fixes for **drift between the project's strategy docs / requirements and the Linear board's phase hierarchy**:
+
+1. **Naming-convention drift** — initiatives not named `i{N}. label`, projects not named `P{N}. label`, duplicate or gapped prefixes (`i1, i3` with no `i2`), or out-of-order numbering.
+2. **Placement drift** — issues sitting in the wrong `P{N}.` project (or no project at all) given what the strategy docs say belongs in that sub-phase.
+3. **Coverage drift** — strategy-doc requirements with no corresponding Linear issue, or Linear issues that no longer map to any documented requirement.
+
+It does **not** reconcile a planning-file mirror — there is none. All reconciliation targets are live Linear objects.
 
 ## Modes
 
-The skill supports three modes, selected by argument or inferred from context:
-
 | Mode | Command | What it does |
 |------|---------|--------------|
-| **push** | `/sync-linear push` | VBW → Linear: push ROADMAP content, plan tasks, and status updates into Linear |
-| **pull** | `/sync-linear pull` | Linear → VBW: pull edits made in Linear back into VBW files |
-| **sync** | `/sync-linear` (default) | Both directions: push first, then pull, reporting any conflicts |
-| **promote** | `/sync-linear promote` | Analyze project completion and recommend status promotions for the next batch of issues |
+| **check** | `/sync-linear` (default) | Read-only audit: report naming, placement, and coverage drift against the board. Proposes no writes. |
+| **fix** | `/sync-linear fix` | Propose-then-apply: present the drift report, ask for confirmation, then apply approved renames/re-placements/issue creations to Linear. |
+| **promote** | `/sync-linear promote` | Analyze sub-phase completion and recommend status promotions for the next batch of issues. |
 
-## Data Sources
+## Reading the Board
 
-### VBW files (source of truth for structure)
-- `.vbw-planning/ROADMAP.md` — Phase definitions, goals, requirements, success criteria
-- `.vbw-planning/STATE.md` — Current phase status, progress, decisions
-- `.vbw-planning/phases/*/PLAN.md` — Detailed task plans per phase
-- `.vbw-planning/linear-map.json` — ID mapping between VBW entities and Linear objects
+To reconcile, build a live picture of the hierarchy from Linear (never from a map file):
 
-### Linear objects (view layer for review and editing)
-- **Initiatives** = VBW Phases (6 total)
-- **Projects** = Feature clusters within phases (25 total)
-- **Issues** = Individual tasks/requirements from VBW plans
+1. **List initiatives** via `mcp__linear-server__linear_getInitiatives` (or search) — these are the phases. Parse `i{N}.` from each name to get phase order.
+2. **List projects** under each initiative via `mcp__linear-server__linear_getProjects` — these are the sub-phases. Parse `P{N}.` from each name to get sub-phase order.
+3. **List issues** in each project via `mcp__linear-server__linear_searchIssues` — these are the requirements/tasks.
+4. **Read the strategy docs** named in `method.config.md` — these define what *should* exist and where. This is the requirement side of the reconciliation.
 
-## ID Mapping
-
-All VBW ↔ Linear relationships are stored in `.vbw-planning/linear-map.json`. This file contains:
-- Team ID and workflow state IDs
-- Initiative IDs mapped to VBW phase slugs
-- Project IDs mapped to feature cluster slugs
-- Issue ID mappings (populated as plans create tasks)
-
-**Never hardcode Linear IDs in skill logic.** Always read from `linear-map.json`.
+The Linear team ID and workflow state IDs come from `method.config.md` (or are resolved live via `mcp__linear-server__linear_getTeams` / `linear_getWorkflowStates`). **Never hardcode Linear IDs** and never read them from `linear-map.json` — that file is retired.
 
 ## Execution Steps
 
-### Push Mode (VBW → Linear)
+### Check Mode (default, read-only)
 
-1. **Read** `.vbw-planning/linear-map.json` for all ID mappings
-2. **Read** `.vbw-planning/ROADMAP.md` for phase content
-3. **For each initiative:**
-   - Read current Linear initiative description via `mcp__linear-server__linear_getInitiativeById`
-   - Compare with ROADMAP content for that phase
-   - If VBW content is newer or different, update via `mcp__linear-server__linear_updateInitiative`
-4. **For each project:**
-   - Read current Linear project description via `mcp__linear-server__linear_getProjectById`
-   - Compare with plan content for that feature cluster
-   - If VBW content is newer, update via `mcp__linear-server__linear_updateProject`
-5. **For VBW plan tasks** (when plans exist in `.vbw-planning/phases/*/PLAN.md`):
-   - Check if a matching Linear issue exists (by title match or stored ID in linear-map.json)
-   - If no issue exists → create via `mcp__linear-server__linear_createIssue` with correct project assignment
-   - If issue exists but status differs → update status
-   - Store new issue IDs back into `linear-map.json`
-6. **Report** what was pushed (created/updated/unchanged counts)
+1. **Read** `method.config.md` § Phase Surface for the convention and the Linear team/state references.
+2. **Read** the strategy docs listed in `method.config.md`.
+3. **Build the live hierarchy** from Linear (initiatives → projects → issues) per *Reading the Board* above.
+4. **Detect naming-convention drift:**
+   - Each initiative name matches `i{N}. label`; each project name matches `P{N}. label`.
+   - Prefixes are contiguous and non-duplicated within their scope.
+5. **Detect placement drift:**
+   - Every issue lives in exactly one `P{N}.` project.
+   - Issue subject matter matches the sub-phase the strategy docs assign it to.
+6. **Detect coverage drift:**
+   - Each strategy-doc requirement maps to at least one Linear issue.
+   - Each Linear issue maps to a documented requirement (or is flagged as undocumented).
+7. **Present a drift report** (see *Output Format*). Propose no writes in check mode.
 
-### Pull Mode (Linear → VBW)
+### Fix Mode (propose-then-apply)
 
-1. **Read** `.vbw-planning/linear-map.json` for all ID mappings
-2. **For each initiative:**
-   - Fetch current description from Linear via `mcp__linear-server__linear_getInitiativeById`
-   - Compare with ROADMAP.md content
-   - If Linear description was edited (differs from last push), extract changes
-   - Present diff to user for approval before updating ROADMAP.md
-3. **For each project:**
-   - Fetch current description from Linear via `mcp__linear-server__linear_getProjectById`
-   - Compare with stored content
-   - If Linear description was edited, present diff to user
-4. **For issues:**
-   - Fetch issues in each project via `mcp__linear-server__linear_searchIssues`
-   - Check for new issues created directly in Linear (not via VBW push)
-   - Check for status changes on existing issues
-   - Report new Linear issues that need to be added to VBW plans
-   - Report status changes that should update VBW task state
-5. **Present a sync report** showing all detected changes, asking for confirmation before applying
-
-### Sync Mode (default)
-
-1. Run **Push** first
-2. Run **Pull** second
-3. If conflicts found (both sides changed the same content), present both versions to user and ask which to keep
-4. Update `linear-map.json` with new `last_synced` timestamp
+1. Run **Check Mode** to produce the drift report.
+2. **Present each proposed change** as a table (rename / re-place / create), grouped by drift type.
+3. **Ask for confirmation.** Never auto-apply.
+4. On approval, apply only the approved changes:
+   - Rename initiatives via `mcp__linear-server__linear_updateInitiative`.
+   - Rename / re-parent projects via `mcp__linear-server__linear_updateProject`.
+   - Move issues into the correct project, or create missing issues, via `mcp__linear-server__linear_updateIssue` / `linear_createIssue`.
+5. **Re-run Check Mode** after applying to confirm the drift cleared. Report residual drift, if any.
 
 ### Promote Mode
 
-Analyzes project completion status and recommends moving the next batch of issues up a workflow status level. Runs automatically as part of sync mode, or standalone via `/sync-linear promote`.
+Analyzes sub-phase completion status and recommends moving the next batch of issues up a workflow status level. Runs standalone via `/sync-linear promote`.
 
 #### Workflow Status Ladder
 
@@ -108,44 +106,34 @@ Analyzes project completion status and recommends moving the next batch of issue
 Future Phases → On Deck → Needs Spec → Specced → Approved → In Progress → Building → UAT → [Released →] Done
 ```
 
-State IDs are stored in `linear-map.json` under `states.*`. Always read from there — never hardcode.
+Workflow state IDs come from `method.config.md` or are resolved live via `mcp__linear-server__linear_getWorkflowStates`. Never hardcode them and never read them from `linear-map.json`.
 
 #### Logic
 
-1. **Read** `linear-map.json` for state IDs and project mappings
-2. **For each Stage 2 project** (active stage), in order (P1 → P10):
-   - Fetch all issues via `mcp__linear-server__linear_searchIssues`
+1. **Read** workflow state references from `method.config.md` (or resolve live).
+2. **List the `P{N}.` projects** in numeric-prefix order for the active phase initiative.
+3. **For each project, in order (P1 → Pn):**
+   - Fetch all issues via `mcp__linear-server__linear_searchIssues`.
    - Classify by status bucket:
      - **Done bucket:** Done, Canceled, Duplicate
      - **Active bucket:** In Progress, Building, UAT, Approved, Specced, Needs Spec
      - **Waiting bucket:** On Deck, Future Phases, Triage, Ideas
-   - Determine project completion: all non-canceled issues in Done bucket
-3. **Find the promotion boundary:**
-   - Walk projects in order. The **leading project** is the highest-numbered project where ALL issues are Done.
-   - The **active project** is the next project (being specced/built).
+   - Determine project completion: all non-canceled issues in the Done bucket.
+4. **Find the promotion boundary:**
+   - Walk projects in numeric-prefix order. The **leading project** is the highest-numbered `P{N}.` where ALL issues are Done.
+   - The **active project** is the next one (being specced/built).
    - The **on-deck project** is the one after that.
    - The **next-up project** is the one after on-deck (candidates for Future Phases → On Deck).
-4. **Recommend promotions** for the next-up project's issues:
-   - Issues in `Future Phases` → recommend `On Deck`
-   - Issues in `Triage` or `Ideas` → recommend `On Deck` (they're in a project, so they're real)
-5. **Present the recommendation** as a table showing issue ID, title, current status, and proposed status
-6. **Ask for confirmation** before executing. On approval, batch-update all issues via `mcp__linear-server__linear_updateIssue`
-
-#### Parallel Track Awareness
-
-Stage 2 has two tracks (from ROADMAP):
-- **Critical path:** WP-1 → WP-2 → WP-3 (Foundation → AG Grid → Editor Parity)
-- **Parallel track:** WP-4 → WP-5 → WP-6/WP-7 (Auth → Nav → Dashboard/Notifications)
-
-The promote logic treats each track independently. A project on the parallel track can promote independently of the critical path. Map projects to tracks using the `wp` field in `linear-map.json`:
-- Critical path: `wp` 1, 2, 3
-- Parallel track: `wp` 4, 5, 6, 7, 11
-- Independent: `wp` 8, 9, 10 (can promote when their dependencies are met)
+5. **Recommend promotions** for the next-up project's issues:
+   - Issues in `Future Phases` → recommend `On Deck`.
+   - Issues in `Triage` or `Ideas` → recommend `On Deck` (they're in a project, so they're real).
+6. **Present the recommendation** as a table showing issue ID, title, current status, and proposed status.
+7. **Ask for confirmation** before executing. On approval, batch-update via `mcp__linear-server__linear_updateIssue`.
 
 #### Edge Cases
 
-- **Project with mixed statuses:** If a project has some Done and some In Progress issues, it's still active — don't promote the next project yet.
-- **Skipped projects:** If a project has 0 issues, skip it in the chain.
+- **Project with mixed statuses:** If a `P{N}.` project has some Done and some In Progress issues, it's still active — don't promote the next project yet.
+- **Skipped projects:** If a `P{N}.` project has 0 issues, skip it in the chain.
 - **Already promoted:** If the next-up project's issues are already On Deck or higher, report "already promoted" and look further ahead.
 - **Multiple promotions:** If several projects have completed since last check, recommend promoting multiple batches. Present each separately for confirmation.
 
@@ -170,53 +158,58 @@ The promote logic treats each track independently. A project on the parallel tra
 Approve? (y/n)
 ```
 
-## Conflict Resolution
+## Resolution Discipline
 
-When both VBW and Linear have changes to the same entity:
-- **Show both versions** side by side
-- **Ask the user** which version to keep (or merge manually)
-- **Never auto-resolve conflicts** — the user always decides
+When a proposed change is ambiguous (e.g., an issue plausibly belongs in two sub-phases, or a requirement maps to no obvious project):
+
+- **Show the options** with the evidence from the strategy docs.
+- **Ask the user** which placement to apply — never auto-resolve a judgment call.
+- Apply only what the user approves.
 
 ## Output Format
 
-After sync, display a summary table:
+After a check or fix, display a drift summary:
 
 ```
-## Sync Report (2026-03-29)
+## Linear Hierarchy Report (2026-06-21)
 
-### Push (VBW → Linear)
-| Type | Created | Updated | Unchanged |
-|------|---------|---------|-----------|
-| Initiatives | 0 | 2 | 4 |
-| Projects | 0 | 3 | 22 |
-| Issues | 5 | 1 | 10 |
+### Naming-convention drift
+| Object | Current name | Expected | Action |
+|--------|--------------|----------|--------|
+| Initiative | Foundation | i1. Foundation | rename |
+| Project | Budget Editor | P2. Budget Editor | rename |
 
-### Pull (Linear → VBW)
-| Type | Changes Detected | Applied |
-|------|-----------------|---------|
-| Initiative descriptions | 1 | 1 |
-| Project descriptions | 0 | 0 |
-| New issues (Linear-only) | 2 | pending |
-| Status changes | 3 | 3 |
+### Placement drift
+| Issue | Currently in | Belongs in | Action |
+|-------|--------------|------------|--------|
+| PROJ-XXX | (none) | P3. Auth & Account | move |
 
-### Conflicts: None
+### Coverage drift
+| Requirement (strategy doc) | Linear issue | Action |
+|----------------------------|--------------|--------|
+| OAuth token refresh | (missing) | create in P3. |
+| PROJ-YYY | (undocumented) | flag for review |
+
+### Clean: naming ✓  placement ✓  coverage ✓   (only sections with drift are shown)
 ```
+
+In **check** mode the Action column is advisory only. In **fix** mode each row is presented for approval before any write.
 
 ## Linear MCP Tools Used
 
-- `mcp__linear-server__linear_getInitiativeById` — read initiative details
-- `mcp__linear-server__linear_createInitiative` / `linear_updateInitiative` — create/update initiatives
-- `mcp__linear-server__linear_getProjectById` — read project details
-- `mcp__linear-server__linear_createProject` / `linear_updateProject` — create/update projects
+- `mcp__linear-server__linear_getInitiatives` / `linear_getInitiativeById` — list/read initiatives (phases)
+- `mcp__linear-server__linear_updateInitiative` — rename an initiative to the `i{N}.` convention
+- `mcp__linear-server__linear_getProjects` / `linear_getProjectById` — list/read projects (sub-phases)
+- `mcp__linear-server__linear_updateProject` — rename / re-parent a project to the `P{N}.` convention
 - `mcp__linear-server__linear_searchIssues` — list/filter issues in a project
 - `mcp__linear-server__linear_getIssueById` — read issue details
-- `mcp__linear-server__linear_createIssue` / `linear_updateIssue` — create/update issues
-- `mcp__linear-server__linear_getWorkflowStates` — get workflow states
+- `mcp__linear-server__linear_createIssue` / `linear_updateIssue` — create or re-place an issue
+- `mcp__linear-server__linear_getWorkflowStates` — resolve workflow state IDs (when not in `method.config.md`)
 
 ## Important Notes
 
-- **Initiative descriptions** use Markdown format with `## Phase N: Name`, `### Scope`, `### Success Criteria` headers
-- **Project descriptions** use Markdown format with `## Project Name`, `### Scope`, `### Success Criteria` headers
-- The user edits in Linear's rich text editor, which converts Markdown to its internal format — when pulling back, normalize formatting
-- Always update `linear-map.json` after any sync operation
-- Include `PROJ-{number}` in commit messages when completing tasks linked to Linear issues
+- **Linear is the phase surface.** Parse phase/sub-phase order from the `i{N}.` / `P{N}.` name prefix — never from `sortOrder`, never from a planning file.
+- **`linear-map.json` and `PHASES.md` are retired** — this skill never reads or writes them. Resolve Linear IDs from `method.config.md` or live MCP queries.
+- **`ROADMAP.md`, if present, is optional legacy narrative** — read it for human context only; it is not a reconciliation source or target.
+- **Initiative/project descriptions** use Markdown (`## Phase`, `### Scope`, `### Success Criteria`); normalize formatting when reading edits made in Linear's rich-text editor.
+- Include `PROJ-{number}` in commit messages when completing tasks linked to Linear issues.

--- a/sop/Linear_SOP.md
+++ b/sop/Linear_SOP.md
@@ -2,7 +2,7 @@
 
 > For the full development pipeline, see [method.md](../method.md).
 
-**v4.0.0** — Last updated: 2026-06-20  *(adds the **Linear MCP Server** section — pipekit's interactive Linear skills target `@tacticlaunch/mcp-linear`'s camelCase tools; carries the `tier:quick`/`tier:standard`/`tier:heavy` labels — including `/pk-express`'s tier:heavy refusal — the config-driven `Spec ready state`, and v2.6.0's two-phase `pk promote` + Draft-by-default model)*
+**v4.1.0** — Last updated: 2026-06-21  *(Linear-native phase surface — Initiative `i{N}.` = phase, Project `P{N}.` = sub-phase, ordered by name prefix. The roadmap's phase order now lives in Linear, not a committed file; `pk next`/`pk status` derive the current phase live. `.vbw-planning/PHASES.md` and `linear-map.json` are retired (bin/pk fallback-only). Carries the **Linear MCP Server** section — pipekit's interactive Linear skills target `@tacticlaunch/mcp-linear`'s camelCase tools; the `tier:quick`/`tier:standard`/`tier:heavy` labels — including `/pk-express`'s tier:heavy refusal — the config-driven `Spec ready state`, and v2.6.0's two-phase `pk promote` + Draft-by-default model)*
 
 Project-specific values (workspace, team ID, state IDs) live in your project's `method.config.md`.
 
@@ -36,11 +36,13 @@ Pipekit's interactive Linear skills (`/linear`, `/sync-linear`, `/roadmap-create
 
 ## Linear Model
 
+**The Linear hierarchy is the phase surface — the source of truth for roadmap order.** There is no committed phase file; `pk next`/`pk status` derive the current phase live from this hierarchy. `/roadmap-create` authors it; `/phase-plan` advances it.
+
 ```
-Initiative = VBW Phase                 <- "What phase does this ship in?"
-  +-- Project = Feature Cluster        <- "What area of the product?"
-       +-- Issue = Feature/Task        <- "What work needs to happen?"
-            +-- Milestone = Work Package  <- "What execution batch?"
+Initiative "i{N}. label" = ordered roadmap PHASE       <- "Which phase ships this?"
+  +-- Project "P{N}. label" = ordered SUB-PHASE        <- "Which sub-phase within the phase?"
+       +-- Issue = work item                           <- "What work needs to happen?"
+            +-- Milestone = Work Package (optional)     <- "What intra-project batch?"
 
 Labels = Cross-cutting metadata        <- Filterable on everything
   Domain:   [project-specific domain labels]
@@ -50,30 +52,44 @@ Labels = Cross-cutting metadata        <- Filterable on everything
   Audience: Client Request
 ```
 
+### Ordering is the numeric name prefix — never Linear `sortOrder`
+
+Phase and sub-phase order is read from the **integer in the name prefix**, parsed numerically (so `P2` sorts before `P10`). Linear's internal `sortOrder` field is an unreliable drag-rank and is **never** used to order phases.
+
+- **Initiative `i{N}. label`** = an ordered roadmap **phase**. The `i{N}.` prefix is the roadmap opt-in: only prefixed initiatives are delivery phases. **Unprefixed initiatives are strategic themes** and are ignored by `pk next`.
+- **Project `P{N}. label`** = an ordered **sub-phase** within a phase. Issues live in projects.
+- **Issue** = a work item.
+
+**Current phase** = the lowest `i{N}` initiative whose status is not `Completed`. **Current sub-phase** = the lowest `P{N}` project whose state is not `completed` or `canceled`.
+
 ### Each Layer's Job
 
 | Layer | Audience | Question | Lifespan |
 |---|---|---|---|
-| **Initiative** | Partner | "What stage?" | Permanent (one per stage) |
-| **Project** | Partner + You | "What feature area?" | Permanent within stage |
-| **Milestone** | You + VBW | "What execution batch?" | Per-stage |
-| **Issue** | You + VBW | "What feature/task?" | Permanent (work item) |
+| **Initiative** (`i{N}.`) | Partner | "Which roadmap phase?" | Permanent (one per phase) |
+| **Project** (`P{N}.`) | Partner + You | "Which sub-phase?" | Permanent within phase |
+| **Milestone** (optional) | You | "What intra-project batch?" | Per-project |
+| **Issue** | You | "What work item?" | Permanent (work item) |
 | **Labels** | Everyone | Domain? Tier? Type? | Permanent (taxonomy) |
+
+The **Milestone = Work Package** layer is an optional intra-project grouping, orthogonal to the phase surface — use it to batch issues within a single project when useful, or skip it entirely.
 
 ---
 
 ## VBW <> Linear Mapping
 
-| VBW | Linear | Notes |
-|---|---|---|
-| Phase | Initiative | 1:1 match |
-| Feature cluster | Project | Grouped by product area |
-| Work Package | Milestone | Execution batches within projects |
-| Plan (phase) | -- | VBW internal only. `.vbw-planning/` |
-| Task | -- | VBW internal only. `.vbw-planning/` |
-| Issue (ISSUES.md) | Issue | Issue IDs shared across both systems |
+The roadmap's phase order lives in the **Linear hierarchy** (Initiative `i{N}.` / Project `P{N}.`), not in a committed file. The phase-source files `.vbw-planning/PHASES.md` and `.vbw-planning/linear-map.json` are **retired** — no skill writes them; `bin/pk` reads them only as a fallback when the Linear hierarchy is unreachable.
 
-**VBW is the planning engine. Linear is the view layer.** VBW pushes structure and tasks to Linear; human edits in Linear; VBW pulls changes back. The `/sync-linear` skill handles both directions.
+| Concept | Linear | Notes |
+|---|---|---|
+| Roadmap phase | Initiative `i{N}. label` | Ordered by the `i{N}` name prefix. The source of truth for phase order. |
+| Sub-phase | Project `P{N}. label` | Ordered by the `P{N}` name prefix, within a phase. Issues live here. |
+| Work Package (optional) | Milestone | Optional intra-project batch within a project. |
+| Plan (phase) | -- | VBW planning-layer internal. `.vbw-planning/phases/*/PLAN.md` |
+| Task | -- | VBW planning-layer internal. `.vbw-planning/` |
+| Issue | Issue | Issue IDs shared across both systems |
+
+**The Linear hierarchy is the source of truth for phase order.** The VBW planning layer still owns task decomposition (`PLAN.md`) and execution state under `.vbw-planning/`; `.vbw-planning/ROADMAP.md` is retained as optional legacy. The `/sync-linear` skill keeps planning state and Linear coherent.
 
 ### What Lives Where
 
@@ -164,14 +180,16 @@ Every status maps to a pipeline position. An issue's status tells you whose turn
 
 ### Phase Management
 
-The backlog is ordered by **phase proximity** (furthest out → closest to execution):
+**Which phase an issue belongs to is defined by the Linear hierarchy** — the `i{N}.` initiative (phase) and `P{N}.` project (sub-phase) it sits under, ordered by name prefix. `pk next`/`pk status` resolve the current phase live from that hierarchy (lowest non-`Completed` `i{N}` initiative). `/roadmap-create` authors the hierarchy; `/phase-plan` advances it. The workflow states below track *pipeline position within* the current phase, not phase membership.
+
+Within the active phase, the backlog is ordered by **pipeline proximity** (furthest out → closest to execution):
 
 ```
 Ideas → Future Phases → On Deck → Needs Spec
 ```
 
-- **Current phase** = issues in Needs Spec + Specced + Approved + Building + UAT + any In `<Env>` state
-- **Next phase** = issues in On Deck
+- **In-flight (current phase)** = issues in Needs Spec + Specced + Approved + Building + UAT + any In `<Env>` state
+- **Queued (next phase)** = issues in On Deck
 - **Future** = issues in Future Phases
 - **Someday** = issues in Ideas
 
@@ -182,9 +200,9 @@ When the current phase ships, promote On Deck → Needs Spec and refill On Deck 
 ## Conventions
 
 - **No sub-issues in Linear.** Task decomposition lives in `.vbw-planning/` only. Linear stays clean — one Issue per feature.
-- **Projects don't overlap.** Each issue lives in exactly one project at a time.
-- **Milestones = Work Packages.** Each issue belongs to one milestone (its WP).
-- **Tier labels are redundant with Initiatives** — intentional. Labels persist after stages complete.
+- **Projects (`P{N}.`) don't overlap.** Each issue lives in exactly one sub-phase project at a time.
+- **Milestones = Work Packages (optional).** When used, a milestone is an intra-project batch; an issue belongs to at most one. Orthogonal to the phase surface — skip it entirely when not useful.
+- **Tier labels are redundant with phase initiatives** — intentional. Labels persist after phases complete.
 - **Urgent priority is reserved** for hotfixes and production emergencies only.
 - **VBW trigger:** VBW planning triggers when a batch of related features in a Work Package reach "Building" — not when individual features are approved.
 
@@ -302,8 +320,11 @@ Key implementation details, architecture decisions, or constraints.
 
 ## Key IDs
 
-All Linear IDs (team, states, initiatives, projects) should be stored in:
-1. `method.config.md` — state IDs for skill consumption
-2. `.vbw-planning/linear-map.json` — full ID mapping for VBW ↔ Linear sync
+The **Linear hierarchy itself is the source of truth** for the roadmap's phase order (Initiative `i{N}.` / Project `P{N}.`, ordered by name prefix) — there is no committed phase file to keep in sync. Skills resolve initiatives and projects live by their name prefixes.
+
+Linear IDs that skills consume directly:
+1. `method.config.md` — team ID and state IDs for skill consumption (see the § Phase Surface contract).
+
+`.vbw-planning/linear-map.json` is **retired**: no skill writes it, and it is no longer the ID map. `bin/pk` reads it only as a fallback when the Linear hierarchy is unreachable.
 
 See `method.config.template.md` for the template.

--- a/sop/Skills_SOP.md
+++ b/sop/Skills_SOP.md
@@ -132,7 +132,7 @@ These sections are *not* required for low-stakes skills (`/sync-linear`, `/skill
 
 v2 retired the v1 `NEXT.md` mirror. The single source of truth for "what should I do next?" is **Linear**, accessed via:
 
-- **`pk next`** — phase-aware (reads `## Current Phase:` from `PHASES.md`, matches to `linear-map.json`, groups Linear issues by status with per-group hints). Falls back to global "next Approved" when no phase context. Best when you know you want to pick up the next issue.
+- **`pk next`** — phase-aware: derives the current phase live from the Linear-native surface (lowest non-`Completed` `i{N}.` initiative → its lowest open `P{N}.` project, by numeric name prefix; legacy `PHASES.md`/`linear-map.json` fall back), then groups that phase's Linear issues by status with per-group hints. Falls back to global "next Approved" when no phase context. Best when you know you want to pick up the next issue.
 - **`pk status`** — full unscoped board view across all phases. Best when you want the wider picture.
 - **`/pipekit-help`** — context-aware skill recommendation based on full project state (Linear, `PHASES.md`, recent transitions, pipeline-state files). Best when you're not sure *which step* in the pipeline to run next.
 

--- a/tests/pk-smoke.sh
+++ b/tests/pk-smoke.sh
@@ -112,6 +112,45 @@ v=$(unit_config "Backend" "")
 
 cleanup
 
+# ── Unit tests: native phase derivation (sourced mode, no network) ───────────
+# pk_native_phase_context / pk_native_roadmap_summary are pure: initiatives JSON
+# in → derivation out. Order comes from the i<N>./P<N>. NAME PREFIX (Linear's
+# sortOrder is an unreliable drag-rank); lifecycle from status/state. These guard
+# the load-bearing jq against regression.
+
+echo "== native phase derivation =="
+
+NATIVE_FIXTURE='{"data":{"initiatives":{"nodes":[
+  {"name":"i0. Setup","status":"Completed","projects":{"nodes":[{"id":"s1","name":"P1. Boot","state":"completed"}]}},
+  {"name":"i1. Build","status":"Active","projects":{"nodes":[
+    {"id":"p1","name":"P1. Foundation","state":"completed"},
+    {"id":"p2","name":"P2. Editor","state":"planned"},
+    {"id":"p10","name":"P10. Later","state":"backlog"}]}},
+  {"name":"i2. Next","status":"Planned","projects":{"nodes":[{"id":"q1","name":"P1. Vendor","state":"backlog"}]}},
+  {"name":"Strategic Theme","status":"Active","projects":{"nodes":[{"id":"z1","name":"Anything","state":"planned"}]}}
+]}}}'
+
+unit_native_ctx() { ( cd "$REPO_ROOT" && source "$PK" && pk_native_phase_context "$1" ); }
+unit_roadmap()    { ( cd "$REPO_ROOT" && source "$PK" && pk_native_roadmap_summary "$1" ); }
+
+v=$(unit_native_ctx "$NATIVE_FIXTURE")
+[ "$v" = "$(printf 'i1. Build\tp2')" ] \
+  && ok "native: phase=i1 (i0 Completed skipped), project=P2 (P1 done; P2<P10 numeric)" \
+  || fail "native: derivation" "got '$v', want 'i1. Build<TAB>p2'"
+
+v=$(unit_native_ctx '')
+[ -z "$v" ] && ok "native: empty input → empty (no crash)" || fail "native: empty input" "got '$v'"
+
+v=$(unit_native_ctx '{"data":{"initiatives":{"nodes":[{"name":"No Prefix","status":"Active","projects":{"nodes":[]}}]}}}')
+[ -z "$v" ] && ok "native: no i<N>. prefix → empty (triggers file fallback)" || fail "native: no prefix" "got '$v'"
+
+RM=$(unit_roadmap "$NATIVE_FIXTURE")
+if   ! printf '%s\n' "$RM" | grep -q 'i1. Build  \[Active\]  → P2. Editor'; then fail "native: roadmap" "missing i1 line: $RM"
+elif ! printf '%s\n' "$RM" | grep -q 'i2. Next  \[Planned\]  → P1. Vendor'; then fail "native: roadmap" "missing i2 line: $RM"
+elif ! printf '%s\n' "$RM" | grep -q 'i0. Setup  \[Completed\]  → all projects done'; then fail "native: roadmap" "missing i0 done line: $RM"
+elif   printf '%s\n' "$RM" | grep -q 'Strategic Theme'; then fail "native: roadmap" "strategic theme not excluded: $RM"
+else ok "native: roadmap walk ordered by prefix, theme excluded, completed shown done"; fi
+
 # ── CLI tests: dispatch + help guard ─────────────────────────────────────────
 
 echo "== dispatch =="


### PR DESCRIPTION
## v4.1.0 — Linear-native phase surface

The roadmap's phase order moves out of committed files and into Linear itself. An Initiative named `i{N}. label` is an ordered **phase**; a Project named `P{N}. label` is an ordered **sub-phase** holding the issues; ordering is the integer in the name prefix, parsed numerically (`P2` before `P10`). `pk next`/`pk status` derive the current phase live; `/roadmap-create` authors the hierarchy; `/phase-plan` advances it. `.vbw-planning/PHASES.md` + `linear-map.json` are **retired** to a read-only fallback; `/vbw:init` is dropped from the Stage 0 contract.

**Why name-prefix, not Linear `sortOrder`:** a live probe against a production Linear workspace showed `sortOrder` is an internal drag-rank that does not track phase sequence (it ordered one initiative's projects `P11, P8, P4, P3, P1, …`). The `i{N}.`/`P{N}.` prefix is the only reliable order, and it doubles as the roadmap opt-in — unprefixed initiatives (strategic themes) are ignored.

### What's in it
- **bin/pk** — `pk_linear_initiatives_json` + `pk_native_phase_context` derivation; `pk_phase_context` dispatcher (native wins, legacy `.vbw-planning/` files fall back); `pk next` shows `Phase: X (Linear)`; `pk status` gains an ordered Roadmap walk. Issue grouping reused unchanged. **+4 smoke unit-tests, suite 39/39.**
- **Skills** — `/roadmap-create` authors the Linear hierarchy directly (no ROADMAP.md/linear-map.json, no `/vbw:init` dep); `/phase-plan` derives/advances via Linear state; `/sync-linear`, `/00-roadmap-review`, `/startup`, `/01-light-spec`, `/review-plan`, `/pk-exit` repointed.
- **Docs** — `method.config.template.md § Phase Surface` (the naming contract); `method.md`/`RUNBOOK.md`/`GUIDE.md` re-stamped v4.1.0; `CLAUDE.md`, `README.md`, `STARTUP.md`, `sop/Linear_SOP.md`, `sop/Skills_SOP.md` migrated.

### Safety
Ships as a **no-op** for existing projects — they aren't `i{N}.`-prefixed yet, so they fall straight back to today's behavior. The native path activates only after a consumer renames its initiatives.

### Deliberately deferred (not in this PR)
The broader VBW *planning layer* — `.vbw-planning/phases/*/PLAN.md`, SUMMARY, `.execution-state.json`, the `pk done` SUMMARY/PLAN lifecycle, and `/vbw:init`'s greenfield codebase analysis. This PR migrates the **phase surface** only.

### Note for consumers
The phase surface reads Linear **Initiatives** — needs `@tacticlaunch/mcp-linear` (registered `linear-server`), not the first-party `mcp.linear.app` remote which lacks initiative tools. `bin/pk` uses the Linear GraphQL API directly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)