### PR TITLE
fix(pk): harden pk deploy hint and exec safety

### DIFF
--- a/bin/pk
+++ b/bin/pk
@@ -1751,7 +1751,7 @@ $commits"
   if [ -n "$deploy_cmd" ]; then
     echo ""
     echo "🚀 Deploy step — this project deploys by script, not branch promotion."
-    echo "   Merged ≠ deployed. Run when ready:  pk deploy   (→ $deploy_cmd)"
+    echo "   Merged ≠ deployed. Run when ready:  pk deploy [-- <args>]   (→ $deploy_cmd)"
   fi
 
   # Advisory: a local Supabase stack / dev server started inside the worktree
@@ -1838,9 +1838,9 @@ cmd_deploy() {
   # exec so the deploy script owns the tty (confirm prompts, op run, FTP output)
   # and its exit code becomes pk's. Args after '--' pass through verbatim via $@.
   if [ ${#passthrough[@]} -gt 0 ]; then
-    exec bash -c "$deploy_cmd \"\$@\"" pk-deploy "${passthrough[@]}"
+    exec bash -euo pipefail -c "$deploy_cmd \"\$@\"" pk-deploy "${passthrough[@]}"
   else
-    exec bash -c "$deploy_cmd"
+    exec bash -euo pipefail -c "$deploy_cmd"
   fi
 }
 


### PR DESCRIPTION
## Summary

- **Hint fix:** `pk done` deploy reminder now shows `pk deploy [-- <args>]` instead of bare `pk deploy`. Scripts that require args (e.g. `deploy-sync.sh --all`) were previously surfaced as a bare invocation that exits 1 with a usage error.
- **Exec safety:** `exec bash -c` now runs with `-euo pipefail` so compound `Deploy command` values (e.g. `./pre-check.sh; ./deploy.sh`) honour `-e` and don't silently continue past a failing sub-command.

Surfaced by code review on the SiteLine v4.6.0 sync PR (findings 1 and 2).

## Test plan

- [ ] `pk done` on a script-deploy project shows the updated hint with `[-- <args>]`
- [ ] `pk deploy -- --all` still delegates correctly to the configured script
- [ ] `pk deploy` against a script that exits non-zero aborts (no silent continuation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)